### PR TITLE
Remove SMTP user and password confirmation from priority check

### DIFF
--- a/lib/util/mailer.js
+++ b/lib/util/mailer.js
@@ -68,7 +68,7 @@ module.exports = function(crowi) {
       return;
     }
 
-    if (config.crowi['mail:smtpUser'] && config.crowi['mail:smtpPassword'] && config.crowi['mail:smtpHost'] && config.crowi['mail:smtpPort']
+    if (config.crowi['mail:smtpHost'] && config.crowi['mail:smtpPort']
       ) {
       // SMTP 設定がある場合はそれを優先
       mailer = createSMTPClient();


### PR DESCRIPTION
メール送信時の SMTP設定を使用するかのチェックに、SMTPユーザとパスワードが含まれており、SMTPユーザとパスワードが設定されていないと、メール送信されないため、チェックを外しました。
