### PR TITLE
Add Node.js version for CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,10 @@ machine:
     - mongodb
   environment:
     MONGO_URI: mongodb://127.0.0.1/crowi_test
+  node:
+      version: 4.6.2
+  post:
+    - npm install -g npm@3
 notify:
   webhooks:
     - url: https://webhooks.gitter.im/e/5a035388e3274b621d20
-


### PR DESCRIPTION
## About

- Add Node.js version 4.6.2
    - Latest 4.x version

## Motivation

- Crowi is depend on Node.js v4.x
    - But, default version of CircleCI is v0.10 

## References

- http://qiita.com/inuscript/items/d2c87e076595f801b44b