### PR TITLE
Fix pagename problem

### DIFF
--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -332,7 +332,7 @@ module.exports = function(crowi) {
       /^http:\/\/.+$/, // avoid miss in renaming
       /.+\/edit$/,
       /.+\.md$/,
-      /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments).+/,
+      /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments)(\/.*|)$/,
     ];
 
     var isCreatable = true;

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -329,7 +329,7 @@ module.exports = function(crowi) {
       /^\/\-\/.*/,
       /^\/_r\/.*/,
       /^\/user\/[^\/]+\/(bookmarks|comments|activities|pages|recent-create|recent-edit)/, // reserved
-      /^http:\/\/.+$/, // avoid miss in renaming
+      /^https?:\/\/.+$/, // avoid miss in renaming
       /.+\/edit$/,
       /.+\.md$/,
       /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments)(\/.*|$)/,

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -325,14 +325,14 @@ module.exports = function(crowi) {
   pageSchema.statics.isCreatableName = function(name) {
     var forbiddenPages = [
       /\^|\$|\*|\+|\#/,
-      /^\/_api\/.*/,
+      /^\/_.*/, // /_api/* and so on
       /^\/\-\/.*/,
       /^\/_r\/.*/,
       /^\/user\/[^\/]+\/(bookmarks|comments|activities|pages|recent-create|recent-edit)/, // reserved
       /^http:\/\/.+$/, // avoid miss in renaming
       /.+\/edit$/,
       /.+\.md$/,
-      /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments)(\/.*|)$/,
+      /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments)(\/.*|$)/,
     ];
 
     var isCreatable = true;

--- a/test/models/page.test.js
+++ b/test/models/page.test.js
@@ -62,7 +62,7 @@ describe('Page', function () {
         },
       ];
 
-      testDBUtil.generateFixture(conn, 'Page', fixture)
+      return testDBUtil.generateFixture(conn, 'Page', fixture)
       .then(function(pages) {
         done();
       });
@@ -91,6 +91,43 @@ describe('Page', function () {
         });
       });
     });
+  });
+
+  describe('.isCreatableName', function() {
+
+    expect(Page.isCreatableName('/hoge')).to.be.true;
+
+    // edge cases
+    expect(Page.isCreatableName('/me')).to.be.false;
+    expect(Page.isCreatableName('/me/')).to.be.false;
+    expect(Page.isCreatableName('/me/x')).to.be.false;
+    expect(Page.isCreatableName('/meeting')).to.be.true;
+    expect(Page.isCreatableName('/meeting/x')).to.be.true;
+
+    // under score
+    expect(Page.isCreatableName('/_')).to.be.false;
+    expect(Page.isCreatableName('/_r/x')).to.be.false;
+    expect(Page.isCreatableName('/_api')).to.be.false;
+    expect(Page.isCreatableName('/_apix')).to.be.false;
+    expect(Page.isCreatableName('/_api/x')).to.be.false;
+
+    expect(Page.isCreatableName('/hoge/xx.md')).to.be.false;
+
+
+    var forbidden = ['installer', 'register', 'login', 'logout', 'admin', 'files', 'trash', 'paste', 'comments'];
+    for (var i = 0; i < forbidden.length ; i++) {
+      var pn = forbidden[i];
+      expect(Page.isCreatableName('/' + pn + '')).to.be.false;
+      expect(Page.isCreatableName('/' + pn + '/')).to.be.false;
+      expect(Page.isCreatableName('/' + pn + '/abc')).to.be.false;
+    }
+
+    var forbidden = ['bookmarks', 'comments', 'activities', 'pages', 'recent-create', 'recent-edit'];
+    for (var i = 0; i < forbidden.length ; i++) {
+      var pn = forbidden[i];
+      expect(Page.isCreatableName('/user/aoi/' + pn)).to.be.false;
+      expect(Page.isCreatableName('/user/aoi/x/' + pn)).to.be.true;
+    }
   });
 
   describe('.isCreator', function() {


### PR DESCRIPTION
Originally got feedback from: #100 

- Fix: The page named like `/meeting` cannot be created, now it can be created.
- Now page name start with `_` is not creatable name. (`/_*`)

Close #100 