### PR TITLE
XSS脆弱性の修正

### DIFF
--- a/resource/js/crowi.js
+++ b/resource/js/crowi.js
@@ -163,7 +163,7 @@ Crowi.rendererType.markdown.prototype = {
       tables: true,
       breaks: true,
       pedantic: false,
-      sanitize: false,
+      sanitize: true,
       smartLists: true,
       smartypants: false,
       langPrefix: 'lang-'


### PR DESCRIPTION
本文等のMarkdownがサポートされているところで`<script>`タグを含んだ文章を書くと、表示する際に任意のJavaScriptが実行されてしまいます。

Markedの`sanitize`オプションを`true`にするとスクリプトは実行されなくなりますが、これにより他のタグ(`<img>`等)もサニタイズされてしまいます...