### PR TITLE
Fixed toc outline breaks

### DIFF
--- a/resource/css/_wiki.scss
+++ b/resource/css/_wiki.scss
@@ -8,6 +8,7 @@ div.body {
   border: solid 1px #aaa;
   border-radius: 5px;
   max-width: 250px;
+  overflow: hidden;
 
   .revision-toc-head {
     display: inline-block;


### PR DESCRIPTION
Fixed that the outline of TOC was breaks.

before:
![before](https://cloud.githubusercontent.com/assets/74355/21566175/ad18c87c-cee3-11e6-8c04-178e449b6a4c.png)
after:
![after](https://cloud.githubusercontent.com/assets/74355/21566174/ad13450a-cee3-11e6-8912-5f48fe11e882.png)
