### PR TITLE
Add Markdown edit toolbar

### DIFF
--- a/lib/views/_form.html
+++ b/lib/views/_form.html
@@ -8,6 +8,7 @@
   </ul>
 </div>
 {% endif %}
+<div id="markdown-edit-helper"></div>
 <div id="form-box" class="row">
   <form action="/_/edit" id="page-form" method="post" class="col-md-6 {% if isUploadable() %}uploadable{% endif %} page-form">
     <textarea name="pageForm[body]" class="form-control" id="form-body">{% if pageForm.body %}{{ pageForm.body }}{% elseif not page.revision.body %}# {{ path|path2name }}{% else %}{{ page.revision.body }}{% endif %}</textarea>

--- a/resource/css/_form.scss
+++ b/resource/css/_form.scss
@@ -1,3 +1,5 @@
+$markdown-edit-helper-height: 36px;
+
 .crowi.main-container .main .content-main.on-edit { // {{{ Edit Form of Page
   padding: 0;
 
@@ -16,7 +18,7 @@
 
   .tab-content {
     top: 48px;
-    bottom: 58px;
+    bottom: (58px + $markdown-edit-helper-height);
     padding: 0 12px;
     position: absolute;
     z-index: 1051;
@@ -26,6 +28,11 @@
 
     .alert-info {
       display: none;
+    }
+
+    #markdown-edit-helper {
+      height: $markdown-edit-helper-height;
+      border-bottom: solid 1px #ccc;
     }
 
     .edit-form { // {{{

--- a/resource/js/app.js
+++ b/resource/js/app.js
@@ -8,6 +8,7 @@ import HeaderSearchBox  from './components/HeaderSearchBox';
 import SearchPage  from './components/SearchPage';
 import PageListSearch  from './components/PageListSearch';
 //import PageComment  from './components/PageComment';
+import MarkdownEditHelper from './components/MarkdownEditHelper';
 
 if (!window) {
   window = {};
@@ -20,10 +21,13 @@ crowi.fetchUsers();
 const crowiRenderer = new CrowiRenderer();
 window.crowiRenderer = crowiRenderer;
 
+const editor = document.querySelector('#form-body');
+
 const componentMappings = {
   'search-top': <HeaderSearchBox />,
   'search-page': <SearchPage />,
   'page-list-search': <PageListSearch />,
+  'markdown-edit-helper': <MarkdownEditHelper editor={editor} />,
   //'page-comment': <PageComment />,
 };
 

--- a/resource/js/components/MarkdownEditHelper.js
+++ b/resource/js/components/MarkdownEditHelper.js
@@ -1,0 +1,278 @@
+import React from 'react';
+
+class MardownEditHelper extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  componentDidMount() {
+    this.enableEvent();
+  }
+
+  enableEvent() {
+    this.props.editor.addEventListener('keydown', (e) => {
+      if (e.metaKey === true) {
+        switch (e.key) {
+          case 'b':
+            this.handleBold();
+            break;
+          case 'i':
+            this.handleBold();
+            break;
+          case 'k':
+            this.handleLink();
+            break;
+          // case 's':
+          //   // TODO: save document or other action
+          //   e.preventDefault();
+          //   break;
+          default:
+            // nothing to do
+        }
+      }
+    });
+  }
+
+  createButton(iconClass, handler, title, string) {
+    const iconClassName = 'fa ' + iconClass;
+
+    return (
+      <span>
+        <a className="btn" onClick={handler} data-toggle="tooltip" data-placement="top" title={title}>
+          <i className={iconClassName} aria-hidden="true"></i>{string}
+        </a>
+      </span>
+    );
+  }
+
+  buttonUl() {
+    return this.createButton('fa-list-ul', this.handleUl.bind(this), 'Add a bulleted list');
+  }
+
+  buttonOl() {
+    return this.createButton('fa-list-ol', this.handleOl.bind(this), 'Add a numbered list');
+  }
+
+  buttonBold() {
+    return this.createButton('fa-bold', this.handleBold.bind(this), 'Add bold text (cmd + b)');
+  }
+
+  buttonItalic() {
+    return this.createButton('fa-italic', this.handleItalic.bind(this), 'Add italic text (cmd + i)');
+  }
+
+  buttonQuote() {
+    return this.createButton('fa fa-quote-left', this.handleQuote.bind(this), 'Insert a quote');
+  }
+
+  buttonLink() {
+    return this.createButton('fa-link', this.handleLink.bind(this), 'Add a link (cmd + k)');
+  }
+
+  buttonStrikeThrough() {
+    return this.createButton('fa-strikethrough', this.handleStrikeThrough.bind(this), 'Add strike through text');
+  }
+
+  buttonCode() {
+    return this.createButton('fa-code', this.handleCode.bind(this), 'Insert code');
+  }
+
+  buttonHeader(number) {
+    return this.createButton('fa-header', this.handleHeader.bind(this, number), 'Insert header ' + number, number);
+  }
+
+  handleUl() {
+    this.insertLeftTag('-');
+  }
+
+  handleOl() {
+    this.insertLeftTag('1.');
+  }
+
+  handleBold() {
+    this.insertTag('**');
+  }
+
+  handleItalic() {
+    this.insertTag('_');
+  }
+
+  handleQuote() {
+    this.insertLeftTag('>');
+  }
+
+  handleLink() {
+    this.insertLinkTag();
+  }
+
+  handleStrikeThrough() {
+    this.insertTag('~~');
+  }
+
+  handleCode() {
+    this.insertTag('`');
+  }
+
+  handleHeader(number) {
+    const headerTags = {
+      1: '#',
+      2: '##',
+      3: '###',
+    };
+
+    this.insertLeftTag(headerTags[number]);
+  }
+
+  getCurrentSelection() {
+    const editor = this.props.editor;
+
+    editor.focus();
+    return {
+      start: editor.selectionStart,
+      end:   editor.selectionEnd,
+      content: {
+        before: editor.value.substr(0, editor.selectionStart),
+        target: editor.value.substr(editor.selectionStart, (editor.selectionEnd - editor.selectionStart)),
+        after:  editor.value.substr(editor.selectionEnd),
+      }
+    };
+  }
+
+  reSelect(start, end) {
+    const editor = this.props.editor;
+    editor.setSelectionRange(start, end);
+    editor.focus();
+  }
+
+  replaceEditorValue(start, end, newText) {
+    const editor = this.props.editor;
+    editor.setSelectionRange(start, end);
+    editor.focus();
+
+    let inserted = false;
+    try {
+      // Chrome, Safari
+      inserted = document.execCommand('insertText', false, newText);
+    } catch (e) {
+      inserted = false;
+    }
+
+    if (!inserted) {
+      // Firefox
+      editor.value = editor.value.substr(0, start) + newText + editor.value.substr(end);
+    }
+  }
+
+  insertTag(tag) {
+    const currentSelection = this.getCurrentSelection();
+
+    const editor = this.props.editor;
+    const preText  = editor.value.substr(currentSelection.start - tag.length, tag.length);
+    const postText = editor.value.substr(currentSelection.end, tag.length);
+
+    let newText = '';
+    let replaceStart = 0;
+    let replaceEnd   = 0;
+    let selectStart  = 0;
+    let selectEnd    = 0;
+
+    if (preText === tag && postText === tag) {
+      // Already inserted
+      newText = currentSelection.content.target;
+      replaceStart = currentSelection.start - tag.length;                  // |**STRING**
+      replaceEnd   = currentSelection.end   + tag.length;                  //  **STRING**|
+      selectStart  = currentSelection.start - tag.length;                  //   |STRING
+      selectEnd    = selectStart + currentSelection.content.target.length; //    STRING|
+    } else {
+      // Not yet inserted
+      newText = tag + currentSelection.content.target + tag;
+      replaceStart = currentSelection.start;                               //   |STRING
+      replaceEnd   = currentSelection.end;                                 //    STRING|
+      selectStart  = currentSelection.start + tag.length;                  // **|STRING**
+      selectEnd    = selectStart + currentSelection.content.target.length; //  **STRING|**
+    }
+
+    this.replaceEditorValue(replaceStart, replaceEnd, newText);
+    this.reSelect(selectStart, selectEnd);
+  }
+
+  insertLeftTag(tag) {
+    const currentSelection = this.getCurrentSelection();
+
+    const editor = this.props.editor;
+    const preText = editor.value.substr(currentSelection.start - tag.length - 1, tag.length);
+
+    let newText = '';
+    let replaceStart = 0;
+    let replaceEnd   = 0;
+    let selectStart  = 0;
+    let selectEnd    = 0;
+
+    if (preText === tag) {
+      // Already inserted
+      const regexp = new RegExp("\n" + tag + ' ', 'g');
+      newText = currentSelection.content.target.replace(regexp, "\n");
+      replaceStart = currentSelection.start - tag.length - 1;
+      replaceEnd   = currentSelection.end;
+      selectStart  = currentSelection.start - tag.length - 1;
+      selectEnd    = selectStart + newText.length;
+    } else {
+      newText = tag + ' ' + currentSelection.content.target.replace(/\n/g, "\n" + tag + ' ');
+
+      const regexp = new RegExp("\n" + tag + ' $');
+      newText = newText.replace(regexp, "\n");
+
+      replaceStart = currentSelection.start;
+      replaceEnd   = currentSelection.end;
+      selectStart  = currentSelection.start + tag.length + 1;
+      selectEnd    = selectStart + newText.length - tag.length - 1;
+    }
+
+    this.replaceEditorValue(replaceStart, replaceEnd, newText);
+    this.reSelect(selectStart, selectEnd);
+  }
+
+  insertLinkTag() {
+    const currentSelection = this.getCurrentSelection();
+
+    const editor = this.props.editor;
+
+    let newText = '[' + currentSelection.content.target + '](url)';
+    let replaceStart = currentSelection.start;
+    let replaceEnd   = currentSelection.end;
+    let selectStart  = currentSelection.end + 3; // [STRING](|url)
+    let selectEnd    = selectStart + 3;          // [STRING](url|)
+
+    this.replaceEditorValue(replaceStart, replaceEnd, newText);
+    this.reSelect(selectStart, selectEnd);
+  }
+
+  render() {
+    return (
+      <div className="markdown-edit-helper">
+        <div>
+          {this.buttonBold()}
+          {this.buttonItalic()}
+          {this.buttonLink()}
+          {this.buttonStrikeThrough()}
+          {this.buttonCode()}
+          {this.buttonHeader(1)}
+          {this.buttonHeader(2)}
+          {this.buttonHeader(3)}
+          {this.buttonQuote()}
+          {this.buttonUl()}
+          {this.buttonOl()}
+        </div>
+      </div>
+    );
+  }
+}
+
+MardownEditHelper.propTypes = {
+  editor: React.PropTypes.element.isRequired,
+};
+
+MardownEditHelper.defaultProps = {
+};
+
+export default MardownEditHelper;


### PR DESCRIPTION
## Overview

![_2016-12-11_16_36_10](https://cloud.githubusercontent.com/assets/10488/21078821/19540732-bfc0-11e6-9f41-83ebc3136a0d.png)

## Feature

- Show toolbar in Edit mode.
- Tools:
    - **Bold**
    - _Italic_
    - link
    - ~~Strike Through~~
    - `code`
    - Header (h1, h2, h3)
    - quote
    - Bulleted list
    - Numbered list

## Keybord shortcuts

- Compatible GitHub's shortcuts

| key | feature |
| --- | --- |
| `Cmd + k` | Add bold |
| `Cmd + i`  | Add italic |
| `Cmd + k` | Add url link |

## Future plan

- Move event handlings from `crowi-form.js` to `MarkdownEditorHelper.js`
    - enter, tab and paste event handlings

## Screen capture

![toolbar](https://cloud.githubusercontent.com/assets/10488/21078857/e9365684-bfc1-11e6-824e-7850377be105.gif)

## References

- [JSからtextareaの文字列を変更した時、Undoに対応できるようにする ](https://mimemo.io/m/mqLXOlJe7ozQ19r)
