### PR TITLE
Fix: JavaScript error on editing

### DIFF
--- a/lib/views/page.html
+++ b/lib/views/page.html
@@ -165,11 +165,11 @@
 
         //data-spy="affix" data-offset-top="80"
         var headerHeight = $('#page-header').outerHeight(true);
-        $('.header-wrap').css({height: headerHeight + 'px'});
+        $('.header-wrap').css({height: (headerHeight + 16) + 'px'});
         $('#page-header').affix({
           offset: {
             top: function() {
-              return headerHeight + 74; // (54 header + 20 padding-top)
+              return headerHeight + 86; // (54 header + 16 header padding-top + 16 content padding-top)
             }
           }
         });

--- a/resource/css/_page.scss
+++ b/resource/css/_page.scss
@@ -65,6 +65,7 @@
       h1 {
         font-size: 28px;
         margin-top: 0;
+        margin-bottom: 0;
 
         a:last-child {
           color: #D1E2E4;

--- a/resource/js/crowi-form.js
+++ b/resource/js/crowi-form.js
@@ -128,7 +128,7 @@ $(function() {
         var indent = listMarkMatch[1];
         var num = parseInt(listMarkMatch[2]);
         if (num !== 1) {
-          listMark = listMark.return(/\s*\d+/, indent + (num +1));
+          listMark = listMark.replace(/\s*\d+/, indent + (num +1));
         }
       }
       $target.selection('insert', {text: "\n" + listMark, mode: 'before'});

--- a/resource/js/crowi-form.js
+++ b/resource/js/crowi-form.js
@@ -214,6 +214,10 @@ $(function() {
 
   var handlePasteEvent = function(event) {
     var currentLine = getCurrentLine(event);
+
+    if (!currentLine) {
+      return false;
+    }
     var $target = $(event.target);
     var pasteText = event.clipboardData.getData('text');
 
@@ -228,11 +232,14 @@ $(function() {
 
     var newPos = currentLine.end + pasteText.length;
     $target.selection('setPos', {start: newPos, end: newPos});
+
+    return true;
   };
 
   document.getElementById('form-body').addEventListener('paste', function(event) {
-    event.preventDefault();
-    handlePasteEvent(event);
+    if (handlePasteEvent(event)) {
+      event.preventDefault();
+    }
   });
 
   var unbindInlineAttachment = function($form) {


### PR DESCRIPTION
* Fix content header style

## Fix error on pasting with all-text selected

When paste with all-text selected, cannot figure out `currentLine`. It causes an error below:
 
```
Uncaught TypeError: Cannot read property 'text' of null
```

## Fix error on numbered list

Input below:

```
1. xxx
2. xxx[Enter]
```

then, 

```
crowi-form.js:131 Uncaught TypeError: listMark.return is not a function
```

related to https://github.com/crowi/crowi/pull/57