### PR TITLE
Fix pagename problem

### DIFF
--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -332,7 +332,7 @@ module.exports = function(crowi) {
       /^http:\/\/.+$/, // avoid miss in renaming
       /.+\/edit$/,
       /.+\.md$/,
-      /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments).+/,
+      /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments)(\/.*|)$/,
     ];
 
     var isCreatable = true;


### PR DESCRIPTION
The page named like `/meeting`cannot be created.