### PR TITLE
Fix an issue Slack icon was not displayed

### DIFF
--- a/lib/views/_form.html
+++ b/lib/views/_form.html
@@ -25,7 +25,7 @@
         <span class="input-group extended-setting">
           <span class="input-group-addon">
             <label>
-              <i class="fa fa-slack"></i>
+              <i class="fab fa-slack"></i>
               <input class="" type="checkbox" name="pageForm[notify][slack][on]" value="1">
             </label>
           </span>

--- a/lib/views/admin/notification.html
+++ b/lib/views/admin/notification.html
@@ -19,7 +19,7 @@
     <div class="col-md-9">
 
       <ul class="nav nav-tabs">
-        <li class="active"><a href="#slack" data-toggle="tab"><i class="fa fa-slack"></i> Slack</a></li>
+        <li class="active"><a href="#slack" data-toggle="tab"><i class="fab fa-slack"></i> Slack</a></li>
       </ul>
 
       <br>
@@ -73,12 +73,12 @@
         {% if hasSlackToken %}
         <p>Crowi and Slack is already <strong>connected</strong>. You can re-connect to refresh and overwirte the token with your Slack account.</p>
         <a class="btn btn-default" href="{{ slackAuthUrl }}">
-          <i class="fa fa-slack"></i> Reconnect to Slack
+          <i class="fab fa-slack"></i> Reconnect to Slack
         </a>
         {% else %}
         <p>Slack clientId and clientSecret is configured. Now, you can connect with Slack.</p>
         <a class="btn btn-primary" href="{{ slackAuthUrl }}">
-          <i class="fa fa-slack"></i> Connect to Slack
+          <i class="fab fa-slack"></i> Connect to Slack
         </a>
         {% endif %}
       </div>


### PR DESCRIPTION
# Overview
Brand icons require "fab" instead of "fa" class FontAwesome 5.
But I missed replacing it.

https://github.com/crowi/crowi/pull/288

# Screens
<img width="280" alt="2018-06-08 13 27 55" src="https://user-images.githubusercontent.com/2351326/41139406-4831ad16-6b22-11e8-85f5-c1412a9992fa.png">