### PR TITLE
Made deleted pages not to be displayed in "recent-create"

### DIFF
--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -541,7 +541,7 @@ module.exports = function(crowi) {
     var User = crowi.model('User');
     var limit = option.limit || 50;
     var offset = option.offset || 0;
-    var conditions = { creator: user._id, redirectTo: null };
+    var conditions = { creator: user._id, redirectTo: null, status: STATUS_PUBLISHED };
     if (!user.equals(currentUser._id)) {
       conditions.grant = GRANT_PUBLIC;
     }

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -541,7 +541,15 @@ module.exports = function(crowi) {
     var User = crowi.model('User');
     var limit = option.limit || 50;
     var offset = option.offset || 0;
-    var conditions = { creator: user._id, redirectTo: null, status: STATUS_PUBLISHED };
+    var conditions = {
+      creator: user._id,
+      redirectTo: null,
+      $or: [
+        {status: null},
+        {status: STATUS_PUBLISHED},
+      ],
+    };
+
     if (!user.equals(currentUser._id)) {
       conditions.grant = GRANT_PUBLIC;
     }


### PR DESCRIPTION
FEATURE REQUEST:

![2017-03-16 19 02 51](https://cloud.githubusercontent.com/assets/4442708/23991440/bb6a298c-0a7c-11e7-88d4-8257e5cd4117.png)

I often visit "recent-create". Showing deleted pages in this view is annoying. 

I want these pages to be invisible. No problem if merged this patch since it is possible to list the deleted pages from here, I think.

![2017-03-16 19 10 28](https://cloud.githubusercontent.com/assets/4442708/23991428/b765b86a-0a7c-11e7-9721-68d3fde0e7a6.png)
