### PR TITLE
Unfurl Slack URL

### DIFF
--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -15,6 +15,7 @@ module.exports = function(crowi, app) {
     , bookmark  = require('./bookmark')(crowi, app)
     , revision  = require('./revision')(crowi, app)
     , search    = require('./search')(crowi, app)
+    , slack     = require('./slack')(crowi, app)
     , loginRequired = middleware.loginRequired
     , accessTokenParser = middleware.accessTokenParser(crowi, app)
     , csrf      = middleware.csrfVerify(crowi, app)
@@ -120,6 +121,8 @@ module.exports = function(crowi, app) {
 
   //app.get('/_api/revision/:id'     , user.useUserData()         , revision.api.get);
   //app.get('/_api/r/:revisionId'    , user.useUserData()         , page.api.get);
+
+  app.post('/_api/slack/event'       , slack.api.handleEvent);
 
   app.post('/_/edit'                 , form.revision             , loginRequired(crowi, app) , csrf, page.pageEdit);
   app.get('/trash/$'                 , loginRequired(crowi, app) , page.deletedPageListShow);

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -1,0 +1,95 @@
+module.exports = function(crowi, app) {
+  'use strict';
+
+  var slackHelper = require('../util/slack')(crowi)
+  , Page = crowi.model('Page')
+  , User = crowi.model('User')
+  , actions = {};
+
+  var api = actions.api = {};
+
+  function fetchPage(link) {
+  }
+
+  api.handleEvent = function(req, res) {
+    if (req.body.type != null && req.body.type == 'url_verification') {
+      verifyChallenge(req, res);
+      return;
+    }
+
+    let event = req.body.event;
+    switch (event.type) {
+      case 'link_shared':
+      unfurl(req, res);
+      break;
+      default:
+      break;
+    }
+  }
+
+  function verifyChallenge(req, res) {
+    res.send(req.body.challenge);
+  }
+
+  function unfurl(req, res) {
+    const https = require('https');
+    const HOST = 'slack.com'
+    const PATH = '/api/chat.unfurl';
+
+    const link = req.body.event.links[0];
+    const channel = req.body.event.channel;
+    const url = require('url').parse(link.url, true);
+
+    var pagePath = url.path || null;
+    var pageId = url.query.page_id || null; // TODO: handling
+    var revisionId = url.query.revision_id || null;
+
+    User.findAllUsers()
+    .then (function(users) {
+      return Page.findPage(pagePath, users[0], revisionId);
+    })
+    .then(function(pageData) {
+      let unfurls = { };
+      unfurls[link.url] = {
+        "title": pageData.path,
+        "text": slackHelper.prepareAttachmentTextForCreate(pageData)
+      };
+
+      let config = crowi.getConfig();
+      let token = config.notification['slack:token'];
+      let postData = {
+        "token": token,
+        "channel": channel,
+        "ts": req.body.event.message_ts,
+        "unfurls": encodeURIComponent(JSON.stringify(unfurls))
+      };
+
+      let postDataStr = JSON.stringify(postData);
+
+      let options = {
+        host: HOST,
+        port: 443,
+        path: PATH + "?token=" + postData['token'] + '&channel=' + postData["channel"] + "&ts=" + postData["ts"] + "&unfurls=" + postData["unfurls"],
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json;charset=utf-8'
+        }
+      };
+
+      let slackReq = https.request(options, (slackRes) => {
+        slackRes.setEncoding('utf8');
+      });
+      slackReq.on('error', (e) => {
+        console.error('failed to send a request to Slack: ' + e.message);
+      });
+      slackReq.end();
+      res.send(200);
+    })
+    .catch(function(err) {
+      console.error('failed in fetching page: ' + err);
+      res.send(404);
+    });
+  }
+
+  return actions;
+};


### PR DESCRIPTION
To achieve this: https://api.slack.com/docs/message-link-unfurling

### Example

<img width="666" alt="screen shot 2017-04-03 at 12 10 27" src="https://cloud.githubusercontent.com/assets/2490/24594282/9a29e7f6-1866-11e7-8404-5769194a97d9.png">

### Known issue

- [ ] Cannot unfurl an URL if it contains white space (i.e. `%20`)