### PR TITLE
NOT allow to use double slash (`//`) in page path

### DIFF
--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -383,7 +383,7 @@ module.exports = function(crowi) {
       /^\/_r\/.*/,
       /^\/user\/[^\/]+\/(bookmarks|comments|activities|pages|recent-create|recent-edit)/, // reserved
       /^\/?https?:\/\/.+$/, // avoid miss in renaming
-      /.*\/\/.*/,           // avoid miss in renaming
+      /\/{2,}/,             // avoid miss in renaming
       /.+\/edit$/,
       /.+\.md$/,
       /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments)(\/.*|$)/,

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -383,6 +383,7 @@ module.exports = function(crowi) {
       /^\/_r\/.*/,
       /^\/user\/[^\/]+\/(bookmarks|comments|activities|pages|recent-create|recent-edit)/, // reserved
       /^\/?https?:\/\/.+$/, // avoid miss in renaming
+      /.*\/\/.*/,           // avoid miss in renaming
       /.+\/edit$/,
       /.+\.md$/,
       /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments)(\/.*|$)/,


### PR DESCRIPTION
## Overview

- Now, Crowi not allow to use double slash (`//`) in path.

## Cause

- When Crowi's path has a double slash and nginx's `merge_slashes` is on.
    - User request "double slash path" to nginx.
    - Nginx request "single slash path" to Crowi.
    - Crowi search page by "single slash path" in DB, but not found.


## References

- [merge_slashes](http://nginx.org/en/docs/http/ngx_http_core_module.html#merge_slashes)
- [nginx はデフォルトで merge slash する](http://r-kurain.hatenablog.com/entry/20120504/1336117840)
