### PR TITLE
Add word-wrap in comment body

### DIFF
--- a/resource/css/_comment.scss
+++ b/resource/css/_comment.scss
@@ -55,6 +55,7 @@
         }
         .page-comment-body {
           padding: 8px 0;
+          word-wrap: break-word;
         }
       }
     }

--- a/resource/css/_wiki.scss
+++ b/resource/css/_wiki.scss
@@ -104,7 +104,7 @@ div.body {
     background: #444;
     color: #f0f0f0;
     font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
-    word-break: break-word;
+    word-wrap: break-word;
   }
 
   img {


### PR DESCRIPTION
### summally
- add `word-wrap: break-word;` in comment body

|before|after|
|---|---|
|![2016-09-13 20 30 49](https://cloud.githubusercontent.com/assets/5100073/18472800/7933872a-79f4-11e6-8c5d-030e51f85ae9.png)|![2016-09-13 20 31 12](https://cloud.githubusercontent.com/assets/5100073/18472808/807c4ada-79f4-11e6-9290-77e0b6b59af0.png)|

### notes
- `word-break` has no propety `break-word`
- see [word-break](https://developer.mozilla.org/ja/docs/Web/CSS/word-break) [word-wrap](https://developer.mozilla.org/ja/docs/Web/CSS/word-wrap)

