### PR TITLE
Use client side "date" instead of server side "date" when create new memo

### DIFF
--- a/resource/js/crowi.js
+++ b/resource/js/crowi.js
@@ -213,6 +213,11 @@ $(function() {
 
 
   $('#create-page').on('shown.bs.modal', function (e) {
+    // quick hack: replace from server side rendering "date" to client side "date"
+    var today = new Date();
+    var dateString = today.getFullYear() + '/' + (today.getMonth() + 1) + '/' + today.getDate();
+    $('#create-page-today .page-today-suffix').text('/' + dateString);
+    $('#create-page-today .page-today-input2').data('prefix', '/' + dateString + '/');
 
     var input2Width = $('#create-page-today .col-xs-10').outerWidth();
     var newWidth = input2Width


### PR DESCRIPTION
## About

- When create new memo, the Crowi creates a "date" path automatically.
    - But, that "date" is server side date.
    - I want use client side date automatically.

## Screenshot

<img width="928" alt="screenshot_2017-06-04_11_39_18" src="https://cloud.githubusercontent.com/assets/10488/26764409/439f3b1c-491b-11e7-8cdc-107a8c0772e3.png">
