### PR TITLE
Add an error handling in search result page

### DIFF
--- a/resource/js/util/PostProcessor/Mathjax.js
+++ b/resource/js/util/PostProcessor/Mathjax.js
@@ -52,6 +52,10 @@ export default class Mathjax {
       return html;
     }
 
+    if (typeof dom === 'undefined') {
+      return html;
+    }
+
     const intervalId = setInterval(() => {
       if (this.crowi.window.MathJax) {
         const MathJax = this.crowi.window.MathJax;


### PR DESCRIPTION
## About

- An error message was found on the search results page when MathJax support is on.
- This PR solved that errors.
    - MathJax supports on the search results page is **not included** in this PR.

## Screenshot

### Before

![screenshot 2018-02-02 09 42 10](https://user-images.githubusercontent.com/10488/35710904-5e3e196a-07fd-11e8-9094-3ff9838a20d2.png)

### After

![screenshot 2018-02-02 09 40 36](https://user-images.githubusercontent.com/10488/35710861-2b61ef8a-07fd-11e8-81c8-d5f17265490e.png)
