### PR TITLE
Added paste event handler to improve textarea editor.

### DIFF
--- a/resource/js/crowi-form.js
+++ b/resource/js/crowi-form.js
@@ -219,8 +219,8 @@ $(function() {
 
     var match = currentLine.text.match(/^(\s*(?:>|\-|\+|\*|\d+\.) (?:\[(?:x| )\] )?)/);
     if (match) {
-      if (pasteText.match(/\n/)) {
-        pasteText = pasteText.replace(/(\n)/g, "$1" + match[1]); // + ' ');
+      if (pasteText.match(/(?:\r\n|\r|\n)/)) {
+        pasteText = pasteText.replace(/(\r\n|\r|\n)/g, "$1" + match[1]);
       }
     }
 

--- a/resource/js/crowi-form.js
+++ b/resource/js/crowi-form.js
@@ -212,6 +212,29 @@ $(function() {
     }
   });
 
+  var handlePasteEvent = function(event) {
+    var currentLine = getCurrentLine(event);
+    var $target = $(event.target);
+    var pasteText = event.clipboardData.getData('text');
+
+    var match = currentLine.text.match(/^(\s*(?:>|\-|\+|\*|\d+\.) (?:\[(?:x| )\] )?)/);
+    if (match) {
+      if (pasteText.match(/\n/)) {
+        pasteText = pasteText.replace(/(\n)/, "$1" + match[1]); // + ' ');
+      }
+    }
+
+    $target.selection('insert', {text: pasteText, mode: 'after'});
+
+    var newPos = currentLine.end + pasteText.length;
+    $target.selection('setPos', {start: newPos, end: newPos});
+  };
+
+  document.getElementById('form-body').addEventListener('paste', function(event) {
+    event.preventDefault();
+    handlePasteEvent(event);
+  });
+
   var unbindInlineAttachment = function($form) {
     $form.unbind('.inlineattach');
   };

--- a/resource/js/crowi-form.js
+++ b/resource/js/crowi-form.js
@@ -220,7 +220,7 @@ $(function() {
     var match = currentLine.text.match(/^(\s*(?:>|\-|\+|\*|\d+\.) (?:\[(?:x| )\] )?)/);
     if (match) {
       if (pasteText.match(/\n/)) {
-        pasteText = pasteText.replace(/(\n)/, "$1" + match[1]); // + ' ');
+        pasteText = pasteText.replace(/(\n)/g, "$1" + match[1]); // + ' ');
       }
     }
 


### PR DESCRIPTION
When paste event fired and first charactor of current line is some keywords, modify the text to a convenient format.

![crowi](https://cloud.githubusercontent.com/assets/10488/14337765/c5977ce6-fcab-11e5-9d5b-8c96a33ca59f.gif)

- I tested:
    - Chrome latest version
    - Safari latest version
    - Firefox latest version
    