### PR TITLE
update readme from node6.x to 8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Don't use `master` branch because it is unstable. Use released version except wh
 Dependencies
 -------------
 
-* Node.js (6.x)
+* Node.js (8.x)
 * MongoDB
 * Elasticsearch (optional) ([Doc is here](https://github.com/crowi/crowi/wiki/Configure-Search-Functions))
 * Redis (optional)


### PR DESCRIPTION
got this error when trying installation with Node.js 6.9.5
```
error crowi@1.7.0-dev: The engine "node" is incompatible with this module. Expected version "8.x".
error Found incompatible module
```