### PR TITLE
Add search features to Smartphone and Tablet view

### DIFF
--- a/lib/views/layout/layout.html
+++ b/lib/views/layout/layout.html
@@ -30,7 +30,7 @@
   <div class="navbar-header">
     <a class="navbar-brand" href="/">
       <img alt="Crowi" src="/logo/32x32.png" width="16">
-      {% block title %}{{ config.crowi['app:title']|default('Crowi') }}{% endblock %}
+      <span class="hidden-xs">{% block title %}{{ config.crowi['app:title']|default('Crowi') }}{% endblock %}</span>
     </a>
   {% if searchConfigured() %}
   <div class="navbar-form navbar-left search-top" role="search" id="search-top">

--- a/lib/views/layout/layout.html
+++ b/lib/views/layout/layout.html
@@ -33,7 +33,7 @@
       {% block title %}{{ config.crowi['app:title']|default('Crowi') }}{% endblock %}
     </a>
   {% if searchConfigured() %}
-  <div class="navbar-form navbar-left search-top visible-lg visible-md visible-xs" role="search" id="search-top">
+  <div class="navbar-form navbar-left search-top" role="search" id="search-top">
   </div>
   {% endif %}
   </div>

--- a/lib/views/layout/layout.html
+++ b/lib/views/layout/layout.html
@@ -33,7 +33,7 @@
       {% block title %}{{ config.crowi['app:title']|default('Crowi') }}{% endblock %}
     </a>
   {% if searchConfigured() %}
-  <div class="navbar-form navbar-left search-top visible-lg visible-md" role="search" id="search-top">
+  <div class="navbar-form navbar-left search-top visible-lg visible-md visible-xs" role="search" id="search-top">
   </div>
   {% endif %}
   </div>

--- a/resource/css/_search.scss
+++ b/resource/css/_search.scss
@@ -127,8 +127,8 @@
   }
 }
 
-// Extra small devices Phones (<768px)
-@media (max-width: $screen-xs-max) {
+// Smartphone and Tablet
+@media (max-width: $screen-sm-max) {
   .search-top {
     margin-top: 4px 0 0 0;
     padding: 0;
@@ -136,9 +136,13 @@
     box-shadow: none !important;
     -webkit-box-shadow: none !important;
 
+    .search-form {
+      width: 100%;
+    }
+
     .search-top-input-group {
       .search-top-input {
-        width: 180px;
+        width: 100%;
       }
       .btn {
         margin-left: -38px;
@@ -162,36 +166,16 @@
   }
 }
 
-// Small devices Tablets (≥768px)
-@media (max-width: $screen-sm-max) {
+// Smartphone
+@media (max-width: $screen-xs-max) {
   .search-top {
-    margin-top: 4px 0 0 0;
-    padding: 0;
-    border-style: none !important;
-    box-shadow: none !important;
-    -webkit-box-shadow: none !important;
-
-    .search-top-input-group {
-      .search-top-input {
-        width: 240px;
-      }
-      .btn {
-        margin-left: -38px;
-        z-index: 10;
-      }
+    .search-form {
+      width: 24%;
     }
-  }
-
-  .search-result {
-    .search-result-content {
-      .search-result-page {
-        .wiki {
-          h1, h2, h3, h4, h5, h6 {
-            font-size: medium;
-          }
-          height: 250px;
-          overflow: scroll;
-        }
+    .search-box {
+      .search-suggest {
+        left: 2%;
+        width: 94%;
       }
     }
   }

--- a/resource/css/_search.scss
+++ b/resource/css/_search.scss
@@ -126,3 +126,34 @@
     }
   }
 }
+
+@media (max-width: $screen-xs-max) {
+  .search-top {
+    margin-top: 4px 0 0 0;
+    padding: 0;
+
+    .search-top-input-group {
+      .search-top-input {
+        width: 180px;
+      }
+      .btn {
+        margin-left: -38px;
+        z-index: 10;
+      }
+    }
+  }
+
+  .search-result {
+    .search-result-content {
+      .search-result-page {
+        .wiki {
+          h1, h2, h3, h4, h5, h6 {
+            font-size: medium;
+          }
+          height: 250px;
+          overflow: scroll;
+        }
+      }
+    }
+  }
+}

--- a/resource/css/_search.scss
+++ b/resource/css/_search.scss
@@ -161,3 +161,38 @@
     }
   }
 }
+
+// Small devices Tablets (≥768px)
+@media (max-width: $screen-sm-max) {
+  .search-top {
+    margin-top: 4px 0 0 0;
+    padding: 0;
+    border-style: none !important;
+    box-shadow: none !important;
+    -webkit-box-shadow: none !important;
+
+    .search-top-input-group {
+      .search-top-input {
+        width: 240px;
+      }
+      .btn {
+        margin-left: -38px;
+        z-index: 10;
+      }
+    }
+  }
+
+  .search-result {
+    .search-result-content {
+      .search-result-page {
+        .wiki {
+          h1, h2, h3, h4, h5, h6 {
+            font-size: medium;
+          }
+          height: 250px;
+          overflow: scroll;
+        }
+      }
+    }
+  }
+}

--- a/resource/css/_search.scss
+++ b/resource/css/_search.scss
@@ -131,6 +131,7 @@
   .search-top {
     margin-top: 4px 0 0 0;
     padding: 0;
+    border-style: none !important;
 
     .search-top-input-group {
       .search-top-input {

--- a/resource/css/_search.scss
+++ b/resource/css/_search.scss
@@ -127,11 +127,14 @@
   }
 }
 
+// Extra small devices Phones (<768px)
 @media (max-width: $screen-xs-max) {
   .search-top {
     margin-top: 4px 0 0 0;
     padding: 0;
     border-style: none !important;
+    box-shadow: none !important;
+    -webkit-box-shadow: none !important;
 
     .search-top-input-group {
       .search-top-input {

--- a/resource/css/_search.scss
+++ b/resource/css/_search.scss
@@ -137,7 +137,7 @@
     -webkit-box-shadow: none !important;
 
     .search-form {
-      width: 100%;
+      width: 76%;
     }
 
     .search-top-input-group {
@@ -145,7 +145,6 @@
         width: 100%;
       }
       .btn {
-        margin-left: -38px;
         z-index: 10;
       }
     }
@@ -170,7 +169,9 @@
 @media (max-width: $screen-xs-max) {
   .search-top {
     .search-form {
-      width: 24%;
+      min-width: 40%;
+      max-width: 50%;
+      width: 50%;
     }
     .search-box {
       .search-suggest {

--- a/resource/js/components/SearchPage/SearchResult.js
+++ b/resource/js/components/SearchPage/SearchResult.js
@@ -78,7 +78,7 @@ export default class SearchResult extends React.Component {
     return (
       <div className="content-main">
         <div className="search-result row" id="search-result">
-          <div className="col-md-4 page-list search-result-list" id="search-result-list">
+          <div className="col-md-4 hidden-xs page-list search-result-list" id="search-result-list">
             <nav data-spy="affix" data-offset-top="120">
               <ul className="page-list-ul nav">
                 {listView}
@@ -111,4 +111,3 @@ SearchResult.defaultProps = {
   searchResultMeta: {},
   searchError: null,
 };
-

--- a/resource/js/components/SearchPage/SearchResult.js
+++ b/resource/js/components/SearchPage/SearchResult.js
@@ -78,7 +78,7 @@ export default class SearchResult extends React.Component {
     return (
       <div className="content-main">
         <div className="search-result row" id="search-result">
-          <div className="col-md-4 hidden-xs page-list search-result-list" id="search-result-list">
+          <div className="col-md-4 hidden-xs hidden-sm page-list search-result-list" id="search-result-list">
             <nav data-spy="affix" data-offset-top="120">
               <ul className="page-list-ul nav">
                 {listView}


### PR DESCRIPTION
# Search in Smartphone and Tablet view

## About

- In smartphone view:
    - Add the search box on Header
    - Disable search result list
    - Hide wiki title

## Screenshot

### Top

- Wiki titles is hidden.

![2016-12-05 07 51 46](https://cloud.githubusercontent.com/assets/10488/20869881/cbe9f416-babf-11e6-83d4-f60fc1f7aaa9.png)

### Input search words

- Display suggests

![2016-12-05 07 51 53](https://cloud.githubusercontent.com/assets/10488/20869884/fa9bee54-babf-11e6-92b4-24f364254fd4.png)

### Search Page

- Hide search result list
- Result box is fixed height
    - When contents overflow, scroll bar will appear

![2016-12-05 07 52 04](https://cloud.githubusercontent.com/assets/10488/20869890/0c6175b4-bac0-11e6-884a-3630ad392bfd.png)
