### PR TITLE
:sparkles: Support pagination on /_api/search

### DIFF
--- a/lib/routes/search.js
+++ b/lib/routes/search.js
@@ -5,6 +5,7 @@ module.exports = function(crowi, app) {
     , Page = crowi.model('Page')
     , User = crowi.model('User')
     , ApiResponse = require('../util/apiResponse')
+    , ApiPaginate = require('../util/apiPaginate')
 
     , sprintf = require('sprintf')
 
@@ -36,8 +37,7 @@ module.exports = function(crowi, app) {
   api.search = function(req, res){
     var keyword = req.query.q || null;
     var tree = req.query.tree || null;
-    var offset = parseInt(req.query.offset) || 0;
-    var limit = parseInt(req.query.limit) || 50;
+    var paginateOpts = ApiPaginate.parseOptions(req.query);
 
     if (keyword === null || keyword === '') {
       return res.json(ApiResponse.error('keyword should not empty.'));
@@ -48,7 +48,7 @@ module.exports = function(crowi, app) {
       return res.json(ApiResponse.error('Configuration of ELASTICSEARCH_URI is required.'));
     }
 
-    var searchOpts = {offset: offset, limit: limit};
+    var searchOpts = Object.assign({}, paginateOpts);
     var doSearch;
     if (tree) {
       doSearch = search.searchKeywordUnderPath(keyword, tree, searchOpts);

--- a/lib/routes/search.js
+++ b/lib/routes/search.js
@@ -37,7 +37,13 @@ module.exports = function(crowi, app) {
   api.search = function(req, res){
     var keyword = req.query.q || null;
     var tree = req.query.tree || null;
-    var paginateOpts = ApiPaginate.parseOptions(req.query);
+    var paginateOpts;
+
+    try {
+      paginateOpts = ApiPaginate.parseOptionsForElasticSearch(req.query);
+    } catch (e) {
+      res.json(ApiResponse.error(e));
+    }
 
     if (keyword === null || keyword === '') {
       return res.json(ApiResponse.error('keyword should not empty.'));

--- a/lib/routes/search.js
+++ b/lib/routes/search.js
@@ -30,10 +30,15 @@ module.exports = function(crowi, app) {
    *
    * @apiParam {String} q keyword
    * @apiParam {String} path
+   * @apiParam {String} offset
+   * @apiParam {String} limit
    */
   api.search = function(req, res){
     var keyword = req.query.q || null;
     var tree = req.query.tree || null;
+    var offset = parseInt(req.query.offset) || 0;
+    var limit = parseInt(req.query.limit) || 50;
+
     if (keyword === null || keyword === '') {
       return res.json(ApiResponse.error('keyword should not empty.'));
     }
@@ -43,12 +48,12 @@ module.exports = function(crowi, app) {
       return res.json(ApiResponse.error('Configuration of ELASTICSEARCH_URI is required.'));
     }
 
-
+    var searchOpts = {offset: offset, limit: limit};
     var doSearch;
     if (tree) {
-      doSearch = search.searchKeywordUnderPath(keyword, tree, {});
+      doSearch = search.searchKeywordUnderPath(keyword, tree, searchOpts);
     } else {
-      doSearch = search.searchKeyword(keyword, {});
+      doSearch = search.searchKeyword(keyword, searchOpts);
     }
     var result = {};
     doSearch

--- a/lib/util/apiPaginate.js
+++ b/lib/util/apiPaginate.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const LIMIT_DEFAULT = 50;
+const LIMIT_MAX = 1000;
+
+const OFFSET_DEFAULT = 0;
+
+const parseIntValue = function (value, defaultValue, maxLimit) {
+  if (!value) {
+    return defaultValue;
+  }
+
+  var v = parseInt(value);
+  if (!maxLimit) {
+    return v;
+  }
+
+  return ((v <= 10) ? v : maxLimit);
+};
+
+function ApiPaginate () {
+};
+
+ApiPaginate.parseOptions = function(params) {
+  var limit = parseIntValue(params.limit, LIMIT_DEFAULT, LIMIT_MAX);
+  var offset = parseIntValue(params.offset, OFFSET_DEFAULT);
+  console.log('limit', limit);
+  console.log('offset', offset);
+
+  return {limit: limit, offset: offset};
+};
+
+module.exports = ApiPaginate;

--- a/lib/util/apiPaginate.js
+++ b/lib/util/apiPaginate.js
@@ -5,6 +5,8 @@ const LIMIT_MAX = 1000;
 
 const OFFSET_DEFAULT = 0;
 
+const DEFAULT_MAX_RESULT_WINDOW = 10000;
+
 const parseIntValue = function (value, defaultValue, maxLimit) {
   if (!value) {
     return defaultValue;
@@ -15,17 +17,20 @@ const parseIntValue = function (value, defaultValue, maxLimit) {
     return v;
   }
 
-  return ((v <= 10) ? v : maxLimit);
+  return ((v <= maxLimit) ? v : maxLimit);
 };
 
 function ApiPaginate () {
 };
 
-ApiPaginate.parseOptions = function(params) {
+ApiPaginate.parseOptionsForElasticSearch = function(params) {
   var limit = parseIntValue(params.limit, LIMIT_DEFAULT, LIMIT_MAX);
   var offset = parseIntValue(params.offset, OFFSET_DEFAULT);
-  console.log('limit', limit);
-  console.log('offset', offset);
+
+  // See https://github.com/crowi/crowi/pull/293
+  if ((limit + offset) > DEFAULT_MAX_RESULT_WINDOW) {
+    throw new Error(`(limit + offset) must be less than or equal to ${DEFAULT_MAX_RESULT_WINDOW}`);
+  }
 
   return {limit: limit, offset: offset};
 };

--- a/lib/util/search.js
+++ b/lib/util/search.js
@@ -461,8 +461,11 @@ SearchClient.prototype.appendCriteriaForPathFilter = function(query, path)
 SearchClient.prototype.searchKeyword = function(keyword, option)
 {
   var from = option.offset || null;
+  var size = option.limit || null;
   var query = this.createSearchQuerySortedByScore();
   this.appendCriteriaForKeywordContains(query, keyword);
+
+  this.appendResultSize(query, from, size);
 
   return this.search(query);
 };
@@ -475,13 +478,12 @@ SearchClient.prototype.searchByPath = function(keyword, prefix)
 SearchClient.prototype.searchKeywordUnderPath = function(keyword, path, option)
 {
   var from = option.offset || null;
+  var size = option.limit || null;
   var query = this.createSearchQuerySortedByScore();
   this.appendCriteriaForKeywordContains(query, keyword);
   this.appendCriteriaForPathFilter(query, path);
 
-  if (from) {
-    this.appendResultSize(query, from);
-  }
+  this.appendResultSize(query, from, size);
 
   return this.search(query);
 };


### PR DESCRIPTION
This pull request makes `/_api/search`API  paginatable with `limit` and `offset` parameters which same with `/_api/pages.list' API.

```console
$ curl -X GET "http://localhost:3000/_api/search?access_token=MY_SECRET_TOKEN&q=memo&tree=/user/&limit=2&offset=1" | jq '.data[]._id'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2202  100  2202    0     0  50029      0 --:--:-- --:--:-- --:--:-- 51209
"5b123f13403dd50264d0fec7"
"5b133b6b83558c0266a8454a"
```

## Motivation

I want to create a cli tool to search crowi pages, but `/_api/search` does not support pagination parameters, yet. 

### Question

It seems that `/_api/page.list` API can't configure `limit` by query parameters. ([here](https://github.com/crowi/crowi/blob/master/lib/routes/page.js#L515)).

I wonder whether `/_api/search` API should support `limit` parameter, or not. 🤔 

What do you think about `limit` parameter on `/_api/search` API?