### PR TITLE
Use docker image again

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -5,6 +5,7 @@ services:
       context: .
       args:
         NODE_ENV: development
+    tty: true
     environment:
       DEBUG: "crowi:*"
       MONGO_URI: mongodb://mongodb:27017/crowi

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,7 +1,10 @@
 version: '3'
 services:
-  node:
-    image: node:8.11.2
+  crowi:
+    build:
+      context: .
+      args:
+        NODE_ENV: development
     environment:
       DEBUG: "crowi:*"
       MONGO_URI: mongodb://mongodb:27017/crowi
@@ -9,10 +12,9 @@ services:
       ELASTICSEARCH_URI: elasticsearch:9200/
       PLANTUML_URI: //localhost:8080
       FILE_UPLOAD: local
-    working_dir: /home/node/app
     volumes:
-      - ./:/home/node/app
-      - /home/node/app/node_modules
+      - ./:/crowi
+      - /crowi/node_modules
     ports:
       - 3000:3000
     links:


### PR DESCRIPTION
# Overview
Since it is necessary to unify the version of npm, I use Crowi's Docker image again.

# Historical Background
Problems occurred when switching branches by using Named Volume in the compose file. Therefore, we decided to use the Node image.
https://github.com/crowi/crowi/pull/291