### PR TITLE
Support search operators (minus and phrase) with ES v2.x and v5.x

### DIFF
--- a/lib/util/search.js
+++ b/lib/util/search.js
@@ -331,24 +331,70 @@ SearchClient.prototype.appendCriteriaForKeywordContains = function(query, keywor
   if (!query.body.query.bool) {
     query.body.query.bool = {};
   }
-
   if (!query.body.query.bool.must || !Array.isArray(query.body.query.must)) {
     query.body.query.bool.must = [];
   }
+  if (!query.body.query.bool.must_not || !Array.isArray(query.body.query.must_not)) {
+    query.body.query.bool.must_not = [];
+  }
 
-  query.body.query.bool.must.push({
-    multi_match: {
-      query: keyword,
-      // TODO: By user's i18n setting, change boost or search target fields
-      fields: [
-        "path_ja^2",
-        "body_ja",
-        // "path_en",
-        // "body_en",
-      ],
-      operator: "and"
+  var appendMultiMatchQuery = function(query, type, keywords) {
+    var target;
+    switch (type) {
+      case 'not_match':
+        target = query.body.query.bool.must_not;
+        break;
+      case 'match':
+      default:
+        target = query.body.query.bool.must;
     }
-  });
+
+    target.push({
+      multi_match: {
+        query: keywords.join(' '),
+        // TODO: By user's i18n setting, change boost or search target fields
+        fields: [
+          "path_ja^2",
+          "body_ja",
+          // "path_en",
+          // "body_en",
+        ],
+        operator: "and"
+      }
+    });
+
+    return query;
+  };
+
+  var parsedKeywords = this.getParsedKeywords(keyword);
+
+  if (parsedKeywords.match.length > 0) {
+    query = appendMultiMatchQuery(query, 'match', parsedKeywords.match);
+  }
+
+  if (parsedKeywords.not_match.length > 0) {
+    query = appendMultiMatchQuery(query, 'not_match', parsedKeywords.not_match);
+  }
+
+  if (parsedKeywords.phrase.length > 0) {
+    var phraseQueries = [];
+    parsedKeywords.phrase.forEach(function(phrase) {
+      phraseQueries.push({
+        multi_match: {
+          query: phrase, // each phrase is quoteted words
+          type: 'phrase',
+          fields: [ // Not use "*.ja" fields here, because we want to analyze (parse) search words
+            "path^2",
+            "body"
+          ],
+        }
+      });
+    });
+
+    // minus + phrase (ex. -"foo bar" ) is not support yet.
+
+    query.body.query.bool.must.push(phraseQueries);
+  }
 };
 
 SearchClient.prototype.appendCriteriaForPathFilter = function(query, path)
@@ -399,6 +445,47 @@ SearchClient.prototype.searchKeywordUnderPath = function(keyword, path, option)
 
   return this.search(query);
 };
+
+SearchClient.prototype.getParsedKeywords = function(keyword)
+{
+  var matchWords = [];
+  var notMatchWords = [];
+  var phraseWords = [];
+
+  keyword.trim();
+  keyword = keyword.replace(/\s+/g, ' ');
+
+  // First: Parse phrase keywords
+  var phraseRegExp = new RegExp(/("[^"]+")/g);
+  var phrases = keyword.match(phraseRegExp);
+  if (phrases !== null) {
+    keyword = keyword.replace(phraseRegExp, '');
+
+    phrases.forEach(function(phrase) {
+      phrase.trim();
+      phraseWords.push(phrase);
+    });
+  }
+
+  // Second: Parse other keywords (include minus keywords)
+  keyword.split(' ').forEach(function(word) {
+    if (word === '') {
+      return;
+    }
+
+    if (word.match(/^\-(.+)$/)) {
+      notMatchWords.push((RegExp.$1));
+    } else {
+      matchWords.push(word);
+    }
+  });
+
+  return {
+    match: matchWords,
+    not_match: notMatchWords,
+    phrase: phraseWords,
+  };
+}
 
 SearchClient.prototype.syncPageCreated = function(page, user)
 {

--- a/lib/util/search.js
+++ b/lib/util/search.js
@@ -384,8 +384,8 @@ SearchClient.prototype.appendCriteriaForKeywordContains = function(query, keywor
           query: phrase, // each phrase is quoteted words
           type: 'phrase',
           fields: [ // Not use "*.ja" fields here, because we want to analyze (parse) search words
-            "path^2",
-            "body"
+            "path_raw^2",
+            "body_raw",
           ],
         }
       });

--- a/lib/util/search.js
+++ b/lib/util/search.js
@@ -393,9 +393,25 @@ SearchClient.prototype.appendCriteriaForKeywordContains = function(query, keywor
       });
     });
 
-    // minus + phrase (ex. -"foo bar" ) is not support yet.
-
     query.body.query.bool.must.push(phraseQueries);
+  }
+
+  if (parsedKeywords.not_phrase.length > 0) {
+    var notPhraseQueries = [];
+    parsedKeywords.not_phrase.forEach(function(phrase) {
+      notPhraseQueries.push({
+        multi_match: {
+          query: phrase, // each phrase is quoteted words
+          type: 'phrase',
+          fields: [ // Not use "*.ja" fields here, because we want to analyze (parse) search words
+            "path_raw^2",
+            "body_raw",
+          ],
+        }
+      });
+    });
+
+    query.body.query.bool.must_not.push(notPhraseQueries);
   }
 };
 
@@ -453,19 +469,25 @@ SearchClient.prototype.getParsedKeywords = function(keyword)
   var matchWords = [];
   var notMatchWords = [];
   var phraseWords = [];
+  var notPhraseWords = [];
 
   keyword.trim();
   keyword = keyword.replace(/\s+/g, ' ');
 
   // First: Parse phrase keywords
-  var phraseRegExp = new RegExp(/("[^"]+")/g);
+  var phraseRegExp = new RegExp(/(-?"[^"]+")/g);
   var phrases = keyword.match(phraseRegExp);
+
   if (phrases !== null) {
     keyword = keyword.replace(phraseRegExp, '');
 
     phrases.forEach(function(phrase) {
       phrase.trim();
-      phraseWords.push(phrase);
+      if (phrase.match(/^\-/)) {
+        notPhraseWords.push(phrase.replace(/^\-/, ''));
+      } else {
+        phraseWords.push(phrase);
+      }
     });
   }
 
@@ -486,6 +508,7 @@ SearchClient.prototype.getParsedKeywords = function(keyword)
     match: matchWords,
     not_match: notMatchWords,
     phrase: phraseWords,
+    not_phrase: notPhraseWords,
   };
 }
 

--- a/lib/util/search.js
+++ b/lib/util/search.js
@@ -340,9 +340,11 @@ SearchClient.prototype.appendCriteriaForKeywordContains = function(query, keywor
 
   var appendMultiMatchQuery = function(query, type, keywords) {
     var target;
+    var operator = 'and';
     switch (type) {
       case 'not_match':
         target = query.body.query.bool.must_not;
+        operator = 'or';
         break;
       case 'match':
       default:
@@ -359,7 +361,7 @@ SearchClient.prototype.appendCriteriaForKeywordContains = function(query, keywor
           // "path_en",
           // "body_en",
         ],
-        operator: "and"
+        operator: operator,
       }
     });
 

--- a/resource/js/components/SearchPage/SearchResultList.js
+++ b/resource/js/components/SearchPage/SearchResultList.js
@@ -17,7 +17,9 @@ export default class SearchResultList extends React.Component {
       if (keyword === '') {
         return;
       }
-      const k = keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const k = keyword
+            .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+            .replace(/(^"|"$)/g, ''); // for phrase (quoted) keyword
       const keywordExp = new RegExp(`(${k}(?!(.*?\]|.*?\\)|.*?"|.*?>)))`, 'ig');
       returnBody = returnBody.replace(keywordExp, '<em class="highlighted">$&</em>');
     });
@@ -56,4 +58,3 @@ SearchResultList.defaultProps = {
   pages: [],
   searchingKeyword: '',
 };
-

--- a/resource/js/components/SearchPage/SearchResultList.js
+++ b/resource/js/components/SearchPage/SearchResultList.js
@@ -14,6 +14,9 @@ export default class SearchResultList extends React.Component {
     let returnBody = body;
 
     this.props.searchingKeyword.split(' ').forEach((keyword) => {
+      if (keyword === '') {
+        return;
+      }
       const k = keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const keywordExp = new RegExp(`(${k}(?!(.*?\]|.*?\\)|.*?"|.*?>)))`, 'ig');
       returnBody = returnBody.replace(keywordExp, '<em class="highlighted">$&</em>');

--- a/resource/search/mappings.json
+++ b/resource/search/mappings.json
@@ -49,9 +49,14 @@
       "properties" : {
         "path": {
           "type": "string",
-          "copy_to": ["path_ja", "path_en"],
+          "copy_to": ["path_raw", "path_ja", "path_en"],
           "include_in_all": false,
           "index": "not_analyzed"
+        },
+        "path_raw": {
+          "type": "string",
+          "analyzer": "standard",
+          "include_in_all": false
         },
         "path_ja": {
           "type": "string",
@@ -65,9 +70,14 @@
         },
         "body": {
           "type": "string",
-          "copy_to": ["body_ja", "body_en"],
+          "copy_to": ["body_raw", "body_ja", "body_en"],
           "include_in_all": false,
           "index": "not_analyzed"
+        },
+        "body_raw": {
+          "type": "string",
+          "analyzer": "standard",
+          "include_in_all": false
         },
         "body_ja": {
           "type": "string",


### PR DESCRIPTION
## Overview

- Google search operators:
    - https://support.google.com/websearch/answer/2466433
- This pull request support "minus" and "phrase" search symbols
- The target of this p-r is https://github.com/crowi/crowi/pull/181

## Features

### Minus

Use `-` before search keyword

- ex:
    - `aaa -ccc`

### Phrase

Quote search words using `"` 

- ex:
    - `"東京空港"`

## Related

- https://github.com/crowi/crowi/pull/156