### PR TITLE
Support the Elasticsearch 5.x

### DIFF
--- a/lib/crowi/index.js
+++ b/lib/crowi/index.js
@@ -344,24 +344,4 @@ Crowi.prototype.exitOnError = function(err) {
   process.exit(1);
 };
 
-Crowi.prototype.getParsedVersion = function(version) {
-  version = version || this.version;
-
-  var major = 0;
-  var minor = 0;
-  var revision = 0;
-
-  if (version.match(/^(\d+)\.(\d+)\.(\d+)$/)) {
-    major    = +(RegExp.$1);
-    minor    = +(RegExp.$2);
-    revision = +(RegExp.$3);
-  }
-
-  return {
-    major: major,
-    minor: minor,
-    revision: revision,
-  };
-};
-
 module.exports = Crowi;

--- a/lib/crowi/index.js
+++ b/lib/crowi/index.js
@@ -217,15 +217,7 @@ Crowi.prototype.getIo = function() {
 };
 
 Crowi.prototype.getSearcher = function() {
-  if (this.searcher !== null) {
-    if (this.searcher.isSupportedESVersion()) {
-      return this.searcher;
-    } else {
-      this.searcher = null;
-    }
-  }
-
-  return null;
+  return this.searcher;
 };
 
 Crowi.prototype.getMailer = function() {
@@ -243,12 +235,21 @@ Crowi.prototype.setupSearcher = function() {
     if (searcherUri) {
       try {
         self.searcher = new (require(path.join(self.libDir, 'util', 'search')))(self, searcherUri);
+        self.searcher
+          .isSupportedESVersion()
+          .then(function(result) {
+            if (result) {
+              resolve();
+            } else {
+              reject(new Error('Detect unsupported Elasticsearch version: ' + self.searcher.getServerVersion()));
+            }
+          });
       } catch (e) {
         debug('Error on setup searcher', e);
         self.searcher = null;
+        resolve();
       }
     }
-    resolve();
   });
 };
 

--- a/lib/crowi/index.js
+++ b/lib/crowi/index.js
@@ -217,7 +217,15 @@ Crowi.prototype.getIo = function() {
 };
 
 Crowi.prototype.getSearcher = function() {
-  return this.searcher;
+  if (this.searcher !== null) {
+    if (this.searcher.isSupportedESVersion()) {
+      return this.searcher;
+    } else {
+      this.searcher = null;
+    }
+  }
+
+  return null;
 };
 
 Crowi.prototype.getMailer = function() {
@@ -336,5 +344,24 @@ Crowi.prototype.exitOnError = function(err) {
   process.exit(1);
 };
 
+Crowi.prototype.getParsedVersion = function(version) {
+  version = version || this.version;
+
+  var major = 0;
+  var minor = 0;
+  var revision = 0;
+
+  if (version.match(/^(\d+)\.(\d+)\.(\d+)$/)) {
+    major    = +(RegExp.$1);
+    minor    = +(RegExp.$2);
+    revision = +(RegExp.$3);
+  }
+
+  return {
+    major: major,
+    minor: minor,
+    revision: revision,
+  };
+};
 
 module.exports = Crowi;

--- a/lib/util/search.js
+++ b/lib/util/search.js
@@ -9,8 +9,6 @@ function SearchClient(crowi, esUri) {
   this.DEFAULT_OFFSET = 0;
   this.DEFAULT_LIMIT = 50;
 
-  this.FIELD_TYPE_NAME_THRESHOLD_VERSION = 5;
-
   this.esUri = esUri;
   this.crowi = crowi;
 
@@ -28,42 +26,31 @@ function SearchClient(crowi, esUri) {
   this.mappingFile = crowi.resourceDir + 'search/mappings.json';
 
   this.serverInfo = {};
-  this.serverVersion = {};
+
   Promise
     .resolve(this.client.info())
     .then((info) => {
-      debug(info);
       this.serverInfo = info;
-      this.serverVersion = parseVersion(info);
     })
     .catch((err) => {
+      throw new Error();
     });
 }
 
-function parseVersion(info) {
-  var version = info.version.number; // TODO: check exists
-  if (version.match(/^(\d+)\.(\d+)\.(\d+)$/)) {
-    return {
-      major: RegExp.$1,
-      minor: RegExp.$2,
-      build: RegExp.$3,
-    };
+SearchClient.prototype.isSupportedESVersion = function() {
+  var crowiVersion = this.crowi.getParsedVersion();
+  var ESVersion    = this.crowi.getParsedVersion(this.serverInfo.version.number);
+
+  if (crowiVersion.major === 1 && crowiVersion.minor >= 6) {
+    if (ESVersion.major >= 5) {
+      return true;
+    }
   }
 
-  return {
-    major: 0,
-    minor: 0,
-    build: 0,
-  };
-}
+  console.log('WARNING: Detect unsupported Elasticsearch version: ' + this.serverInfo.version.number);
 
-SearchClient.prototype.isMajorVersionGreaterThanOrEqual = function(number) {
-  return this.serverVersion.major >= number;
+  return false;
 }
-
-SearchClient.prototype.checkESVersion = function() {
-  // TODO
-};
 
 SearchClient.prototype.registerUpdateEvent = function() {
   var pageEvent = this.crowi.event('page');
@@ -321,11 +308,11 @@ SearchClient.prototype.createSearchQuerySortedByUpdatedAt = function(option)
     index: this.index_name,
     type: 'pages',
     body: {
+      stored_fields: fields,
       sort: [{ updated_at: { order: 'desc'}}],
       query: {}, // query
     }
   };
-  this.appendFields(fields);
   this.appendResultSize(query);
 
   return query;
@@ -343,24 +330,15 @@ SearchClient.prototype.createSearchQuerySortedByScore = function(option)
     index: this.index_name,
     type: 'pages',
     body: {
+      stored_fields: fields,
       sort: [ {_score: { order: 'desc'} }],
       query: {}, // query
     }
   };
-  this.appendFields(query, fields);
   this.appendResultSize(query);
 
   return query;
 };
-
-SearchClient.prototype.appendFields = function(query, fields)
-{
-  if (this.isMajorVersionGreaterThanOrEqual(this.FIELD_TYPE_NAME_THRESHOLD_VERSION)) {
-    query.stored_fields = fields;
-  } else {
-    query.fields = fields;
-  }
-}
 
 SearchClient.prototype.appendResultSize = function(query, from, size)
 {

--- a/lib/util/search.js
+++ b/lib/util/search.js
@@ -9,6 +9,8 @@ function SearchClient(crowi, esUri) {
   this.DEFAULT_OFFSET = 0;
   this.DEFAULT_LIMIT = 50;
 
+  this.FIELD_TYPE_NAME_THRESHOLD_VERSION = 5;
+
   this.esUri = esUri;
   this.crowi = crowi;
 
@@ -19,11 +21,44 @@ function SearchClient(crowi, esUri) {
   this.client = new elasticsearch.Client({
     host: this.host,
     requestTimeout: 5000,
+    //log: 'trace',
   });
 
   this.registerUpdateEvent();
-
   this.mappingFile = crowi.resourceDir + 'search/mappings.json';
+
+  this.serverInfo = {};
+  this.serverVersion = {};
+  Promise
+    .resolve(this.client.info())
+    .then((info) => {
+      debug(info);
+      this.serverInfo = info;
+      this.serverVersion = parseVersion(info);
+    })
+    .catch((err) => {
+    });
+}
+
+function parseVersion(info) {
+  var version = info.version.number; // TODO: check exists
+  if (version.match(/^(\d+)\.(\d+)\.(\d+)$/)) {
+    return {
+      major: RegExp.$1,
+      minor: RegExp.$2,
+      build: RegExp.$3,
+    };
+  }
+
+  return {
+    major: 0,
+    minor: 0,
+    build: 0,
+  };
+}
+
+SearchClient.prototype.isMajorVersionGreaterThanOrEqual = function(number) {
+  return this.serverVersion.major >= number;
 }
 
 SearchClient.prototype.checkESVersion = function() {
@@ -286,11 +321,11 @@ SearchClient.prototype.createSearchQuerySortedByUpdatedAt = function(option)
     index: this.index_name,
     type: 'pages',
     body: {
-      fields: fields,
       sort: [{ updated_at: { order: 'desc'}}],
       query: {}, // query
     }
   };
+  this.appendFields(fields);
   this.appendResultSize(query);
 
   return query;
@@ -308,15 +343,24 @@ SearchClient.prototype.createSearchQuerySortedByScore = function(option)
     index: this.index_name,
     type: 'pages',
     body: {
-      fields: fields,
       sort: [ {_score: { order: 'desc'} }],
       query: {}, // query
     }
   };
+  this.appendFields(query, fields);
   this.appendResultSize(query);
 
   return query;
 };
+
+SearchClient.prototype.appendFields = function(query, fields)
+{
+  if (this.isMajorVersionGreaterThanOrEqual(this.FIELD_TYPE_NAME_THRESHOLD_VERSION)) {
+    query.stored_fields = fields;
+  } else {
+    query.fields = fields;
+  }
+}
 
 SearchClient.prototype.appendResultSize = function(query, from, size)
 {

--- a/lib/util/search.js
+++ b/lib/util/search.js
@@ -3,7 +3,8 @@
  */
 
 var elasticsearch = require('elasticsearch'),
-  debug = require('debug')('crowi:lib:search');
+  debug = require('debug')('crowi:lib:search'),
+  versionParser = require('./versionParser')();
 
 function SearchClient(crowi, esUri) {
   this.DEFAULT_OFFSET = 0;
@@ -23,33 +24,53 @@ function SearchClient(crowi, esUri) {
   });
 
   this.registerUpdateEvent();
+
   this.mappingFile = crowi.resourceDir + 'search/mappings.json';
 
   this.serverInfo = {};
-
-  Promise
-    .resolve(this.client.info())
-    .then((info) => {
-      this.serverInfo = info;
-    })
-    .catch((err) => {
-      throw new Error();
-    });
 }
 
-SearchClient.prototype.isSupportedESVersion = function() {
-  var crowiVersion = this.crowi.getParsedVersion();
-  var ESVersion    = this.crowi.getParsedVersion(this.serverInfo.version.number);
+SearchClient.prototype.detectServerVersion = function() {
+  return this.client.info()
+    .then((info) => {
+      this.serverInfo = info;
+      return this.serverInfo.version.number;
+    });
+};
 
-  if (crowiVersion.major === 1 && crowiVersion.minor >= 6) {
-    if (ESVersion.major >= 5) {
-      return true;
-    }
+SearchClient.prototype.getServerVersion = function() {
+  if ('version' in this.serverInfo && 'number' in this.serverInfo.version) {
+    return this.serverInfo.version.number;
   }
 
-  console.log('WARNING: Detect unsupported Elasticsearch version: ' + this.serverInfo.version.number);
+  return null;
+};
 
-  return false;
+SearchClient.prototype.isSupportedESVersion = function() {
+  var self = this;
+
+  return Promise.resolve()
+    .then(() => {
+      if (self.getServerVersion() !== null) {
+        return self.getServerVersion();
+      } else {
+        return self.detectServerVersion();
+      }
+    })
+    .then((serverVersion) => {
+      var ESVersion = versionParser.parse(serverVersion);
+      var crowiVersion = versionParser.parse(self.crowi.version);
+
+      // Crowi 1.6.x requires ES 5.x
+      if (crowiVersion.major === 1 && crowiVersion.minor >= 6) {
+        if (ESVersion.major >= 5) {
+          return true;
+        }
+      }
+
+      return false;
+    })
+  ;
 }
 
 SearchClient.prototype.registerUpdateEvent = function() {

--- a/lib/util/versionParser.js
+++ b/lib/util/versionParser.js
@@ -1,0 +1,23 @@
+module.exports = function() {
+  var versionParser = {};
+
+  versionParser.parse = function(version) {
+    var major = 0;
+    var minor = 0;
+    var revision = 0;
+
+    if (version.match(/^(\d+)\.(\d+)\.(\d+)$/)) {
+      major    = +(RegExp.$1);
+      minor    = +(RegExp.$2);
+      revision = +(RegExp.$3);
+    }
+
+    return {
+      major: major,
+      minor: minor,
+      revision: revision,
+    };
+  };
+
+  return versionParser;
+}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "debug": "~2.2.0",
     "del": "~2.2.0",
     "diff": "~2.2.2",
-    "elasticsearch": "~11.0.1",
+    "elasticsearch": "~12.1.3",
     "emojify.js": "^1.1.0",
     "errorhandler": "~1.3.4",
     "express": "~4.13.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowi",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "The simple & powerful Wiki",
   "tags": [
     "wiki",

--- a/resource/search/mappings.json
+++ b/resource/search/mappings.json
@@ -47,7 +47,7 @@
     "pages": {
       "properties" : {
         "path": {
-          "type" : "multi_field",
+          "type" : "string",
           "fields" : {
             "raw": {"type" : "string", "index" : "not_analyzed"},
             "ja": {"type" : "string", "analyzer" : "kuromoji"},
@@ -55,7 +55,7 @@
           }
         },
         "body": {
-          "type" : "multi_field",
+          "type" : "string",
           "fields" : {
             "ja": {"type" : "string", "analyzer" : "kuromoji"},
             "en": {"type" : "string", "analyzer" : "english"}


### PR DESCRIPTION
## Overview

- Crowi can not work Elasticsearch 5.x

## Include this pull-request

- Bump up version
    - **v1.6.0**
- Upgrade dependency
    - elasticsearch.js: `11.x` to `12.x`
- Modified old-style mappings
    - `"type" : "multi_field"` is deprecated.
        - https://www.elastic.co/guide/en/elasticsearch/reference/1.4/_multi_fields.html
    - use `string` instead of `multi_field`
        - http://stackoverflow.com/questions/40301061/elasticsearch-5-mapperparserexception-with-multi-field
- Modified query field name
    - use `stored_fields` in Elasticsearch 5.x
        - ~~When ES 2.x, use `fields`. Because ES 2.x does not support `stored_fields`~~
    - I got error messages like this:
```json
{
  "error": {
    "root_cause": [
      {
        "type": "parsing_exception",
        "reason": "The field [fields] is no longer supported, please use [stored_fields] to retrieve stored fields or _source filtering if the field is not stored",
        "line": 1,
        "col": 11
      }
    ],
    "type": "parsing_exception",
    "reason": "The field [fields] is no longer supported, please use [stored_fields] to retrieve stored fields or _source filtering if the field is not stored",
    "line": 1,
    "col": 11
  },
  "status": 400
}
```

## IMPORTANT NOTICE

* Elasticsearch 2.x does **NOT** work on Crowi 1.6.0+
