### PR TITLE
Add scroll sync between editor and preview

### DIFF
--- a/resource/js/crowi-form.js
+++ b/resource/js/crowi-form.js
@@ -381,4 +381,37 @@ $(function() {
       $(this).removeClass('dragover');
     });
   }
+
+  var enableScrollSync = function() {
+    var getMaxScrollTop = function(dom) {
+      var rect = dom.getBoundingClientRect();
+
+      return dom.scrollHeight - rect.height;
+    };
+
+    var getScrollRate = function(dom) {
+      var maxScrollTop = getMaxScrollTop(dom);
+      var rate = dom.scrollTop / maxScrollTop;
+
+      return rate;
+    };
+
+    var getScrollTop = function(dom, rate) {
+      var maxScrollTop = getMaxScrollTop(dom);
+      var top = maxScrollTop * rate;
+
+      return top;
+    };
+
+    var editor = document.querySelector('#form-body');
+    var preview = document.querySelector('#preview-body');
+
+    editor.addEventListener('scroll', function(event) {
+      var rate = getScrollRate(this);
+      var top = getScrollTop(preview, rate);
+
+      preview.scrollTop = top;
+    });
+  };
+  enableScrollSync();
 });


### PR DESCRIPTION
## About 

- Add scroll sync between editor and preview.
    - When the editor scrolled, the preview scrolled too.
    - When the preview scrolled, the editor did not scroll.

## Screencast

![crowi4](https://cloud.githubusercontent.com/assets/10488/15994476/8fd1e244-3140-11e6-839b-da4ecaded156.gif)
