### PR TITLE
Fix a bug that a redirection after editing a page can't work properly.

### DIFF
--- a/lib/routes/page.js
+++ b/lib/routes/page.js
@@ -156,12 +156,13 @@ module.exports = function(app) {
         }
         app.set('io').sockets.emit('page edited', {page: data, user: req.user});
 
+        var redirectPath = encodeURI(path);
         if (grant != data.grant) {
           Page.updateGrant(data, grant, req.user, function (err, data) {
-            return res.redirect(path);
+            return res.redirect(redirectPath);
           });
         } else {
-          return res.redirect(path);
+          return res.redirect(redirectPath);
         }
       };
       if (pageData) {


### PR DESCRIPTION
## Problem
I've found that a redirection after editing a page can't work. The given error messages were the following:

```

Connect
400 Error: Bad Request

       at SendStream.error (/home/shinnya/repos/mine/crowi/node_modules/express/node_modules/send/index.js:245:16)
       at SendStream.pipe (/home/shinnya/repos/mine/crowi/node_modules/express/node_modules/send/index.js:418:32)
       at serveStatic (/home/shinnya/repos/mine/crowi/node_modules/express/node_modules/serve-static/index.js:113:12)
       at Layer.handle [as handle_request] (/home/shinnya/repos/mine/crowi/node_modules/express/lib/router/layer.js:82:5)
       at trim_prefix (/home/shinnya/repos/mine/crowi/node_modules/express/lib/router/index.js:302:13)
       at /home/shinnya/repos/mine/crowi/node_modules/express/lib/router/index.js:270:7
       at Function.proto.process_params (/home/shinnya/repos/mine/crowi/node_modules/express/lib/router/index.js:321:12)
       at next (/home/shinnya/repos/mine/crowi/node_modules/express/lib/router/index.js:261:10)
       at expressInit (/home/shinnya/repos/mine/crowi/node_modules/express/lib/middleware/init.js:23:5)
       at Layer.handle [as handle_request] (/home/shinnya/repos/mine/crowi/node_modules/express/lib/router/layer.js:82:5)
```

After editing the page(the path was `/user/shinnya/メモ/2015/05/07/テスト`), I had to get the path `/user/shinnya/%E3%83%A1%E3%83%A2/2015/05/07/%E3%83%86%E3%82%B9%E3%83%88`, but I got `/user/shinnya/%E1%E2/2015/05/07/%C6%B9%C8`.

## Solution
I think we should use an urlencoded path for a redirection, so apply `encodeURI` to a path and use it.