### PR TITLE
Restrict the version of mongoose.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "grunt-mocha-test": "^0.12.7",
     "grunt-sass": "~0.18.0",
     "method-override": "^2.3.1",
-    "mongoose": "^3.8.0",
+    "mongoose": "^3.8.0 && <3.9.3",
     "mongoose-paginate": "^3.1.0",
     "morgan": "^1.5.1",
     "multer": "^0.1.8",


### PR DESCRIPTION
Hi all!
I tried running crowi on my local environment, but I couldn't run because of an error of mongoose. 

# Problem
On booting crowi, mongoose raises the exception like below:

```bash
$ env PASSWORD_SEED=hogefuba MONGO_URI=mongodb://localhost:27017/crowi  node app.js

crowi/node_modules/mongoose/node_modules/mongodb/lib/mongodb/connection/base.js:246
        throw message;
              ^
TypeError: Cannot read property 'length' of undefined
    at processResults (crowi/node_modules/mongoose/node_modules/mongodb/lib/mongodb/db.js:1581:31)
    at crowi/node_modules/mongoose/node_modules/mongodb/lib/mongodb/db.js:1619:20
    at crowi/node_modules/mongoose/node_modules/mongodb/lib/mongodb/db.js:1157:7
    at crowi/node_modules/mongoose/node_modules/mongodb/lib/mongodb/db.js:1890:9
    at Server.Base._callHandler (crowi/node_modules/mongoose/node_modules/mongodb/lib/mongodb/connection/base.js:448:41)
    at crowi/node_modules/mongoose/node_modules/mongodb/lib/mongodb/connection/server.js:481:18
    at MongoReply.parseBody (crowi/node_modules/mongoose/node_modules/mongodb/lib/mongodb/responses/mongo_reply.js:68:5)
    at null.<anonymous> (crowi/node_modules/mongoose/node_modules/mongodb/lib/mongodb/connection/server.js:439:20)
    at emit (events.js:107:17)
    at null.<anonymous> (crowi/node_modules/mongoose/node_modules/mongodb/lib/mongodb/connection/connection_pool.js:201:13)
```

# Environment
```bash
$ node -v
v0.12.2

$ mongo --version
MongoDB shell version: 3.0.2
```

# How to reproduce
```bash
$ npm install --save-dev # will install mongoose 3.9.7 and mongodb 1.4.12
$ env PASSWORD_SEED=hogefuba MONGO_URI=mongodb://localhost:27017/crowi  node app.js
```

# Solution
Restricting the version of mongoose will solve this issue.
mongoose 3.9.3 or more depends on mongodb 1.4.12. In my investigation, mongodb 1.4.12 has a bug that executing `listIndexes()` causes an exception like above by retrieving indexes from an unknown collection.