### PR TITLE
Add revision TOC to PORTAL page

### DIFF
--- a/lib/views/_revision_toc.html
+++ b/lib/views/_revision_toc.html
@@ -1,0 +1,3 @@
+<div class="revision-toc" id="revision-toc">
+  <a data-toggle="collapse" data-parent="#revision-toc" href="#revision-toc-content" class="revision-toc-head collapsed">目次</a>
+</div>

--- a/lib/views/page.html
+++ b/lib/views/page.html
@@ -109,11 +109,7 @@
 
     {# formatted text #}
     <div class="tab-pane {% if not req.body.pageForm %}active{% endif %}" id="revision-body">
-      <div class="revision-toc" id="revision-toc">
-        <a data-toggle="collapse" data-parent="#revision-toc" href="#revision-toc-content" class="revision-toc-head collapsed">目次</a>
-
-      </div>
-      <div class="wiki {{ revision.format }}" id="revision-body-content"></div>
+      {% include '_revision_toc.html' %}
     </div>
 
     {# edit form #}

--- a/lib/views/page_list.html
+++ b/lib/views/page_list.html
@@ -67,7 +67,10 @@
   </ul>
 
   <div class="tab-content">
-    <div class="wiki tab-pane {% if not req.body.pageForm %}active{% endif %}" id="revision-body-content">{{ page.revision.body|nl2br|safe }}</div>
+    <div class="wiki tab-pane {% if not req.body.pageForm %}active{% endif %}">
+      {% include '_revision_toc.html' %}
+      <div id="revision-body-content">{{ page.revision.body|nl2br|safe }}</div>
+    </div>
 
     <script type="text/template" id="raw-text-original">{{ page.revision.body }}</script>
     <script type="text/javascript">


### PR DESCRIPTION
## About

- Add a table of content (TOC) to Portal page.
    - Like normal pages

## Before

![2016-06-08 08 45 13](https://cloud.githubusercontent.com/assets/10488/15878355/5a94b4c4-2d55-11e6-9ed5-41a1804ca67c.png)


## After

![2016-06-08 08 45 02](https://cloud.githubusercontent.com/assets/10488/15878361/6186dfb4-2d55-11e6-8456-273d09ae6492.png)
