### PR TITLE
Fixed "Error: Can not find module 'bluebird'"

### DIFF
--- a/local_modules/crowi-fileupload-local/index.js
+++ b/local_modules/crowi-fileupload-local/index.js
@@ -7,7 +7,6 @@ module.exports = function(crowi) {
     , fs = require('fs')
     , path = require('path')
     , mkdir = require('mkdirp')
-    , Promise = require('bluebird')
     , Config = crowi.model('Config')
     , config = crowi.getConfig()
     , lib = {}


### PR DESCRIPTION
Fixed that "Error: Can not find module 'bluebird'" occurs at startup when setting file upload locally.