### PR TITLE
Add readonly attribute in share link input

### DIFF
--- a/lib/views/widget/page_side_content.html
+++ b/lib/views/widget/page_side_content.html
@@ -2,11 +2,11 @@
 <ul class="fitted-list">
   <li data-toggle="tooltip" data-placement="bottom" title="共有用リンク" class="input-group">
     <span class="input-group-addon">共有用</span>
-    <input class="copy-link form-control" type="text" value="{{ config.crowi['app:title'] }} {{ path }}  {{ baseUrl }}/{{ page._id.toString() }}">
+    <input readonly class="copy-link form-control" type="text" value="{{ config.crowi['app:title'] }} {{ path }}  {{ baseUrl }}/{{ page._id.toString() }}">
   </li>
   <li data-toggle="tooltip" data-placement="bottom" title="Markdown形式のリンク" class="input-group">
     <span class="input-group-addon">Markdown</span>
-    <input class="copy-link form-control" type="text" value="[{{ path }}]({{ baseUrl }}/{{ page._id.toString() }})">
+    <input readonly class="copy-link form-control" type="text" value="[{{ path }}]({{ baseUrl }}/{{ page._id.toString() }})">
   </li>
 </ul>
 


### PR DESCRIPTION
share link を表示している `input` 要素は editable である必要は無いため readonly attribute を追加してみました


| Before | After |
| ------ | -------|
| ![2016-07-28 5 03 36](https://cloud.githubusercontent.com/assets/111251/17190430/c1fe0794-5480-11e6-8c68-b94f3df1e718.png) | ![2016-07-28 5 03 54](https://cloud.githubusercontent.com/assets/111251/17190462/da4b0658-5480-11e6-9eaf-2ab021cf82ab.png) |

---

```
.copy-link.form-control[readonly] {
    background: #fff;
}
```

などとすれば background color を white にすることができますが、 `.copy-link` は onClick で `$(this).select()` するために付けられた class のような気がしたので敢えて弄りませんでした。