### PR TITLE
Fix header navigation title

### DIFF
--- a/lib/views/layout/layout.html
+++ b/lib/views/layout/layout.html
@@ -49,7 +49,7 @@
   <div class="navbar-header">
     <a class="navbar-brand" href="/">
       <img alt="Crowi" src="/logo/32x32.png" width="16">
-      {% block title %}{{ config.crowi['app:title'] }}{% endblock %}
+      {% block title %}{{ config.crowi['app:title']|default('Crowi') }}{% endblock %}
     </a>
   {% if searchConfigured() %}
   <div class="navbar-form navbar-left search-top visible-lg visible-md" role="search" id="search-top">
@@ -147,4 +147,3 @@
 <script src="/js/app{% if env  == 'production' %}.min{% endif %}.js"></script>
 <script src="/js/crowi{% if env  == 'production' %}.min{% endif %}.js"></script>
 </html>
-


### PR DESCRIPTION
## About

- It is displayed as "undefined" on navigation title.

## Before 

<img width="382" alt="2016-07-18 11 31 12" src="https://cloud.githubusercontent.com/assets/10488/16905063/53b4736a-4cdb-11e6-9432-2be0545f5053.png">

## After (Fixed)

<img width="408" alt="2016-07-18 11 30 37" src="https://cloud.githubusercontent.com/assets/10488/16905067/650da316-4cdb-11e6-8bc7-71422ba88607.png">
