### PR TITLE
Remove unnecessary empty paragraph element

### DIFF
--- a/lib/views/widget/searcher.html
+++ b/lib/views/widget/searcher.html
@@ -4,8 +4,6 @@
   <div class="form-group">
     <input id="searchQuery" name="q" type="text" class="form-control" placeholder="検索文字...">
     <button type="submit" class="btn btn-default">検索</button>
-    <p>
-    </p>
     <script>
       function Searcher () {
       };


### PR DESCRIPTION
ブラウザの横幅が 1786px を越えると `div#main` が謎の floating する現象が起こってるんだけど、この `<p>` を消すと動くっぽい。