### PR TITLE
Fix "can not read property" error on search page

### DIFF
--- a/resource/js/app.js
+++ b/resource/js/app.js
@@ -16,7 +16,10 @@ if (!window) {
 }
 
 const mainContent = document.querySelector('#content-main');
-const pageId = mainContent.attributes['data-page-id'].value || null;
+let pageId = null;
+if (mainContent !== null) {
+  pageId = mainContent.attributes['data-page-id'].value;
+}
 
 // FIXME
 const crowi = new Crowi({me: $('#content-main').data('current-username')}, window);


### PR DESCRIPTION
## Overview

- The error of "Cannot read property" appeared on search page.
- The target of pull request is https://github.com/crowi/crowi/pull/175

## Screenshot

![2017-02-12 12 26 21](https://cloud.githubusercontent.com/assets/10488/22859445/1eddde7c-f11f-11e6-8848-2fb961ca861d.png)

