### PR TITLE
Get rid of babel-preset-es2015

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,10 @@
 {
   "presets": [
-    "env",
-    "es2015",
+    ["env", {
+      "targets": {
+        "browsers": ["last 2 versions"]
+      }
+    }],
     "react"
   ]
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -560,11 +560,6 @@
       "from": "babel-preset-env@>=1.4.0 <1.5.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.4.0.tgz"
     },
-    "babel-preset-es2015": {
-      "version": "6.24.1",
-      "from": "babel-preset-es2015@>=6.24.1 <6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz"
-    },
     "babel-preset-flow": {
       "version": "6.23.0",
       "from": "babel-preset-flow@>=6.23.0 <7.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "babel-loader": "~7.0.0",
     "babel-polyfill": "~6.23.0",
     "babel-preset-env": "~1.4.0",
-    "babel-preset-es2015": "~6.24.1",
     "babel-preset-react": "~6.24.1",
     "basic-auth-connect": "~1.0.0",
     "body-parser": "~1.14.1",


### PR DESCRIPTION
Please use `babel-preset-env`. `babel-preset-es2015`  is not recommended.

see: https://github.com/babel/babel-preset-env