### PR TITLE
Support search operators (minus and phrase)

### DIFF
--- a/lib/util/search.js
+++ b/lib/util/search.js
@@ -373,21 +373,67 @@ SearchClient.prototype.appendCriteriaForKeywordContains = function(query, keywor
   if (!query.body.query.bool) {
     query.body.query.bool = {};
   }
-
   if (!query.body.query.bool.must || !Array.isArray(query.body.query.must)) {
     query.body.query.bool.must = [];
   }
+  if (!query.body.query.bool.must_not || !Array.isArray(query.body.query.must_not)) {
+    query.body.query.bool.must_not = [];
+  }
 
-  query.body.query.bool.must.push({
-    multi_match: {
-      query: keyword,
-      fields: [
-        "path.ja^2", // ためしに。
-        "body.ja"
-      ],
-      operator: "and"
+  var appendMultiMatchQuery = function(query, type, keywords) {
+    var target;
+    switch (type) {
+      case 'not_match':
+        target = query.body.query.bool.must_not;
+        break;
+      case 'match':
+      default:
+        target = query.body.query.bool.must;
     }
-  });
+
+    target.push({
+      multi_match: {
+        query: keywords.join(' '),
+        fields: [
+          "path.ja^2", // ためしに。
+          "body.ja"
+        ],
+        operator: "and"
+      }
+    });
+
+    return query;
+  };
+
+  var parsedKeywords = this.getParsedKeywords(keyword);
+
+  if (parsedKeywords.match.length > 0) {
+    query = appendMultiMatchQuery(query, 'match', parsedKeywords.match);
+  }
+
+  if (parsedKeywords.not_match.length > 0) {
+    query = appendMultiMatchQuery(query, 'not_match', parsedKeywords.not_match);
+  }
+
+  if (parsedKeywords.phrase.length > 0) {
+    var phraseQueries = [];
+    parsedKeywords.phrase.forEach(function(phrase) {
+      phraseQueries.push({
+        multi_match: {
+          query: phrase, // each phrase is quoteted words
+          type: 'phrase',
+          fields: [ // Not use "*.ja" fields here, because we want to analyze (parse) search words
+            "path^2",
+            "body"
+          ],
+        }
+      });
+    });
+
+    // minus + phrase (ex. -"foo bar" ) is not support yet.
+
+    query.body.query.bool.must.push(phraseQueries);
+  }
 };
 
 SearchClient.prototype.appendCriteriaForPathFilter = function(query, path)
@@ -438,6 +484,47 @@ SearchClient.prototype.searchKeywordUnderPath = function(keyword, path, option)
 
   return this.search(query);
 };
+
+SearchClient.prototype.getParsedKeywords = function(keyword)
+{
+  var matchWords = [];
+  var notMatchWords = [];
+  var phraseWords = [];
+
+  keyword.trim();
+  keyword = keyword.replace(/\s+/g, ' ');
+
+  // First: Parse phrase keywords
+  var phraseRegExp = new RegExp(/("[^"]+")/g);
+  var phrases = keyword.match(phraseRegExp);
+  if (phrases !== null) {
+    keyword = keyword.replace(phraseRegExp, '');
+
+    phrases.forEach(function(phrase) {
+      phrase.trim();
+      phraseWords.push(phrase);
+    });
+  }
+
+  // Second: Parse other keywords (include minus keywords)
+  keyword.split(' ').forEach(function(word) {
+    if (word === '') {
+      return;
+    }
+
+    if (word.match(/^\-(.+)$/)) {
+      notMatchWords.push((RegExp.$1));
+    } else {
+      matchWords.push(word);
+    }
+  });
+
+  return {
+    match: matchWords,
+    not_match: notMatchWords,
+    phrase: phraseWords,
+  };
+}
 
 SearchClient.prototype.syncPageCreated = function(page, user)
 {

--- a/resource/js/components/SearchPage/SearchResultList.js
+++ b/resource/js/components/SearchPage/SearchResultList.js
@@ -17,7 +17,9 @@ export default class SearchResultList extends React.Component {
       if (keyword === '') {
         return;
       }
-      const k = keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const k = keyword
+            .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+            .replace(/(^"|"$)/g, ''); // for phrase (quoted) keyword
       const keywordExp = new RegExp(`(${k}(?!(.*?\]|.*?\\)|.*?"|.*?>)))`, 'ig');
       returnBody = returnBody.replace(keywordExp, '<em class="highlighted">$&</em>');
     });
@@ -56,4 +58,3 @@ SearchResultList.defaultProps = {
   pages: [],
   searchingKeyword: '',
 };
-

--- a/resource/js/components/SearchPage/SearchResultList.js
+++ b/resource/js/components/SearchPage/SearchResultList.js
@@ -14,6 +14,9 @@ export default class SearchResultList extends React.Component {
     let returnBody = body;
 
     this.props.searchingKeyword.split(' ').forEach((keyword) => {
+      if (keyword === '') {
+        return;
+      }
       const k = keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const keywordExp = new RegExp(`(${k}(?!(.*?\]|.*?\\)|.*?"|.*?>)))`, 'ig');
       returnBody = returnBody.replace(keywordExp, '<em class="highlighted">$&</em>');


### PR DESCRIPTION
## Overview

- Google search operators:
    - https://support.google.com/websearch/answer/2466433
- This pull request support "minus" and "phrase" search symbols
- The target of this p-r is `feature-support-es5` (https://github.com/crowi/crowi/pull/150)

## Features

### Minus

Use `-` before search keyword

- ex:
    - `aaa -ccc`

### Phrase

Quote search words using `"` 

- ex:
    - `"東京空港"`

## Screenshot

### Minus

| before | after |
|-------|-------|
| search: aaa | search: aaa -ccc |
| ![2017-01-08 14 21 57](https://cloud.githubusercontent.com/assets/10488/21747579/eae24252-d5ad-11e6-9060-64c1fa4401c1.png) | ![2017-01-08 14 22 03](https://cloud.githubusercontent.com/assets/10488/21747581/f63bc876-d5ad-11e6-8f74-5912ec563b3d.png) |


### Phrase

| before | after |
|--------|------|
| search: 東京空港 | search: "東京空港" |
| ![2017-01-08 14 25 06](https://cloud.githubusercontent.com/assets/10488/21747587/4aad134c-d5ae-11e6-9987-83ec6ac91dcf.png) | ![2017-01-08 14 25 12](https://cloud.githubusercontent.com/assets/10488/21747589/586e75fc-d5ae-11e6-9e4b-b90fe24918ff.png) |

