### PR TITLE
Sync login status among multiple tabs

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -6,6 +6,7 @@ import moment from 'moment'
 
 import Crowi from './util/Crowi'
 import CrowiRenderer from './util/CrowiRenderer'
+import CrowiAuth from './util/CrowiAuth'
 
 import HeaderSearchBox from 'components/HeaderSearchBox'
 import SearchPage from 'components/SearchPage'
@@ -52,6 +53,9 @@ if (!isSharePage) {
 
 const crowiRenderer = new CrowiRenderer(crowi)
 window.crowiRenderer = crowiRenderer
+
+const crowiAuth = new CrowiAuth(crowi)
+window.crowiAuth = crowiAuth
 
 const componentMappings = {
   'search-top': <HeaderSearchBox crowi={crowi} />,

--- a/client/app.js
+++ b/client/app.js
@@ -39,14 +39,10 @@ if (mainContent !== null) {
   }
 }
 
+const { user = {} } = JSON.parse(document.getElementById('user-context-hydrate').textContent || '{}')
+const csrfToken = $('#content-main').data('csrftoken')
 // FIXME
-const crowi = new Crowi(
-  {
-    me: $('#content-main').data('current-username'),
-    csrfToken: $('#content-main').data('csrftoken'),
-  },
-  window,
-)
+const crowi = new Crowi({ user, csrfToken }, window)
 window.crowi = crowi
 crowi.setConfig(JSON.parse(document.getElementById('crowi-context-hydrate').textContent || '{}'))
 const isSharePage = !!$('#content-main').data('is-share-page') || !!$('#secret-keyword-form-container').data('share-id')

--- a/client/components/PageAlerts.js
+++ b/client/components/PageAlerts.js
@@ -21,7 +21,7 @@ export default class PageAlerts extends React.Component {
       const user = data.user
       const crowi = this.props.crowi
 
-      if (user.username != crowi.me && this.props.pageId == data.page._id) {
+      if (user.username != crowi.getUser().name && this.props.pageId == data.page._id) {
         this.setState({
           alertAppeared: true,
           message: 'edit',

--- a/client/crowi.js
+++ b/client/crowi.js
@@ -172,7 +172,7 @@ $(function() {
   var pageId = $('#content-main').data('page-id')
   var revisionId = $('#content-main').data('page-revision-id')
   var revisionCreatedAt = $('#content-main').data('page-revision-created')
-  var currentUser = $('#content-main').data('current-user')
+  var currentUser = crowi.getUser().id
   var isSeen = $('#content-main').data('page-is-seen')
   var pagePath = $('#content-main').data('path')
   var isSharePage = !!$('#content-main').data('is-share-page')

--- a/client/i18n.js
+++ b/client/i18n.js
@@ -10,7 +10,8 @@ export default () => {
   lngDetector.addDetector({
     name: 'userSetting',
     lookup(options) {
-      const { lang = null } = JSON.parse(document.getElementById('user-context-hydrate').textContent || '{}')
+      const { config = {} } = JSON.parse(document.getElementById('user-context-hydrate').textContent || '{}')
+      const { lang = null } = config
       return lang
     },
     cacheUserLanguage(lng, options) {},

--- a/client/util/Crowi.js
+++ b/client/util/Crowi.js
@@ -21,9 +21,6 @@ export default class Crowi {
     this.apiPost = this.apiPost.bind(this)
     this.apiRequest = this.apiRequest.bind(this)
 
-    // FIXME
-    this.me = context.me
-
     this.users = []
     this.userByName = {}
     this.userById = {}
@@ -44,6 +41,15 @@ export default class Crowi {
 
   getConfig() {
     return this.config
+  }
+
+  setUser(user) {
+    const { id = '', name = '' } = user || {}
+    this.user = { id, name }
+  }
+
+  getUser() {
+    return this.user
   }
 
   getWebSocket() {

--- a/client/util/Crowi.js
+++ b/client/util/Crowi.js
@@ -10,6 +10,7 @@ export default class Crowi {
     this.context = context
     this.config = {}
     this.csrfToken = context.csrfToken
+    this.setUser(context.user)
 
     this.window = window
     this.location = window.location || {}

--- a/client/util/CrowiAuth.js
+++ b/client/util/CrowiAuth.js
@@ -1,0 +1,54 @@
+import queryString from 'query-string'
+
+export default class CrowiAuth {
+  constructor(crowi) {
+    this.crowi = crowi
+    this.location = crowi.location
+    this.localStorage = crowi.localStorage
+
+    this.onStorage = this.onStorage.bind(this)
+
+    this.subscribeStorage()
+    this.updateState()
+  }
+
+  isAuthenticated() {
+    const { id, name } = this.crowi.getUser()
+    return !!(id && name)
+  }
+
+  subscribeStorage() {
+    window.addEventListener('storage', this.onStorage)
+  }
+
+  shouldUpdate() {
+    return this.isAuthenticated() !== this.localStorage.getItem('authenticated')
+  }
+
+  updateState() {
+    if (this.shouldUpdate()) {
+      this.localStorage.setItem('authenticated', this.isAuthenticated())
+    }
+  }
+
+  onStorage(e) {
+    const { key, newValue } = e
+    const isAuthenticated = newValue === 'true'
+    if (key === 'authenticated') {
+      if (isAuthenticated) {
+        this.onLogin()
+      } else {
+        this.onLogout()
+      }
+    }
+  }
+
+  onLogin() {
+    const { continue: continueUrl = '/' } = queryString.parse(this.location.search)
+    top.location.href = continueUrl
+  }
+
+  onLogout() {
+    this.location.reload()
+  }
+}

--- a/client/util/LangProcessor/Template.js
+++ b/client/util/LangProcessor/Template.js
@@ -24,7 +24,7 @@ export default class Template {
 
   getUser() {
     // FIXME
-    const username = window.crowi.me || null
+    const username = window.crowi.getUser().name || null
 
     if (!username) {
       return ''

--- a/lib/crowi/express-init.js
+++ b/lib/crowi/express-init.js
@@ -113,7 +113,10 @@ module.exports = function(crowi, app) {
 
   app.use(i18nMiddleware.handle(i18next))
   app.use((req, res, next) => {
-    res.locals.user_config = { lang: req.i18n.language }
+    const { _id = '', username: name = '' } = req.user || {}
+    const id = _id.toString()
+    const { language: lang = '' } = req.i18n || {}
+    res.locals.user_context = { user: { id, name }, config: { lang } }
     next()
   })
 }

--- a/lib/routes/login.js
+++ b/lib/routes/login.js
@@ -100,6 +100,13 @@ module.exports = function(crowi, app) {
         }
       })
     } else {
+      const { user = {} } = req
+      const User = crowi.model('User')
+      const isLoggedIn = user && '_id' in user && user.status === User.STATUS_ACTIVE
+      if (isLoggedIn) {
+        return res.redirect('/')
+      }
+
       // method GET
       if (req.form) {
         debug(req.form.errors)

--- a/lib/routes/login.js
+++ b/lib/routes/login.js
@@ -24,26 +24,26 @@ module.exports = function(crowi, app) {
 
     clearSession(req)
 
-    var jumpTo = req.session.jumpTo
-    if (jumpTo) {
-      req.session.jumpTo = null
-      return res.redirect(jumpTo)
-    } else {
-      return res.redirect('/')
-    }
+    const continueUrl = req.body.continue || req.query.continue || '/'
+    return res.redirect(continueUrl)
   }
 
   var loginFailure = function(req, res) {
     req.flash('warningMessage', 'Sign in failure.')
-    return res.redirect('/login')
+
+    const continueUrl = req.body.continue || req.query.continue || '/'
+    const query = continueUrl === '/' ? '' : `?continue=${continueUrl}`
+    const redirectUrl = `/login${query}`
+    return res.redirect(redirectUrl)
   }
 
   actions.googleCallback = function(req, res) {
     debug('Header', req.url, req.headers.referer)
     const { query } = req
-    const { code = '' } = query
+    const { code = '', state } = query
     const { google = {} } = req.session
-    const { callbackAction: nextAction = '/login' } = google
+    const { callbackAction: action } = google
+    const nextAction = action ? url.format({ pathname: action, query: { continue: state } }) : '/login'
     debug('googleCallback.nextAction', nextAction)
     req.session.google = { authCode: code }
     debug('google auth code', code)
@@ -84,7 +84,8 @@ module.exports = function(crowi, app) {
 
   actions.login = function(req, res) {
     debug('Header', req.url, req.headers.referer)
-    var loginForm = req.body.loginForm
+    const { loginForm } = req.body
+    const { continue: continueUrl = '/' } = req.query
 
     if (req.method == 'POST' && req.form.isValid) {
       var email = loginForm.email
@@ -103,7 +104,7 @@ module.exports = function(crowi, app) {
       if (req.form) {
         debug(req.form.errors)
       }
-      return res.render('login', {})
+      return res.render('login', { continueUrl })
     }
   }
 

--- a/lib/util/githubAuth.js
+++ b/lib/util/githubAuth.js
@@ -11,13 +11,13 @@ module.exports = function(config) {
   var octokit = require('@octokit/rest')()
   var lib = {}
 
-  function useGitHubStrategy(config) {
+  function useGitHubStrategy(config, callbackQuery) {
     passport.use(
       new GitHubStrategy(
         {
           clientID: config.crowi['github:clientId'],
           clientSecret: config.crowi['github:clientSecret'],
-          callbackURL: config.crowi['app:url'] + '/github/callback',
+          callbackURL: `${config.crowi['app:url']}/github/callback${callbackQuery}`,
           scope: ['user:email', 'read:org'],
         },
         function(accessToken, refreshToken, profile, callback) {
@@ -43,7 +43,9 @@ module.exports = function(config) {
   }
 
   lib.authenticate = function(req, res, next) {
-    useGitHubStrategy(config)
+    const { continue: continueUrl } = req.query
+    const query = continueUrl === '/' ? '' : `?continue=${continueUrl}`
+    useGitHubStrategy(config, query)
     passport.authenticate('github')(req, res, next)
   }
 

--- a/lib/util/googleAuth.js
+++ b/lib/util/googleAuth.js
@@ -5,30 +5,32 @@
 module.exports = function(config) {
   'use strict'
 
-  const lib = {}
   const { google: googleApis } = require('googleapis')
   const debug = require('debug')('crowi:lib:googleAuth')
+  const lib = {}
 
-  function createOauth2Client(url) {
-    return new googleApis.auth.OAuth2(config.crowi['google:clientId'], config.crowi['google:clientSecret'], url)
+  function createOauth2Client() {
+    const clientId = config.crowi['google:clientId']
+    const clientSecret = config.crowi['google:clientSecret']
+    const callbackUrl = config.crowi['app:url'] + '/google/callback'
+    return new googleApis.auth.OAuth2(clientId, clientSecret, callbackUrl)
   }
 
   lib.createAuthUrl = function(req, callback) {
-    var callbackUrl = config.crowi['app:url'] + '/google/callback'
-    var oauth2Client = createOauth2Client(callbackUrl)
+    const oauth2Client = createOauth2Client()
     googleApis.options({ auth: oauth2Client })
 
-    var redirectUrl = oauth2Client.generateAuthUrl({
+    const redirectUrl = oauth2Client.generateAuthUrl({
       access_type: 'offline',
       scope: ['profile', 'email'],
+      state: req.query.continue,
     })
 
     callback(null, redirectUrl)
   }
 
   lib.handleCallback = function(req, callback) {
-    const callbackUrl = config.crowi['app:url'] + '/google/callback'
-    const oauth2Client = createOauth2Client(callbackUrl)
+    const oauth2Client = createOauth2Client()
     googleApis.options({ auth: oauth2Client })
     const { google = {} } = req.session
     const { authCode: code } = google

--- a/lib/util/middlewares.js
+++ b/lib/util/middlewares.js
@@ -161,7 +161,9 @@ exports.adminRequired = function() {
 
 exports.loginRequired = function(crowi, app) {
   return function(req, res, next) {
-    var User = crowi.model('User')
+    const User = crowi.model('User')
+    const { path = '', originalUrl } = req
+    const query = originalUrl === '/' ? '' : `?continue=${originalUrl}`
 
     if (req.user && '_id' in req.user) {
       if (req.user.status === User.STATUS_ACTIVE) {
@@ -177,13 +179,11 @@ exports.loginRequired = function(crowi, app) {
     }
 
     // is api path
-    var path = req.path || ''
     if (path.match(/^\/_api\/.+$/)) {
       return res.sendStatus(403)
     }
 
-    req.session.jumpTo = req.originalUrl
-    return res.redirect('/login')
+    return res.redirect(`/login${query}`)
   }
 }
 

--- a/lib/views/layout/layout.html
+++ b/lib/views/layout/layout.html
@@ -147,7 +147,7 @@
 {{ local_config|json|safe }}
 </script>
 <script type="application/json" id="user-context-hydrate">
-{{ user_config|json|safe }}
+{{ user_context|json|safe }}
 </script>
 
 <script src="{{ assets('/js/app.js') }}"></script>

--- a/lib/views/login.html
+++ b/lib/views/login.html
@@ -50,6 +50,7 @@
       </div>
 
       <input type="hidden" name="_csrf" value="{{ csrf() }}">
+      <input type="hidden" name="continue" value="{{ continueUrl }}">
       <input type="submit" class="btn btn-primary btn-lg btn-block" value="{{ t('page_login.sign_in') }}">
     </form>
 
@@ -62,6 +63,7 @@
         <form role="form" action="/login/google" method="get">
           <button type="submit" class="btn btn-block btn-google"><i class="fab fa-google-plus-square"></i> {{ t('page_login.sign_in') }}</button>
           <input type="hidden" name="_csrf" value="{{ csrf() }}">
+          <input type="hidden" name="continue" value="{{ continueUrl }}">
         </form>
       </div>
       {% endif %}
@@ -71,6 +73,7 @@
         <form role="form" action="/login/github" method="get">
           <button type="submit" class="btn btn-block btn-github"><i class="fab fa-github-square"></i> {{ t('page_login.sign_in') }}</button>
           <input type="hidden" name="_csrf" value="{{ csrf() }}">
+          <input type="hidden" name="continue" value="{{ continueUrl }}">
         </form>
       </div>
       {% endif %}

--- a/lib/views/page.html
+++ b/lib/views/page.html
@@ -77,8 +77,6 @@
   data-path="{{ path }}"
   data-path-shortname="{{ path|path2name }}"
   data-page-id="{% if page %}{{ page._id.toString() }}{% endif %}"
-  data-current-user="{% if user %}{{ user._id.toString() }}{% endif %}"
-  data-current-username="{% if user %}{{ user.username }}{% endif %}"
   data-page-revision-id="{% if revision %}{{ revision._id.toString() }}{% endif %}"
   data-page-revision-created="{% if revision %}{{ revision.createdAt|datetz('U') }}{% endif %}"
   data-page-is-seen="{% if page and page.isSeenUser(user) %}1{% else %}0{% endif %}"

--- a/lib/views/page_list.html
+++ b/lib/views/page_list.html
@@ -67,8 +67,6 @@
   data-path-shortname="{{ path|path2name }}"
   data-page-portal="{% if page and page.isPortal() %}1{% else %}0{% endif %}"
   data-page-id="{% if page %}{{ page._id.toString() }}{% endif %}"
-  data-current-user="{% if user %}{{ user._id.toString() }}{% endif %}"
-  data-current-username="{% if user %}{{ user.username }}{% endif %}"
   data-page-revision-id="{% if revision %}{{ revision._id.toString() }}{% endif %}"
   data-page-revision-created="{% if revision %}{{ revision.createdAt|datetz('U') }}{% endif %}"
   data-page-is-seen="{% if page and page.isSeenUser(user) %}1{% else %}0{% endif %}"


### PR DESCRIPTION
# Changes

- Remember a redirect destination for each page.
- Synchronize login state among multiple tabs.
  - Log out on all tabs when a user logouts on any tab.
  - Log in with all tabs when a user logged in.
  - It remembers a page that was opened when logging out automatically, and restores it when logging in again.
- Redirect to the top page when a user who is already logged in displays the login page.