### PR TITLE
Add plugins mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ More info are [here](https://github.com/crowi/crowi/wiki/Install-and-Configurati
 
 Don't use `master` branch because it is unstable but use released tag version expect when you want to contribute the project.
 
+Install Plugins
+----------------
+
+Install plugins from github:
+
+    $ npm run install-plugin https://github.com/sopmeone/crowi-plugin-something.git
+
+Build plugins:
+
+    $ npm run webpack:plugin
+    
+### CAUTION
+
+Plugins are DISABLED in default settings.  
+Change it on admin page.
 
 Dependencies
 -------------

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Install plugins from github:
 
     $ npm run install-plugin https://github.com/sopmeone/crowi-plugin-something.git
 
+Modify `plugin/plugin.js`:
+
+    const plugins = [
+      require('crowi-plugin-something')
+    ]
+
 Build plugins:
 
     $ npm run webpack:plugin

--- a/README.md
+++ b/README.md
@@ -31,22 +31,6 @@ More info are [here](https://github.com/crowi/crowi/wiki/Install-and-Configurati
 
 Don't use `master` branch because it is unstable but use released tag version expect when you want to contribute the project.
 
-Install Plugins
-----------------
-
-Install plugins from github:
-
-    $ npm run install-plugin https://github.com/sopmeone/crowi-plugin-something.git
-
-Build plugins:
-
-    $ npm run webpack:plugin
-    
-### CAUTION
-
-Plugins are DISABLED in default settings.  
-Change it on admin page.
-
 Dependencies
 -------------
 
@@ -80,6 +64,23 @@ $ PASSWORD_SEED=somesecretstring MONGO_URI=mongodb://username:password@localhost
 * `SECRET_TOKEN`: A secret key for verifying the integrity of signed cookies.
 * `FILE_UPLOAD`: `aws` (default), `local`, `none`
 
+(Opt.) Install Plugins
+-----------------------
+
+Install plugins from github:
+
+    $ npm run install-plugin https://github.com/sopmeone/crowi-plugin-something.git
+
+Build plugins:
+
+    $ npm run webpack:plugin
+    
+After above process, rebooting Crowi is required.
+
+### CAUTION
+
+Plugins are DISABLED in default settings.  
+Change it on admin page.
 
 License
 ---------

--- a/lib/crowi/index.js
+++ b/lib/crowi/index.js
@@ -32,13 +32,9 @@ function Crowi (rootdir, env)
 
   this.assets    = {};
   try {
-    this.assets = require(this.publicDir + '/js/manifest.json') || {};
-    
-    var isEnablePlugin = true;  // TODO configurable
-    if (isEnablePlugin) {
-      var pluginAssets = require(this.publicDir + '/js/manifest-plugin.json') || {};
-      this.assets = Object.assign(this.assets, pluginAssets);
-    }
+    var assets = require(this.publicDir + '/js/manifest.json') || {};
+    var pluginAssets = require(this.publicDir + '/js/manifest-plugin.json') || {};
+    this.assets = Object.assign(assets, pluginAssets);
   } catch (e) {
     // ignore
   }
@@ -120,13 +116,9 @@ Crowi.prototype.getAssetList = function() {
 
   // reload manifest
   try {
-    this.assets = JSON.parse(fs.readFileSync(this.publicDir + '/js/manifest.json'))|| {};
-
-    var isEnablePlugin = true;  // TODO configurable
-    if (isEnablePlugin) {
-      var pluginAssets = require(this.publicDir + '/js/manifest-plugin.json') || {};
-      this.assets = Object.assign(this.assets, pluginAssets);
-    }
+    var assets = require(this.publicDir + '/js/manifest.json') || {};
+    var pluginAssets = require(this.publicDir + '/js/manifest-plugin.json') || {};
+    this.assets = Object.assign(assets, pluginAssets);
   } catch (e) {
     // ignore
     debug('Failed to reload assets on development', e);

--- a/lib/crowi/index.js
+++ b/lib/crowi/index.js
@@ -33,6 +33,12 @@ function Crowi (rootdir, env)
   this.assets    = {};
   try {
     this.assets = require(this.publicDir + '/js/manifest.json') || {};
+    
+    var isEnablePlugin = true;  // TODO configurable
+    if (isEnablePlugin) {
+      var pluginAssets = require(this.publicDir + '/js/manifest-plugin.json') || {};
+      this.assets = Object.assign(this.assets, pluginAssets);
+    }
   } catch (e) {
     // ignore
   }
@@ -115,6 +121,12 @@ Crowi.prototype.getAssetList = function() {
   // reload manifest
   try {
     this.assets = JSON.parse(fs.readFileSync(this.publicDir + '/js/manifest.json'))|| {};
+
+    var isEnablePlugin = true;  // TODO configurable
+    if (isEnablePlugin) {
+      var pluginAssets = require(this.publicDir + '/js/manifest-plugin.json') || {};
+      this.assets = Object.assign(this.assets, pluginAssets);
+    }
   } catch (e) {
     // ignore
     debug('Failed to reload assets on development', e);

--- a/lib/form/admin/plugin.js
+++ b/lib/form/admin/plugin.js
@@ -4,6 +4,6 @@ var form = require('express-form')
   , field = form.field;
 
 module.exports = form(
-  field('settingForm[plugin:isEnablePlugin]').trim().toBoolean()
+  field('settingForm[plugin:isEnabledPlugins]').trim().toBoolean()
 );
 

--- a/lib/form/admin/plugin.js
+++ b/lib/form/admin/plugin.js
@@ -4,6 +4,6 @@ var form = require('express-form')
   , field = form.field;
 
 module.exports = form(
-  field('settingForm[plugin:isEnabledPlugins]').trim().toBoolean()
+  field('settingForm[plugin:isEnabledPlugins]').trim().toBooleanStrict()
 );
 

--- a/lib/form/admin/plugin.js
+++ b/lib/form/admin/plugin.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var form = require('express-form')
+  , field = form.field;
+
+module.exports = form(
+  field('settingForm[plugin:isEnablePlugin]').trim().toBoolean()
+);
+

--- a/lib/form/index.js
+++ b/lib/form/index.js
@@ -14,6 +14,7 @@ exports.admin = {
   mail: require('./admin/mail'),
   aws: require('./admin/aws'),
   google: require('./admin/google'),
+  plugin: require('./admin/plugin'),
   userInvite: require('./admin/userInvite'),
   slackSetting: require('./admin/slackSetting'),
 };

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -62,7 +62,7 @@ module.exports = function(crowi) {
     var originalConfig = crowi.getConfig();
     var newNSConfig = originalConfig[ns] || {};
     Object.keys(config).forEach(function (key) {
-      if (config[key] || config[key] === '') {
+      if (config[key] || config[key] === '' || config[key] === false) {
         newNSConfig[key] = config[key];
       }
     });

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -42,6 +42,8 @@ module.exports = function(crowi) {
       'google:clientId'     : '',
       'google:clientSecret' : '',
 
+      'plugin:isEnabledPlugins' : false,
+
     };
   }
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -43,6 +43,7 @@ module.exports = function(crowi, app) {
   app.post('/_api/admin/settings/mail'  , loginRequired(crowi, app) , middleware.adminRequired() , csrf, form.admin.mail, admin.api.appSetting);
   app.post('/_api/admin/settings/aws'   , loginRequired(crowi, app) , middleware.adminRequired() , csrf, form.admin.aws, admin.api.appSetting);
   app.post('/_api/admin/settings/google', loginRequired(crowi, app) , middleware.adminRequired() , csrf, form.admin.google, admin.api.appSetting);
+  app.post('/_api/admin/settings/plugin', loginRequired(crowi, app) , middleware.adminRequired() , csrf, form.admin.plugin, admin.api.appSetting);
 
   // search admin
   app.get('/admin/search'              , loginRequired(crowi, app) , middleware.adminRequired() , admin.search.index);

--- a/lib/views/admin/app.html
+++ b/lib/views/admin/app.html
@@ -243,16 +243,16 @@
         <p class="well">プラグインの読み込みを有効にします。</p>
 
         <div class="form-group">
-          <label for="settingForm[plugin:isEnablePlugin]" class="col-xs-3 control-label">プラグインを読み込む</label>
+          <label for="settingForm[plugin:isEnabledPlugins]" class="col-xs-3 control-label">プラグインを読み込む</label>
           <div class="col-xs-6">
             <div class="btn-group btn-toggle" data-toggle="buttons">
-              <label class="btn {% if settingForm['plugin:isEnablePlugin'] %}btn-primary active{% else %}btn-default{% endif %}">
-                <input name="settingForm[plugin:isEnablePlugin]" value="true" type="radio"
-                    {% if 'true' == settingForm['plugin:isEnablePlugin'] %}checked{% endif %}> 有効
+              <label class="btn {% if settingForm['plugin:isEnabledPlugins'] %}btn-primary active{% else %}btn-default{% endif %}">
+                <input name="settingForm[plugin:isEnabledPlugins]" value="true" type="radio"
+                    {% if 'true' == settingForm['plugin:isEnabledPlugins'] %}checked{% endif %}> 有効
               </label>
-              <label class="btn {% if !settingForm['plugin:isEnablePlugin'] %}btn-primary active{% else %}btn-default{% endif %}">
-                <input name="settingForm[plugin:isEnablePlugin]" value="false" type="radio"
-                    {% if 'false' != settingForm['plugin:isEnablePlugin'] %}checked{% endif %}> 無効
+              <label class="btn {% if !settingForm['plugin:isEnabledPlugins'] %}btn-primary active{% else %}btn-default{% endif %}">
+                <input name="settingForm[plugin:isEnabledPlugins]" value="false" type="radio"
+                    {% if 'false' != settingForm['plugin:isEnabledPlugins'] %}checked{% endif %}> 無効
               </label>
             </div>
           </div>

--- a/lib/views/admin/app.html
+++ b/lib/views/admin/app.html
@@ -248,11 +248,11 @@
             <div class="btn-group btn-toggle" data-toggle="buttons">
               <label class="btn {% if settingForm['plugin:isEnabledPlugins'] %}btn-primary active{% else %}btn-default{% endif %}">
                 <input name="settingForm[plugin:isEnabledPlugins]" value="true" type="radio"
-                    {% if 'true' == settingForm['plugin:isEnabledPlugins'] %}checked{% endif %}> 有効
+                    {% if true === settingForm['plugin:isEnabledPlugins'] %}checked{% endif %}> 有効
               </label>
               <label class="btn {% if !settingForm['plugin:isEnabledPlugins'] %}btn-primary active{% else %}btn-default{% endif %}">
                 <input name="settingForm[plugin:isEnabledPlugins]" value="false" type="radio"
-                    {% if 'false' != settingForm['plugin:isEnabledPlugins'] %}checked{% endif %}> 無効
+                    {% if !settingForm['plugin:isEnabledPlugins'] %}checked{% endif %}> 無効
               </label>
             </div>
           </div>

--- a/lib/views/admin/app.html
+++ b/lib/views/admin/app.html
@@ -237,13 +237,44 @@
       </fieldset>
       </form>
 
+      <form action="/_api/admin/settings/plugin" method="post" class="form-horizontal" id="pluginSettingForm" role="form">
+      <fieldset>
+      <legend>プラグイン設定</legend>
+        <p class="well">プラグインの読み込みを有効にします。</p>
+
+        <div class="form-group">
+          <label for="settingForm[plugin:isEnablePlugin]" class="col-xs-3 control-label">プラグインを読み込む</label>
+          <div class="col-xs-6">
+            <div class="btn-group btn-toggle" data-toggle="buttons">
+              <label class="btn {% if settingForm['plugin:isEnablePlugin'] %}btn-primary active{% else %}btn-default{% endif %}">
+                <input name="settingForm[plugin:isEnablePlugin]" value="true" type="radio"
+                    {% if 'true' == settingForm['plugin:isEnablePlugin'] %}checked{% endif %}> 有効
+              </label>
+              <label class="btn {% if !settingForm['plugin:isEnablePlugin'] %}btn-primary active{% else %}btn-default{% endif %}">
+                <input name="settingForm[plugin:isEnablePlugin]" value="false" type="radio"
+                    {% if 'false' != settingForm['plugin:isEnablePlugin'] %}checked{% endif %}> 無効
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <div class="col-xs-offset-3 col-xs-6">
+            <input type="hidden" name="_csrf" value="{{ csrf() }}">
+            <button type="submit" class="btn btn-primary">更新</button>
+          </div>
+        </div>
+
+      </fieldset>
+      </form>
+
     </div>
   </div>
 
   <script>
     $(function()
     {
-      $('#appSettingForm, #secSettingForm, #mailSettingForm, #awsSettingForm, #googleSettingForm').each(function() {
+      $('#appSettingForm, #secSettingForm, #mailSettingForm, #awsSettingForm, #googleSettingForm, #pluginSettingForm').each(function() {
         $(this).submit(function()
         {
           function showMessage(formId, msg, status) {
@@ -291,6 +322,27 @@
         });
       });
 
+      // Bootstrap 3 Toggle Switch Snippet
+      // http://www.bootply.com/92189
+      $('.btn-toggle').click(function() {
+        $(this).find('.btn').toggleClass('active');  
+        
+        if ($(this).find('.btn-primary').size()>0) {
+          $(this).find('.btn').toggleClass('btn-primary');
+        }
+        if ($(this).find('.btn-danger').size()>0) {
+          $(this).find('.btn').toggleClass('btn-danger');
+        }
+        if ($(this).find('.btn-success').size()>0) {
+          $(this).find('.btn').toggleClass('btn-success');
+        }
+        if ($(this).find('.btn-info').size()>0) {
+          $(this).find('.btn').toggleClass('btn-info');
+        }
+        
+        $(this).find('.btn').toggleClass('btn-default');
+      });
+      
     });
   </script>
 

--- a/lib/views/layout/layout.html
+++ b/lib/views/layout/layout.html
@@ -22,6 +22,7 @@
 <body
   class="crowi main-container {% block html_base_css %}{% endblock %}"
   data-me="{{ user._id.toString() }}"
+  data-plugin-enabled="{{ config.crowi['plugin:isEnabledPlugins'] }}"
  {% block html_base_attr %}{% endblock %}
  >
 
@@ -131,7 +132,9 @@
 </body>
 {% endblock %}
 
+{% if config.crowi['plugin:isEnabledPlugins'] %}
 <script src="{{ assets('/js/plugin.js') }}"></script>
+{% endif %}
 <script src="{{ assets('/js/crowi.js') }}"></script>
 <script src="{{ assets('/js/app.js') }}"></script>
 </html>

--- a/lib/views/layout/layout.html
+++ b/lib/views/layout/layout.html
@@ -131,6 +131,7 @@
 </body>
 {% endblock %}
 
+<script src="{{ assets('/js/plugin.js') }}"></script>
 <script src="{{ assets('/js/crowi.js') }}"></script>
 <script src="{{ assets('/js/app.js') }}"></script>
 </html>

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "test": "gulp test",
     "build": "gulp",
     "webpack": "webpack",
+    "webpack:plugin": "webpack --config webpack.plugin.config.js",
     "postinstall": "gulp"
   },
   "env": {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "start": "node app.js",
     "test": "gulp test",
     "build": "gulp",
+    "install-plugin": "npm -prefix ./plugin install -- ",
     "webpack": "webpack",
     "webpack:plugin": "webpack --config webpack.plugin.config.js",
     "postinstall": "gulp"

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "crowi-plugin",
+  "version": "1.0.0",
+  "description": "",
+  "main": "plugin.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "MIT"
+}

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -1,0 +1,1 @@
+require('path');

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -1,10 +1,39 @@
+const plugins = [
+  // require('crowi-plugin-...')
+]
+
+// import all plugins
+var pluginMetaDatas = [];
+plugins.forEach((plugin) => {
+  pluginMetaDatas.push(plugin.meta);
+})
+
 export default class CrowiPlugin {
 
-  constructor() {
-  }
+  /**
+   * plug-in PreProcessors
+   * 
+   * @param {Crowi} crowi
+   * @param {CrowiRenderer} crowiRenderer
+   * 
+   * @memberof CrowiPlugin
+   */
+  pluginPreProcessors(crowi, crowiRenderer) {
+    var additionalPreProcessors = [];
 
-  getAllPreProcessors() {
-    return []
+    pluginMetaDatas.forEach((meta) => {
+      // v1
+      if (meta.pluginSchemaVersion === 1) {
+        meta.preProcessorFactories.forEach((f) => {
+          // instanciate PreProcessor
+          var preProcessor = f(crowi);
+          additionalPreProcessors.push(preProcessor);
+        })
+      }
+    });
+
+    crowiRenderer.preProcessors = crowiRenderer.preProcessors.concat(
+        crowiRenderer.preProcessors, additionalPreProcessors);
   }
 
 }

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -1,1 +1,12 @@
-require('path');
+export default class CrowiPlugin {
+
+  constructor() {
+  }
+
+  getAllPreProcessors() {
+    return []
+  }
+
+}
+
+window.crowiPlugin = new CrowiPlugin();     // FIXME

--- a/resource/js/app.js
+++ b/resource/js/app.js
@@ -21,6 +21,12 @@ crowi.fetchUsers();
 const crowiRenderer = new CrowiRenderer();
 window.crowiRenderer = crowiRenderer;
 
+var isEnablePlugin = true;  // TODO configurable
+if (isEnablePlugin) {
+  var crowiPlugin = window.crowiPlugin;   // FIXME
+  crowiPlugin.pluginPreProcessors(crowi, crowiRenderer);
+}
+  
 const componentMappings = {
   'search-top': <HeaderSearchBox />,
   'search-page': <SearchPage />,

--- a/resource/js/app.js
+++ b/resource/js/app.js
@@ -21,9 +21,10 @@ crowi.fetchUsers();
 const crowiRenderer = new CrowiRenderer();
 window.crowiRenderer = crowiRenderer;
 
-var isEnablePlugin = true;  // TODO configurable
-if (isEnablePlugin) {
-  var crowiPlugin = window.crowiPlugin;   // FIXME
+// FIXME
+var isEnabledPlugins = $('body').data('plugin-enabled');
+if (isEnabledPlugins) {
+  var crowiPlugin = window.crowiPlugin;
   crowiPlugin.pluginPreProcessors(crowi, crowiRenderer);
 }
   

--- a/resource/js/util/CrowiRenderer.js
+++ b/resource/js/util/CrowiRenderer.js
@@ -21,12 +21,6 @@ export default class CrowiRenderer {
       new Emoji(),
     ];
 
-    var isEnablePlugin = true;  // TODO configurable
-    if (isEnablePlugin) {
-      var crowiPlugin = window.crowiPlugin;
-      this.preProcessors = this.preProcessors.concat(crowiPlugin.getAllPreProcessors());
-    }
-
     this.langProcessors = {
       'tsv': new Tsv2Table(),
       'tsv-h': new Tsv2Table({header: true}),

--- a/resource/js/util/CrowiRenderer.js
+++ b/resource/js/util/CrowiRenderer.js
@@ -21,6 +21,12 @@ export default class CrowiRenderer {
       new Emoji(),
     ];
 
+    var isEnablePlugin = true;  // TODO configurable
+    if (isEnablePlugin) {
+      var crowiPlugin = window.crowiPlugin;
+      this.preProcessors = this.preProcessors.concat(crowiPlugin.getAllPreProcessors());
+    }
+
     this.langProcessors = {
       'tsv': new Tsv2Table(),
       'tsv-h': new Tsv2Table({header: true}),

--- a/webpack.plugin.config.js
+++ b/webpack.plugin.config.js
@@ -21,7 +21,6 @@ var config = {
       {
         test: /.jsx?$/,
         loader: 'babel-loader',
-        exclude: /node_modules/,
         query: {
           presets: ['es2015', 'react']
         }

--- a/webpack.plugin.config.js
+++ b/webpack.plugin.config.js
@@ -1,0 +1,53 @@
+var path = require('path');
+var webpack = require('webpack');
+
+var ManifestPlugin = require('webpack-manifest-plugin');
+
+var config = {
+  entry: {
+    plugin: './plugin/plugin.js',
+  },
+  output: {
+    path: path.join(__dirname + "/public/js"),
+    filename: "[name].[hash].js"
+  },
+  resolve: {
+    modulesDirectories: [
+      './node_modules', './plugin/node_modules',
+    ],
+  },
+  module: {
+    loaders: [
+      {
+        test: /.jsx?$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        query: {
+          presets: ['es2015', 'react']
+        }
+      }
+    ]
+  },
+  plugins: []
+};
+
+if (process.env && process.env.NODE_ENV !== 'development') {
+  config.plugins = [
+    new webpack.DefinePlugin({
+      'process.env':{
+        'NODE_ENV': JSON.stringify('production')
+      }
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+      compress:{
+        warnings: false
+      }
+    }),
+  ];
+}
+
+config.plugins.push(new ManifestPlugin({
+  fileName: 'manifest-plugin.json'
+}));
+
+module.exports = config;


### PR DESCRIPTION
Overview
----------

Add following features:

* Users will be able to install plugins from github
* Switchable whether enabled/disabled on admin page
    * Default is disabled and code size loaded by client(browser) does not increase at all.

Quick Start
------------

example plugin: https://github.com/yuki-takei/crowi-plugin-pukiwiki-like-linker.git

```bash
# install plugin
# see https://github.com/yuki-takei/crowi-plugin-pukiwiki-like-linker.git

# build /public/js/plugin.[hash].js
$ npm run webpack:plugin

> crowi@1.5.3 webpack:plugin /Projects/crowi
> webpack --config webpack.plugin.config.js

Hash: 5f221bd71feebd379477
Version: webpack 1.13.3
Time: 2302ms
                         Asset      Size  Chunks             Chunk Names
plugin.5f221bd71feebd379477.js   5.09 kB       0  [emitted]  plugin
          manifest-plugin.json  51 bytes          [emitted]

# boot
$ MONGO_URI=mongodb://localhost/crowi node app.js
```

`/public/js/plugin.[hash].js` is not included yet.
Enable at `http://localhost:3000/admin/app`.

![image](https://cloud.githubusercontent.com/assets/1638767/23336213/d19b694c-fc0c-11e6-9fe6-e5cde249c47b.png)



Processing Flow
-----------------

1. https://github.com/crowi/crowi/compare/master...yuki-takei:feature-plugin#diff-459c51e11dee6f33cb09b35e6d0f87c5R25
    * injects enable/disable flag to `data-plugin-enabled`
1. https://github.com/crowi/crowi/compare/master...yuki-takei:feature-plugin#diff-459c51e11dee6f33cb09b35e6d0f87c5R135
    * include `plugin.js` if plugin is enabled
1. https://github.com/crowi/crowi/compare/master...yuki-takei:feature-plugin#diff-8fb27e59a72903a664ed0201a2a05bf0R6
    1. require plugins
    1. store metadatas
    metadata is assumed to contain some factories).
    Though [crowi-plugin-pukiwiki-like-linker](https://github.com/yuki-takei/crowi-plugin-pukiwiki-like-linker) contains only one factory of PreProcessor (see [meta.js](https://github.com/yuki-takei/crowi-plugin-pukiwiki-like-linker/blob/master/meta.js), other plugins could contain multiple factories of any class.
1. https://github.com/crowi/crowi/compare/master...yuki-takei:feature-plugin#diff-39992ee08af86834f2b5095ded60c098R25
    * `crowiPlugin.pluginPreProcessors` called.
    * instanciate PreProcessors and append to `crowiRenderer.preProcessors`


In the future
-------------

### Other than PreProcessor

At the moment, this plugin mechanism can add only PreProcessors. I would like to create [lsx](http://ukiya.sakura.ne.jp/index.php?PukiWiki%2F1.4%2F%E3%83%9E%E3%83%8B%E3%83%A5%E3%82%A2%E3%83%AB%2F%E3%83%97%E3%83%A9%E3%82%B0%E3%82%A4%E3%83%B3%2F%E7%8B%AC%E8%87%AA%E3%81%AB%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%9F%E3%82%82%E3%81%AE%2Flsx) like plugin. It will require some change to the base part of crowi [in this way](https://github.com/crowi/crowi/compare/master...yuki-takei:feature-plugin#diff-39992ee08af86834f2b5095ded60c098R28).

### Compatibility

At the moment, metadata object of plugin is designed to have `pluginSchemaVersion` and is used at [here](https://github.com/crowi/crowi/compare/master...yuki-takei:feature-plugin#diff-8fb27e59a72903a664ed0201a2a05bf0R26). It will help us maintain compatibility even if we want to make a big change.

### Plaggable from admin page

* add npm packages from admin page
* add crowi-plugins from admin page
* add plugin snippets (metadata and some codes) from admin page
* kick webpack command from admin page