### PR TITLE
Fixed markup in page-list icon

### DIFF
--- a/lib/views/widget/page_list.html
+++ b/lib/views/widget/page_list.html
@@ -33,7 +33,7 @@
 
     {% if page.seenUsers.length >= config.seener_threshold %}
     <span>
-      <i class="fa fa-eye">{{ page.seenUsers.length }}</i>
+      <i class="fa fa-eye"></i>{{ page.seenUsers.length }}
     </span>
     {% endif  %}
 


### PR DESCRIPTION
## About

- Fix markup changed by #102
    - It was displayed at an unexpected font

## Before

- see "`1`"

<img width="469" alt="2016-07-21 07 44 45" src="https://cloud.githubusercontent.com/assets/10488/17005786/0bad8a5a-4f17-11e6-8054-0f2f9c3e70eb.png">


## After

<img width="472" alt="2016-07-21 07 44 22" src="https://cloud.githubusercontent.com/assets/10488/17005790/13e837ce-4f17-11e6-96c4-412f528a019c.png">
