### PR TITLE
Fixed creating activity by "like" action

### DIFF
--- a/lib/models/activity.js
+++ b/lib/models/activity.js
@@ -89,7 +89,7 @@ module.exports = function(crowi) {
    */
   activitySchema.statics.createByPageLike = function(page, user) {
     let parameters = {
-      user: user,
+      user: user._id,
       targetModel: ActivityDefine.MODEL_PAGE,
       target: page,
       action: ActivityDefine.ACTION_LIKE,


### PR DESCRIPTION
## Overview

- If `user` was an object, this comparison did not work:
    - https://github.com/crowi/crowi/blob/4500f9acd81a6a764586a9074f863c59ac8d1362/lib/models/activity.js#L209