### PR TITLE
Change behavior of applicationNotInstalled middleware

### DIFF
--- a/lib/util/middlewares.js
+++ b/lib/util/middlewares.js
@@ -162,7 +162,7 @@ exports.applicationNotInstalled = function() {
 
     if (Object.keys(config.crowi).length !== 1) {
       req.flash('errorMessage', 'Application already installed.');
-      return res.redirect('admin');
+      return res.redirect('admin'); // admin以外はadminRequiredで'/'にリダイレクトされる
     }
 
     return next();

--- a/lib/util/middlewares.js
+++ b/lib/util/middlewares.js
@@ -161,7 +161,8 @@ exports.applicationNotInstalled = function() {
     var config = req.config;
 
     if (Object.keys(config.crowi).length !== 1) {
-      return res.render('500', { error: 'Application already installed.' });
+      req.flash('errorMessage', 'Application already installed.');
+      return res.redirect('admin');
     }
 
     return next();

--- a/lib/views/admin/index.html
+++ b/lib/views/admin/index.html
@@ -12,6 +12,14 @@
 
 {% block content_main %}
 <div class="content-main">
+  
+  {% set emessage = req.flash('errorMessage') %}
+  {% if emessage.length %}
+  <div class="alert alert-danger">
+    {{ emessage }}
+  </div>
+  {% endif %}
+
   <div class="row">
     <div class="col-md-3">
       <ul class="nav nav-pills nav-stacked">


### PR DESCRIPTION
If crowi already installed,

### In case of admin user
- redirect to `/admin`
- display error message

[![https://gyazo.com/9888954b0ae608d359406badc687f27e](https://i.gyazo.com/9888954b0ae608d359406badc687f27e.png)](https://gyazo.com/9888954b0ae608d359406badc687f27e)

-----

### In case of no admin user
- redirect to `/`