### PR TITLE
Fix: encodeURI when the portal exists

### DIFF
--- a/lib/routes/page.js
+++ b/lib/routes/page.js
@@ -93,6 +93,8 @@ module.exports = function(crowi, app) {
       renderVars.pager = generatePager(pagerOptions);
       renderVars.pages = pageList;
       res.render('page_list', renderVars);
+    }).catch(function(err) {
+      debug('Error on rendering pageListShow', err);
     });
   };
 
@@ -202,11 +204,13 @@ module.exports = function(crowi, app) {
       Page.hasPortalPage(path + '/', req.user)
       .then(function(page) {
         if (page) {
-          return res.redirect(path + '/');
+          return res.redirect(encodeURI(path) + '/');
         } else {
           debug('Catch pageShow', err);
           return renderPage(null, req, res);
         }
+      }).catch(function(err) {
+        debug('Error on rendering pageShow (redirect to portal)', err);
       });
     });
   };


### PR DESCRIPTION
* Fix: Cannot redirect when the path name includes multi-byte in some case.