### PR TITLE
Separate blocks with newline characters in revision history

### DIFF
--- a/resource/js/crowi.js
+++ b/resource/js/crowi.js
@@ -756,7 +756,7 @@ $(function() {
 
           $diffDisplay.text('');
 
-          var diff = jsdiff.diffLines(previousText, currentText);
+          var diff = jsdiff.diffLines(previousText, currentText, {'newlineIsToken': true});
           diff.forEach(function(part) {
             var color = part.added ? 'green' : part.removed ? 'red' : 'grey';
             var $span = $('<span>');


### PR DESCRIPTION
Add `newlineIsToken` option to diffLines method

see https://github.com/kpdecker/jsdiff#api

>* `JsDiff.diffLines(oldStr, newStr[, options])` - diffs two blocks of text, comparing line by line.
    Options
>    * `ignoreWhitespace`: `true` to ignore leading and trailing whitespace. This is the same as `diffTrimmedLines`
>    * `newlineIsToken`: `true` to treat newline characters as separate tokens.  This allows for changes to the newline structure to occur independently of the line content and to be treated as such. In general this is the more human friendly form of `diffLines` and `diffLines` is better suited for patches and other computer friendly output.

demo: 

before

![2017-01-27 18 32 18](https://cloud.githubusercontent.com/assets/4442708/22366267/17d9a712-e4bf-11e6-9034-9ddb76195343.png)

after

![2017-01-27 18 31 41](https://cloud.githubusercontent.com/assets/4442708/22366277/21d3f970-e4bf-11e6-80cc-581713839d30.png)
