### PR TITLE
READMEの英語の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Install dependencies and build CSS and JavaScript:
 
     $ npm install
 
-More info are [here](https://github.com/crowi/crowi/wiki/Install-and-Configuration).
+More info is [here](https://github.com/crowi/crowi/wiki/Install-and-Configuration).
 
 ### WARNING
 
-Don't use `master` branch because it is unstable but use released tag version expect when you want to contribute the project.
+Don't use `master` branch because it is unstable. Use released version except when you want to contribute to the project.
 
 
 Dependencies
@@ -47,7 +47,7 @@ Dependencies
 Start Up on Local
 -------------------
 
-Crowi is designed setting up to Heroku or some PaaS, but you can start up Crowi with ENV parameter on your local.
+Crowi is designed to be set up on Heroku or some PaaS, but you can also start up Crowi with ENV parameter on your local.
 
 ```
 $ PASSWORD_SEED=somesecretstring MONGO_URI=mongodb://username:password@localhost/crowi node app.js
@@ -58,10 +58,10 @@ $ PASSWORD_SEED=somesecretstring MONGO_URI=mongodb://username:password@localhost
 
 * `PORT`: Server port. default: `3000`.
 * `NODE_ENV`: `production` OR `development`.
-* `MONGO_URI`: URI to connect MongoDB. This parameter is also by `MONGOHQ_URL` OR `MONGOLAB_URI`.
-* `REDIS_URL`: URI to connect Redis (to session store). This parameter is also by `REDISTOGO_URL`.
-* `ELASTICSEARCH_URI`: URI to connect Elasticearch.
-* `PASSWORD_SEED`: A password seed is used by password hash generator.
+* `MONGO_URI`: URI to connect to MongoDB. This parameter is also by `MONGOHQ_URL` OR `MONGOLAB_URI`.
+* `REDIS_URL`: URI to connect to Redis (to session store). This parameter is also by `REDISTOGO_URL`.
+* `ELASTICSEARCH_URI`: URI to connect to Elasticearch.
+* `PASSWORD_SEED`: A password seed used by password hash generator.
 * `SECRET_TOKEN`: A secret key for verifying the integrity of signed cookies.
 * `FILE_UPLOAD`: `aws` (default), `local`, `none`
 


### PR DESCRIPTION
良いソフトウェアを開発していただき、ありがとうございます。

さて、READMEの英文において何点か誤りと思われる箇所を発見しましたので、修正のPull Requestを送らせていただきます。各変更とその理由を以下に簡単に説明致します。

---

> (修正前) More info are here.
> (修正後) More info is here.

“Information” は不可算名詞なので、 “are” を “is” に修正しました。

> (修正前) Don't use master branch because it is unstable but use released tag version expect when you want to contribute the project.
> (修正後) Don't use master branch because it is unstable. Use released version except when you want to contribute to the project.

* “Don't use ~ because ~ but use ~.” という構造で、 “but” は “Don't” の not との対応を意図したものと思われますが、解釈しづらいため、2文に分割しました。
* “released tag version” は単に “released version” で相応しいかと思いましたので、そのように修正しました。
* ”except” を意図したと思われる品詞用法/文脈で “expect” が用いられていましたのでtypoと判断し、修正しました。

> (修正前) Crowi is designed setting up to Heroku or some PaaS, but you can start up Crowi with ENV parameter on your local.
> (修正後) Crowi is designed to be set up on Heroku or some PaaS, but you can also start up Crowi with ENV parameter on your local.

* 動詞 “design” は第4文型を取りませんし、 “setting~” が分詞構文を取っているような文脈でもないため、誤りと判断しました。文脈から「Herokuや他のPaaSで構築されることを意図して設計されている」という風に読み取れますから、相応しい形に修正しました。
* 誤りではありませんが、文脈を考慮し、 “can” の直後に “also” を追加しました。

> (修正前) connect (MongoDB|Redis|Elasticearch)
> (修正後) connect to (MongoDB|Redis|Elasticearch)

接続の意味で使われていると思われるため、 “connect to” という形に修正しました。

> (修正前) `PASSWORD_SEED`: A password seed is used by password hash generator
> (修正後) `PASSWORD_SEED`: A password seed used by password hash generator.

誤りではありませんが、他の箇条書き項目はすべて名詞で注釈が書かれているため、こちらも名詞化しました。

---

以上です。誤りがないように調べたつもりですが、万が一誤りやお節介な点がありましたら申し訳ありません。

よろしくお願いします。