### PR TITLE
Fix not to higilight (<strong>) link

### DIFF
--- a/resource/js/crowi.js
+++ b/resource/js/crowi.js
@@ -319,7 +319,12 @@ $(function() {
     var path = $link.data('path');
     var shortPath = $link.data('short-path');
 
-    $link.html(path.replace(new RegExp(shortPath + '(/)?$'), '<strong>' + shortPath + '$1</strong>'));
+    var escape = function(s) {
+      return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+    };
+    var pattern = escape(shortPath) + '(/)?$';
+
+    $link.html(path.replace(new RegExp(pattern), '<strong>' + shortPath + '$1</strong>'));
   });
 
 


### PR DESCRIPTION
## before

- "かっこ(かっこ)かっこ " doesn't have `<strong>` highlight.

![2016-05-17 10 07 03](https://cloud.githubusercontent.com/assets/10488/15308392/b181ff84-1c17-11e6-8db4-da2974bbb55f.png)

## after

- Fixed it.

![2016-05-17 10 07 11](https://cloud.githubusercontent.com/assets/10488/15308394/b486e6ea-1c17-11e6-9461-7c0b974b5182.png)

