### PR TITLE
Fix: Order of parsing body to parse access_token

### DIFF
--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -111,7 +111,7 @@ module.exports = function(crowi, app) {
   app.post('/_api/likes.add'          , accessTokenParser , loginRequired(crowi, app) , csrf, page.api.like);
   app.post('/_api/likes.remove'       , accessTokenParser , loginRequired(crowi, app) , csrf, page.api.unlike);
   app.get( '/_api/attachments.list'   , accessTokenParser , loginRequired(crowi, app) , attachment.api.list);
-  app.post('/_api/attachments.add'    , accessTokenParser , loginRequired(crowi, app) , uploads.single('file'), csrf, attachment.api.add);
+  app.post('/_api/attachments.add'    , uploads.single('file'), accessTokenParser, loginRequired(crowi, app) ,csrf, attachment.api.add);
   app.post('/_api/attachments.remove' , accessTokenParser , loginRequired(crowi, app) , csrf, attachment.api.remove);
 
   app.get( '/_api/revisions.get'      , accessTokenParser , loginRequired(crowi, app) , revision.api.get);


### PR DESCRIPTION
- Caused by changes of usage of `multer`
- To parse `access_token` of `req.body` in `accessTokenParser`, `multer` middleware should be set before `accessTokenParser`