### PR TITLE
Fix a problem that we can't change a page to portal in a specific condition

### DIFF
--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -138,7 +138,7 @@ module.exports = function(crowi) {
   };
 
   pageSchema.methods.isRedirectOriginPage = function() {
-    return this.redirectTo != null;
+    return this.redirectTo !== null;
   };
 
   pageSchema.methods.like = function(userData) {

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -137,6 +137,10 @@ module.exports = function(crowi) {
     });
   };
 
+  pageSchema.methods.isRedirectOriginPage = function() {
+    return this.redirectTo != null;
+  };
+
   pageSchema.methods.like = function(userData) {
     var self = this,
       Page = self;

--- a/lib/routes/page.js
+++ b/lib/routes/page.js
@@ -860,8 +860,9 @@ module.exports = function(crowi, app) {
     var pageId = req.body.page_id;
     var previousRevision = req.body.revision_id || null;
     var newPagePath = Page.normalizePath(req.body.new_path);
+    var newPageIsPortal = newPagePath.endsWith("/");
     var options = {
-      createRedirectPage: req.body.create_redirect || 0,
+      createRedirectPage: !newPageIsPortal && req.body.create_redirect || 0,
       moveUnderTrees: req.body.move_trees || 0,
     };
 

--- a/lib/routes/page.js
+++ b/lib/routes/page.js
@@ -864,18 +864,13 @@ module.exports = function(crowi, app) {
       createRedirectPage: req.body.create_redirect || 0,
       moveUnderTrees: req.body.move_trees || 0,
     };
-    var page = {};
 
     if (!Page.isCreatableName(newPagePath)) {
       return res.json(ApiResponse.error(sprintf('このページ名は作成できません (%s)', newPagePath)));
     }
 
-    Page.findPageByPath(newPagePath)
-    .then(function(page) {
-      // if page found, cannot cannot rename to that path
-      return res.json(ApiResponse.error(sprintf('このページ名は作成できません (%s)。ページが存在します。', newPagePath)));
-    }).catch(function(err) {
-
+    var rename = function() {
+      var page = {};
       Page.findPageById(pageId)
       .then(function(pageData) {
         page = pageData;
@@ -892,6 +887,26 @@ module.exports = function(crowi, app) {
       }).catch(function(err) {
         return res.json(ApiResponse.error('Failed to update page.'));
       });
+    }
+
+    Page.findPageByPath(newPagePath)
+    .then(function(page) {
+      if (page.isRedirectOriginPage() &&  page.isGrantedFor(req.user)) {
+        debug('Unlink page', page._id, page.path);
+        Page.removePageById(page._id)
+        .then(function(data) {
+          debug('Redirect Page deleted', data.path);
+          rename();
+        }).catch(function(err) {
+          debug('Error occured while get setting', err, err.stack);
+          return res.json(ApiResponse.error('Failed to delete redirect page.'));
+        });
+      } else {
+        // can't rename to that path when page found and can't remove it
+        return res.json(ApiResponse.error(sprintf('このページ名は作成できません (%s)。ページが存在します。', newPagePath)));
+      }
+    }).catch(function(err) {
+      rename();
     });
   };
 


### PR DESCRIPTION
# Overview
Fix a problem that we can't change a page to portal in a specific condition.

# Reproduce
1. Create a page (`/hoge`)
<img width="1440" alt="2018-05-11 15 43 21" src="https://user-images.githubusercontent.com/2351326/39915456-fac5b7ba-5542-11e8-8f7c-8b7db2485388.png">

2. Move this page to `/hoge/`
<img width="1440" alt="2018-05-11 15 43 28" src="https://user-images.githubusercontent.com/2351326/39915457-fc9e3f26-5542-11e8-836c-007a0b4c3ef4.png">
* A page whose URL ends with a slash will be a portal

3. We can't change a page to portal
<img width="1440" alt="2018-05-11 15 43 40" src="https://user-images.githubusercontent.com/2351326/39915462-fe39bc66-5542-11e8-816f-199f6f3d5a76.png">

# Cause
`/hoge` page become a redirect page when moved this page to `/hoge/`.
Page is exists as a redirect page, so we can't unportalize `/hoge/`.

# Solution (Changes)
- If existed page is a redirect page, we'll delete it.
  - By this, "Unportalize" will work normally.
-  In case of renaming, if new page's url ends with slash, the server don't create a redirect page.

# Related issues
Close #283