### PR TITLE
Change the response of attachments.add endpoint

### DIFF
--- a/lib/routes/attachment.js
+++ b/lib/routes/attachment.js
@@ -108,11 +108,11 @@ module.exports = function(crowi, app) {
           // TODO size
           return Attachment.create(id, req.user, filePath, originalName, fileName, fileType, fileSize);
         }).then(function(data) {
-          var imageUrl = fileUploader.generateUrl(data.filePath);
+          var attachment = data.toObject();
+          attachment["url"] = fileUploader.generateUrl(data.filePath);
           var result = {
             page: page.toObject(),
-            attachment: data.toObject(),
-            filename: imageUrl,
+            attachment: attachment,
             pageCreated: pageCreated,
           };
 


### PR DESCRIPTION
Thanks! Please feel free to close this P-R if you don't like this changes.

- Put "filename" field inside "attachment"
- Change key name "filename" to "url"

e.g.

```console
$ curl -XPOST 'localhost:3000/_api/attachments.add' \
    -F 'access_token=foo' \
    -F 'page_id=58aeb24fddccc34b78480e63' \
    -F 'file=@a.png;type=image/png'
```
```json
    ...

  "attachment": {
    "__v": 0,
    "fileFormat": "image/png",
    "fileName": "4af09af67e0ec873854fa81be5ba00b4.png",
    "originalName": "a.png",
    "filePath": "attachment/58aeb24fddccc34b78480e63/cd0ee67e063633930ad154dcea56eaf5.png",
    "creator": "58a5deb70cd01346dd6a1264",
    "page": "58aeb24fddccc34b78480e63",
    "_id": "58aeb52172576cf68d791658",
    "createdAt": "2017-02-23T10:10:41.436Z",
    "fileSize": 85250,
    "url": "/uploads/attachment/58aeb24fddccc34b78480e63/cd0ee67e063633930ad154dcea56eaf5.png"
  },
  "pageCreated": false,
  "ok": true
}
```
