### PR TITLE
can upload any file

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "gulp-uglify": "~1.4.2",
     "gulp-watch": "~4.3.5",
     "highlight.js": "~9.0.0",
-    "inline-attachment": "git+https://github.com/Rovak/InlineAttachment.git#2.0.2",
+    "inline-attachment": "git+https://github.com/Rovak/InlineAttachment.git#2.0.3",
     "jquery": "~2.1.4",
     "jquery.cookie": "~1.4.1",
     "jshint-stylish": "~2.1.0",

--- a/resource/js/crowi-form.js
+++ b/resource/js/crowi-form.js
@@ -416,7 +416,10 @@ $(function() {
         path: location.pathname
       },
       progressText: '(Uploading file...)',
-      urlText: "\n![file]({filename})\n"
+      urlText: "\n![file]({filename})\n",
+      allowedTypes: [
+          '*'
+      ]
     };
 
     attachmentOption.onFileUploadResponse = function(res) {


### PR DESCRIPTION
画像以外もアップロードできるようにしました。

アップロードしたあとにエディターに表示している文字列が画像展開用のURLになっているんですが、そこは編集者が直せばいいかなぁくらいにおもって修正していません。
ほんらいなら、filenameによって展開するURLを変更するような処理をいれたほうが親切かもしれませんが、まぁわかるだろうくらいの。

あとは、page下部の Attachementsにでているfilenameの接頭辞として image がついてしまっているのですが、そこまで気にしないかとおもって変更していません。