### PR TITLE
Fix: /{path}* shows unexpected pages

### DIFF
--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -453,9 +453,17 @@ module.exports = function(crowi) {
     });
   };
 
+  /**
+   * findListByStartWith
+   *
+   * If `path` has `/` at the end, returns '{path}/*' and '{path}' self.
+   * If `path` doesn't have `/` at the end, returns '{path}*'
+   * e.g.
+   */
   pageSchema.statics.findListByStartWith = function(path, userData, option) {
     var Page = this;
     var User = crowi.model('User');
+    var pathCondition = [];
 
     if (!option) {
       option = {sort: 'updatedAt', desc: -1, offset: 0, limit: 50};
@@ -471,10 +479,15 @@ module.exports = function(crowi) {
     var queryReg = new RegExp('^' + path);
     var sliceOption = option.revisionSlice || {$slice: 1};
 
+    pathCondition.push({path: queryReg});
+    if (path.match(/\/$/)) {
+      debug('Page list by ending with /, so find also upper level page');
+      pathCondition.push({path: path.substr(0, path.length -1)});
+    }
+
     return new Promise(function(resolve, reject) {
       // FIXME: might be heavy
       var q = Page.find({
-          path: queryReg,
           redirectTo: null,
           $or: [
             {grant: null},
@@ -485,23 +498,19 @@ module.exports = function(crowi) {
           ],
         })
         .populate('revision')
+        .and({
+          $or: pathCondition
+        })
         .sort(sortOpt)
         .skip(opt.offset)
         .limit(opt.limit);
 
-      q.exec(function(err, pages) {
-        if (err) {
-          return reject(err);
-        }
-
-        Page.populate(pages, {path: 'revision.author', model: 'User', select: User.USER_PUBLIC_FIELDS}, function(err, data) {
-          if (err) {
-            return reject(err);
-          }
-
-          return resolve(data);
-        });
-      });
+      q.exec()
+      .then(function(pages) {
+        Page.populate(pages, {path: 'revision.author', model: 'User', select: User.USER_PUBLIC_FIELDS})
+        .then(resolve)
+        .catch(reject);
+      })
     });
   };
 

--- a/lib/routes/page.js
+++ b/lib/routes/page.js
@@ -81,7 +81,7 @@ module.exports = function(crowi, app) {
     .then(function(portalPage) {
       renderVars.page = portalPage;
 
-      return Page.findListByStartWith(path.substr(0, path.length -1), req.user, queryOptions);
+      return Page.findListByStartWith(path, req.user, queryOptions);
     }).then(function(pageList) {
 
       if (pageList.length > limit) {


### PR DESCRIPTION
* if user access `/u/` to get list of `/u/*`, then all of `/u*` appeared. (`/user/*` also)
* so now if the user access `/u/`, then show `/u/*` and just `/u`