### PR TITLE
Omit symlinks

### DIFF
--- a/lib/views/layout/layout.html
+++ b/lib/views/layout/layout.html
@@ -15,6 +15,8 @@
 
   <script src="{{ assets('/js/bundled.js') }}"></script>
   <link href='//fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+  <!-- Font Awesome -->
+  <link href='//cdn.jsdelivr.net/fontawesome/4.7.0/css/font-awesome.min.css' rel='stylesheet' type='text/css'>
 </head>
 {% endblock %}
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "express": "~4.14.0",
     "express-form": "~0.12.0",
     "express-session": "~1.14.0",
-    "font-awesome": "~4.7.0",
     "googleapis": "=12.3.0",
     "gulp": "~3.9.0",
     "gulp-concat": "~2.6.0",

--- a/public/css/diff2html
+++ b/public/css/diff2html
@@ -1,1 +1,0 @@
-../../node_modules/diff2html/dist

--- a/public/emoji_images
+++ b/public/emoji_images
@@ -1,1 +1,0 @@
-../node_modules/emojify.js/dist/images

--- a/public/fonts
+++ b/public/fonts
@@ -1,1 +1,0 @@
-../node_modules/font-awesome/fonts

--- a/resource/js/util/PreProcessor/Emoji.js
+++ b/resource/js/util/PreProcessor/Emoji.js
@@ -3,8 +3,9 @@ import emojify from 'emojify.js';
 export default class Emoji {
 
   constructor() {
+    // see https://github.com/Ranks/emojify.js/issues/123
     emojify.setConfig({
-      img_dir: '/emoji_images/basic',
+      img_dir: 'https://github.global.ssl.fastly.net/images/icons/emoji/',
     });
   }
 


### PR DESCRIPTION
My environment
-----------------

* Windows 10 + Windows Subsystem for Linux

What happens?
----------------

* Some assets are not loaded when `node app.js` because of broken symlinks on Windows

Approach
-----------

* Omit symlinks and adopt Environment-independent methods

Note
------

* Omitting `public/js/reveal` has not been done because it looks like beta.