### PR TITLE
Add graph renderer

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -165,9 +165,13 @@ gulp.task('css:sass', function() {
 });
 
 gulp.task('css:concat', ['css:sass'], function() {
-  return gulp.src([css.main, 'node_modules/highlight.js/styles/tomorrow-night.css'])
+  return gulp.src([
+    css.main,
+    'node_modules/highlight.js/styles/tomorrow-night.css',
+    'node_modules/mermaid/dist/mermaid.css',
+  ])
     .pipe(concat('crowi.css'))
-    .pipe(gulp.dest(dirs.cssDist))
+    .pipe(gulp.dest(dirs.cssDist));
 });
 
 gulp.task('css:min', ['css:concat'], function() {

--- a/lib/views/page_list.html
+++ b/lib/views/page_list.html
@@ -130,8 +130,8 @@
 
   <script type="text/javascript">
     $(function(){
-        $('#view-timeline .timeline-body').each(function()
-        {
+      $('a[data-toggle="tab"][href="#view-timeline"]').on('shown.bs.tab', function (e) {
+        $('#view-timeline .timeline-body').each(function() {
           var id = $(this).attr('id');
           var contentId = '#' + id + ' > script';
           var revisionBody = '#' + id + ' .revision-body';
@@ -139,7 +139,7 @@
           var renderer = new Crowi.renderer($(contentId).html(), $(revisionBody));
           renderer.render();
         });
-        //$('.tooltip .tabs').tabs();
+      });
     });
   </script>
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "jshint-stylish": "~2.1.0",
     "kerberos": "0.0.17",
     "marked": "~0.3.5",
+    "mermaid": "^6.0.0",
     "method-override": "~2.3.1",
     "mkdirp": "^0.5.1",
     "mongoose": "4.2.5",

--- a/resource/css/_mermaid.scss
+++ b/resource/css/_mermaid.scss
@@ -1,0 +1,6 @@
+// see: node_modules/mermaid/dist/mermaid.css
+.crowi-mermaid {
+  .label {
+    color: #333;
+  }
+}

--- a/resource/css/crowi.scss
+++ b/resource/css/crowi.scss
@@ -16,6 +16,7 @@
 @import 'comment';
 @import 'user';
 @import 'portal';
+@import 'mermaid';
 
 
 ul {

--- a/resource/js/crowi.js
+++ b/resource/js/crowi.js
@@ -6,12 +6,17 @@
 var hljs = require('highlight.js');
 var jsdiff = require('diff');
 var marked = require('marked');
+var mermaid = require('mermaid');
 var Crowi = {};
 
 if (!window) {
   window = {};
 }
 window.Crowi = Crowi;
+
+mermaid.initialize({
+  startOnLoad: false
+});
 
 Crowi.createErrorView = function(msg) {
   $('#main').prepend($('<p class="alert-message error">' + msg + '</p>'));
@@ -137,6 +142,14 @@ Crowi.rendererType = {};
 Crowi.rendererType.markdown = function(){};
 Crowi.rendererType.markdown.prototype = {
   render: function(contentText) {
+    var markedRenderer = new marked.Renderer();
+    markedRenderer.code = function(code, language) {
+      if (typeof language !== 'undefined' && language.match(/^mermaid/)) {
+        return '<div class="crowi-mermaid">' + code + '</div>';
+      }
+
+      return '<pre><code>' + code + '</code></pre>';
+    };
 
     marked.setOptions({
       gfm: true,
@@ -162,7 +175,8 @@ Crowi.rendererType.markdown.prototype = {
       sanitize: false,
       smartLists: true,
       smartypants: false,
-      langPrefix: 'lang-'
+      langPrefix: 'lang-',
+      renderer: markedRenderer
     });
 
     var contentHtml = Crowi.unescape(contentText);
@@ -178,6 +192,7 @@ Crowi.rendererType.markdown.prototype = {
         throw err;
       }
       $body.html(content);
+      mermaid.init({}, $body.children('.crowi-mermaid'));
     });
   },
   preFormatMarkdown: function(content){
@@ -226,7 +241,6 @@ Crowi.userPicture = function (user) {
     return '/images/userpicture.png';
   }
 };
-
 
 $(function() {
   var pageId = $('#content-main').data('page-id');


### PR DESCRIPTION
## About
- Add graph renderer using [mermaid](https://knsv.github.io/mermaid/)
- Supported graphs
  - flowchart
  - sequence diagram
  - gantt diagram
- Unsupport graphs (Not yet support)
  - git graph
  - class diagram
- Not support in presentation mode
## Syntax
- Syntax details are below:
  - [Flowchart](https://knsv.github.io/mermaid/#flowcharts-basic-syntax)
  - [Sequence Diagram](https://knsv.github.io/mermaid/#sequence-diagrams)
  - [Gantt Diagram](https://knsv.github.io/mermaid/#gant-diagrams)

<table style="width: 100%;">
<tr>
<td>Flowchart</td>
<td>
<pre>```mermaid
graph TD;
    A-->B;
    A-->C;
    B-->D;
    C-->D;
```</pre>
</td>
<td>
<img width="174" alt="2016-06-05 17 09 22" src="https://cloud.githubusercontent.com/assets/10488/15804353/4735ca1a-2b40-11e6-976d-c473eda05941.png">
</td>
</tr>

<tr>
<td>Sequence Diagram</td>
<td>
<pre>```mermaid
sequenceDiagram
    Alice->>John: Hello John, how are you?
    John-->>Alice: Great!
```</pre>
</td>
<td>
<img width="455" alt="2016-06-05 17 10 33" src="https://cloud.githubusercontent.com/assets/10488/15804362/9a56ebfc-2b40-11e6-95dd-56bad08f72d8.png">
</td>
</tr>

<tr>
<td>Gantt Diagram</td>
<td>
<pre>```mermaid
gantt
    title A Gantt Diagram

    section Section
    A task           :a1, 2014-01-01, 30d
    Another task     :after a1  , 20d
    section Another
    Task in sec      :2014-01-12  , 12d
    anther task      : 24d
```</pre>
</td>
<td>
<img width="465" alt="2016-06-05 17 13 42" src="https://cloud.githubusercontent.com/assets/10488/15804373/de912d82-2b40-11e6-8f7d-d055fb7f6125.png">
</td>
</tr>
</table>

## Changed things
- Rendering timings were change.
  - When page_list tab clicked
  - When preview tab clicked
- Switched timer for preview when tab of preview is on / off.
