### PR TITLE
言語設定columnのレイアウト崩れを修正

### DIFF
--- a/lib/views/me/index.html
+++ b/lib/views/me/index.html
@@ -80,8 +80,6 @@
           <label><input type="radio" name="userForm[lang]" value="{{ consts.language.LANG_EN_US }}" {% if user.lang == consts.language.LANG_EN_US %}checked="checked"{% endif %}>{{ t('English') }}</label>
           <label><input type="radio" name="userForm[lang]" value="{{ consts.language.LANG_JA }}" {% if user.lang == consts.language.LANG_JA %}checked="checked"{% endif %}>{{ t('Japanese') }}</label>
         </div>
-        <div class="col-sm-offset-2 col-sm-10">
-        </div>
       </div>
       <div class="form-group">
         <div class="col-sm-offset-2 col-sm-10">

--- a/lib/views/me/index.html
+++ b/lib/views/me/index.html
@@ -73,17 +73,16 @@
           </p>
           {% endif %}
         </div>
-        <div class="form-group {% if not user.lang %}has-error{% endif %}">
-          <label for="userForm[lang]" class="col-sm-2 control-label">{{ t('Language') }}</label>
-          <div class="col-sm-4 radio">
-            <label><input type="radio" name="userForm[lang]" value="{{ consts.language.LANG_EN_US }}" {% if user.lang == consts.language.LANG_EN_US %}checked="checked"{% endif %}>{{ t('English') }}</label>
-            <label><input type="radio" name="userForm[lang]" value="{{ consts.language.LANG_JA }}" {% if user.lang == consts.language.LANG_JA %}checked="checked"{% endif %}>{{ t('Japanese') }}</label>
-          </div>
-          <div class="col-sm-offset-2 col-sm-10">
-          </div>
+      </div>
+      <div class="form-group {% if not user.lang %}has-error{% endif %}">
+        <label for="userForm[lang]" class="col-sm-2 control-label">{{ t('Language') }}</label>
+        <div class="col-sm-4 radio">
+          <label><input type="radio" name="userForm[lang]" value="{{ consts.language.LANG_EN_US }}" {% if user.lang == consts.language.LANG_EN_US %}checked="checked"{% endif %}>{{ t('English') }}</label>
+          <label><input type="radio" name="userForm[lang]" value="{{ consts.language.LANG_JA }}" {% if user.lang == consts.language.LANG_JA %}checked="checked"{% endif %}>{{ t('Japanese') }}</label>
+        </div>
+        <div class="col-sm-offset-2 col-sm-10">
         </div>
       </div>
-
       <div class="form-group">
         <div class="col-sm-offset-2 col-sm-10">
           <button type="submit" class="btn btn-primary">{{ t('Update') }}</button>

--- a/lib/views/me/index.html
+++ b/lib/views/me/index.html
@@ -76,9 +76,9 @@
       </div>
       <div class="form-group {% if not user.lang %}has-error{% endif %}">
         <label for="userForm[lang]" class="col-sm-2 control-label">{{ t('Language') }}</label>
-        <div class="col-sm-4 radio">
-          <label><input type="radio" name="userForm[lang]" value="{{ consts.language.LANG_EN_US }}" {% if user.lang == consts.language.LANG_EN_US %}checked="checked"{% endif %}>{{ t('English') }}</label>
-          <label><input type="radio" name="userForm[lang]" value="{{ consts.language.LANG_JA }}" {% if user.lang == consts.language.LANG_JA %}checked="checked"{% endif %}>{{ t('Japanese') }}</label>
+        <div class="col-sm-4">
+          <label class="radio-inline"><input type="radio" name="userForm[lang]" value="{{ consts.language.LANG_EN_US }}" {% if user.lang == consts.language.LANG_EN_US %}checked="checked"{% endif %}>{{ t('English') }}</label>
+          <label class="radio-inline"><input type="radio" name="userForm[lang]" value="{{ consts.language.LANG_JA }}" {% if user.lang == consts.language.LANG_JA %}checked="checked"{% endif %}>{{ t('Japanese') }}</label>
         </div>
       </div>
       <div class="form-group">


### PR DESCRIPTION
ユーザー設定 > ユーザー情報ページ ( `http://<host>/me` ) の、 「ユーザーの基本情報」項目における言語設定columnのレイアウト崩れを修正しました。

||幅768px以上|幅768px未満|
|---|---|---|
|**修正前**|![before](https://cloud.githubusercontent.com/assets/4680738/26281875/2338bea2-3e3f-11e7-9211-3ac3be127de3.png)|![before-short](https://cloud.githubusercontent.com/assets/4680738/26281878/2c74bbf6-3e3f-11e7-8f1e-dbb8a6c730c6.png)|
|**修正後**|![after](https://cloud.githubusercontent.com/assets/4680738/26281918/4ade5d6c-3e40-11e7-8480-6aed14b5c832.png)|![after-short](https://cloud.githubusercontent.com/assets/4680738/26281884/580343be-3e3f-11e7-8880-7a88ea0f282d.png)|

具体的な変更内容は以下の通りです:
* 言語設定の `div.form-group` が、メールアドレス設定の `div.form-group` の中に入れられていたため、 column 全体が左にずれる現象が起こっていたので、その入れ子を修正しました。 (commit: `65b8675`)
* 見た目とは関係ありませんが、言語設定の `div.form-group` の中に、中身のない `div.col-sm-offset-2.col-sm-10` が入れられていたので、不要かと思い削除しました。 (commit: `2c4bcf0`)
* inline 形式の radio buttons に対する Bootstrap class 設定が `label.radio-inline` ではなく `div.radio` となっていたため、「英語」の radio button と「日本語」の radio button の間のスペースが十分に取られていなかったので、修正しました。 Bootstrap Document での該当する項目は [こちら](https://bootstrapdocs.com/v3.3.6/docs/css/#inline-checkboxes-and-radios) です。 (commit: `f2c6946` )

以上、よろしくお願いします。