### PR TITLE
Prepare v1.7.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,9 @@
 CHANGES
 ========
 
-## 1.7.0
+## 1.6.5
 
-- TBD
+- Fix: Fix: Can't add page grant correctly with mongodb 3.6 (#325)
 
 ## 1.6.4
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 CHANGES
 ========
 
+## 1.7.0
+
+- TBD
+
 ## 1.6.4
 
 - Fix: Can't unportalize in case (#286)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,25 @@
 CHANGES
 ========
 
+## 1.7.0
+
+- Feature: GitHub Authentication (#282)
+- Feature: Rename a page hierarchy (#301)
+- Feature: Share pages externally (#313, #334)
+- Feature: Group search results by page type (#312)
+- Improve: Support pagination on the search api (Thank you @hirakiuc, #293)
+- Improve: Support bearer token (Thank you @hirakiuc, #299)
+- Fix: Can't add page grant correctly with mongodb 3.6 (#326)
+- Updates: Elasticsearch v6 (#336)
+- Updates: FontAwesome v5 (#288)
+- API Changes:
+    - Add `bookmarks.list` (Thank you @hirakiuc, #296)
+- Dev: Introduce Prettier and ESLint instead of JSHint (#297)
+- And some document updates, package updates. Thank you @onsd @inductor.
+
 ## 1.6.5
 
-- Fix: Fix: Can't add page grant correctly with mongodb 3.6 (#325)
+- Fix: Can't add page grant correctly with mongodb 3.6 (#325)
 
 ## 1.6.4
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Crowi - The Simple & Powerful Communication Tool Based on Wiki
 ================================================================
 
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/crowi/crowi/tree/v1.6.4)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/crowi/crowi/tree/v1.7.0)
 
 [![Circle CI](https://circleci.com/gh/crowi/crowi.svg?style=svg)](https://circleci.com/gh/crowi/crowi)
 [![Join the chat at https://gitter.im/crowi/general](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/crowi/general)
@@ -35,9 +35,9 @@ Don't use `master` branch because it is unstable. Use released version except wh
 Dependencies
 -------------
 
-* Node.js (8.x)
+* Node.js 8.x
 * MongoDB
-* Elasticsearch (optional) ([Doc is here](https://github.com/crowi/crowi/wiki/Configure-Search-Functions))
+* Elasticsearch 6.x (optional) ([Doc is here](https://github.com/crowi/crowi/wiki/Configure-Search-Functions))
 * Redis (optional)
 * Amazon S3 (optional)
 * Google Project (optional)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ docker-compose -f docker-compose.development.yml up
 ### Features
 
 - Express restarts when a file changed
-- Gulp compiled assets automatically
+- webpack compiled assets automatically
 
 #### When a trouble occured
 

--- a/client/components/ExternalShare/AccessLogModal.js
+++ b/client/components/ExternalShare/AccessLogModal.js
@@ -11,6 +11,7 @@ class AccessLogModal extends React.Component {
     super(props)
 
     this.state = {
+      requesting: false,
       pageId: null,
       shares: [],
       pagination: {
@@ -109,7 +110,9 @@ class AccessLogModal extends React.Component {
 
   async getPage(pageId, options = {}) {
     const limit = this.state.pagination.limit
-    if (!this.state.error) {
+    if (!this.state.error && !this.state.requesting) {
+      this.setState({ requesting: true })
+
       try {
         const { share } = await this.props.crowi.apiGet('/shares.list', {
           limit: 5,
@@ -119,9 +122,9 @@ class AccessLogModal extends React.Component {
         })
         const { docs: shares, total, page: current, pages: count } = share
         const pagination = { total, current, count, limit }
-        this.setState({ pageId, shares, pagination })
+        this.setState({ pageId, shares, pagination, requesting: false })
       } catch (err) {
-        this.setState({ error: true })
+        this.setState({ error: true, requesting: false })
       }
     }
   }

--- a/client/components/ExternalShare/AccessLogModal.js
+++ b/client/components/ExternalShare/AccessLogModal.js
@@ -27,13 +27,21 @@ class AccessLogModal extends React.Component {
     this.renderAccessLogTable = this.renderAccessLogTable.bind(this)
   }
 
-  renderShareInfo(uuid, username, name, createdAt) {
+  renderShareInfo(uuid, username, name, createdAt, isActive) {
     const { t } = this.props
     const date = moment(createdAt).format('llll')
     return (
       <div>
         <h4>
-          {t('Share ID')}: <a href={`/_share/${uuid}`}>{uuid}</a>
+          {(isActive && (
+            <span>
+              {t('Share ID')}: <a href={`/_share/${uuid}`}>{uuid}</a> <span className="label label-success">Active</span>
+            </span>
+          )) || (
+            <span>
+              {t('Share ID')}: {uuid} <span className="label label-danger">Inactive</span>
+            </span>
+          )}
         </h4>
         <dl className="share-info">
           <div>
@@ -92,10 +100,11 @@ class AccessLogModal extends React.Component {
       creator: { name, username },
       createdAt,
       accesses,
+      status,
     } = share
     return (
       <div key={i}>
-        {this.renderShareInfo(uuid, username, name, createdAt)}
+        {this.renderShareInfo(uuid, username, name, createdAt, status === 'active')}
         {accesses.length > 0 ? (
           <Table bordered hover condensed>
             {this.renderTableHeader()}

--- a/client/components/PageListSearch.js
+++ b/client/components/PageListSearch.js
@@ -129,13 +129,15 @@ export default class PageListSearch extends React.Component {
     return (
       <div>
         <input type="hidden" name="q" value={this.state.searchingKeyword} onChange={this.handleChange} className="form-control" />
-        <SearchResult
-          tree={this.state.tree}
-          pages={this.state.searchedPages}
-          searchingKeyword={this.state.searchingKeyword}
-          searchResultMeta={this.state.searchResultMeta}
-          searchError={this.state.searchError}
-        />
+        <div className="content-main">
+          <SearchResult
+            tree={this.state.tree}
+            pages={this.state.searchedPages}
+            searchingKeyword={this.state.searchingKeyword}
+            searchResultMeta={this.state.searchResultMeta}
+            searchError={this.state.searchError}
+          />
+        </div>
       </div>
     )
   }

--- a/client/components/RenameTree/RenameTree.js
+++ b/client/components/RenameTree/RenameTree.js
@@ -120,7 +120,7 @@ class RenameTree extends React.Component {
       return (
         <ul className="tree" key={path}>
           <li className="leaf">
-            {name} {isRoot && renderChanges(path)}
+            <a href={`${path}`}>{name}</a> {isRoot && renderChanges(path)}
             {hasNodeErrors && renderNodeErrors(nodeErrors)}
           </li>
           {hasChildren && <li>{renderRoot(children)}</li>}

--- a/client/components/SearchPage/SearchResult.js
+++ b/client/components/SearchPage/SearchResult.js
@@ -7,7 +7,7 @@ import SearchResultList from './SearchResultList'
 // Search.SearchResult
 export default class SearchResult extends React.Component {
   isNotSearchedYet() {
-    return !this.props.searchResultMeta.took
+    return this.props.searchResultMeta.took === undefined
   }
 
   isNotFound() {

--- a/client/components/SearchPage/SearchResult.js
+++ b/client/components/SearchPage/SearchResult.js
@@ -28,7 +28,7 @@ export default class SearchResult extends React.Component {
     // console.log(this.isError());
     if (this.isError()) {
       return (
-        <div className="content-main">
+        <div>
           <i className="searcing fa fa-exclamation-triangle" /> Error on searching.
         </div>
       )
@@ -44,7 +44,7 @@ export default class SearchResult extends React.Component {
         under = ` under "${this.props.tree}"`
       }
       return (
-        <div className="content-main">
+        <div>
           <i className="fa fa-meh" /> No page found with &quot;{this.props.searchingKeyword}&quot;{under}
         </div>
       )

--- a/lib/crowi/index.js
+++ b/lib/crowi/index.js
@@ -288,6 +288,7 @@ Crowi.prototype.start = async function() {
   if (this.redisOpts) {
     const redisAdapter = require('socket.io-redis')
     io.adapter(redisAdapter(this.redisOpts))
+    debug('Using socket.io-redis')
   }
   io.sockets.on('connection', socket => {})
 

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -406,7 +406,7 @@ module.exports = function(crowi) {
 
   pageSchema.statics.isCreatableName = function(name) {
     var forbiddenPages = [
-      /\^|\$|\*|\+|#/,
+      /\^|\$|\*|\+|\?|#/,
       /^\/_.*/, // /_api/* and so on
       /^\/-\/.*/,
       /^\/_r\/.*/,

--- a/lib/models/share.js
+++ b/lib/models/share.js
@@ -60,6 +60,7 @@ module.exports = function(crowi) {
           {
             path: 'accesses',
             populate: { path: 'tracking' },
+            options: { sort: { lastAccessedAt: -1 } },
           },
         ]
       : []
@@ -132,6 +133,7 @@ module.exports = function(crowi) {
   shareSchema.statics.findShareByPageId = async function(pageId, query, options) {
     const self = this
     query = Object.assign({ page: pageId }, query !== undefined ? query : {})
+
     return self.findShare(query, options)
   }
 

--- a/lib/routes/login.js
+++ b/lib/routes/login.js
@@ -160,7 +160,11 @@ module.exports = function(crowi, app) {
           return loginFailure(req, res)
         }
 
-        const { user_id: githubId } = tokenInfo
+        const { organizations, user_id: githubId } = tokenInfo
+        if (organizations && !User.isGitHubAccountValid(organizations)) {
+          clearSession(req)
+          return loginFailure(req, res)
+        }
         User.findUserByGitHubId(githubId, function(err, userData) {
           debug('findUserByGitHubId', err, userData)
           if (!userData) {

--- a/lib/routes/share.js
+++ b/lib/routes/share.js
@@ -92,6 +92,7 @@ module.exports = (crowi, app) => {
     try {
       const shareData = await Share.findShares(query, options)
       const result = { share: shareData }
+
       return res.json(ApiResponse.success(result))
     } catch (err) {
       return res.json(ApiResponse.error(err))
@@ -106,7 +107,7 @@ module.exports = (crowi, app) => {
     }
 
     try {
-      const shareData = await Share.findShareByPageId(pageId, { status: Share.STATUS_ACTIVE }, populateAccesses)
+      const shareData = await Share.findShareByPageId(pageId, { status: Share.STATUS_ACTIVE }, { populateAccesses })
       const result = { share: shareData }
       return res.json(ApiResponse.success(result))
     } catch (err) {

--- a/lib/routes/share.js
+++ b/lib/routes/share.js
@@ -10,11 +10,12 @@ module.exports = (crowi, app) => {
 
   async function firstOrCreateTrackingId(req) {
     const { trackingId } = req.session
+    debug('ShereAccess from session', trackingId)
     if (!trackingId) {
       const userAgent = req.headers['user-agent']
       const remoteAddress = req.headers['x-forwarded-for'] || req.connection.remoteAddress
       const tracking = await Tracking.create({ userAgent, remoteAddress })
-      req.session.trackingId = tracking._id
+      debug('ShereAccess new created', tracking._id)
       return tracking._id
     }
     return trackingId
@@ -27,6 +28,8 @@ module.exports = (crowi, app) => {
     } catch (err) {
       console.error(err)
     }
+
+    return trackingId
   }
 
   function hasAccessAuthority(secretKeywords, { uuid, secretKeyword }) {
@@ -58,13 +61,17 @@ module.exports = (crowi, app) => {
     try {
       const share = await Share.findShareByUuid(uuid, { status: Share.STATUS_ACTIVE })
       const shareId = share.uuid
-      addAccessLog(req, share)
+      const trackingId = await addAccessLog(req, share)
+      req.session.trackingId = trackingId
+
       if (hasAccessAuthority(secretKeywords, share)) {
         req.session.shareIds = updateShareIds(shareIds, uuid)
         const page = share.page
         const { path = '', revision = {} } = page
+
         return res.render('page_share', { hasSecretKeyword: true, shareId, page, path, revision })
       }
+
       return res.render('page_share', { hasSecretKeyword: false, shareId })
     } catch (err) {
       console.error(err)

--- a/lib/util/githubAuth.js
+++ b/lib/util/githubAuth.js
@@ -52,9 +52,9 @@ module.exports = function(config) {
       useGitHubStrategy(config)
       passport.authenticate('github', function(err, user, info) {
         if (err) {
-          callback(err, null)
+          return callback(err, null)
         }
-        callback(err, user)
+        return callback(err, user)
       })(req, res, next)
     }
   }

--- a/lib/util/swigFunctions.js
+++ b/lib/util/swigFunctions.js
@@ -62,7 +62,7 @@ module.exports = function(crowi, app, req, locals) {
   }
 
   locals.isUserPageList = function(path) {
-    if (path.match(/^\/user\/[^/]+\/$/)) {
+    if (path.match(/^\/user\/[^/]+\/$/) || path.match(/^\/user\/$/)) {
       return true
     }
 

--- a/lib/views/page.html
+++ b/lib/views/page.html
@@ -154,14 +154,16 @@
         <i class="fa fa-wrench"></i> <span class="caret"></span>
       </a>
       <ul class="dropdown-menu">
-       <li><a href="#" data-target="#renamePage" data-toggle="modal"><i class="fa fa-share"></i> {{ t('Move') }}</a></li>
        {% if !isUserPage(path) %}
-       <li><a href="#" data-target="#renameTree" data-toggle="modal"><i class="fa fa-share"></i> {{ t('Move pages under', path|path2name ) }}</a></li>
+         <li><a href="#" data-target="#renamePage" data-toggle="modal"><i class="fa fa-share"></i> {{ t('Move') }}</a></li>
+         <li><a href="#" data-target="#renameTree" data-toggle="modal"><i class="fa fa-share"></i> {{ t('Move pages under', path|path2name ) }}</a></li>
        {% endif %}
+
        <li><a href="?presentation=1" class="toggle-presentation"><i class="fa fa-arrows-alt"></i> {{ t('Presentation Mode') }} (beta)</a></li>
+
        {% if isDeletablePage() %}
-       <li class="divider"></li>
-       <li class=""><a href="#" data-target="#deletePage" data-toggle="modal"><i class="fa fa-trash-alt text-danger"></i> {{ t('Delete') }}</a></li>
+         <li class="divider"></li>
+         <li class=""><a href="#" data-target="#deletePage" data-toggle="modal"><i class="fa fa-trash-alt text-danger"></i> {{ t('Delete') }}</a></li>
        {% endif %}
       </ul>
     </li>

--- a/lib/views/page_list.html
+++ b/lib/views/page_list.html
@@ -18,7 +18,7 @@
       <h1 class="title flex-item-title">
         <span id="revision-path">{{ path|insertSpaceToEachSlashes }}</span>
         {% if searchConfigured() && !isTopPage() && !isTrashPage() %}
-        <form class="input-group search-input-group hidden-xs hidden-sm" data-toggle="tooltip" data-placement="bottom" title="{{ path }} 以下から検索" id="search-listpage-form">
+        <form class="input-group search-input-group hidden-xs hidden-sm" data-toggle="tooltip" data-placement="bottom" title="Search pages under '{{ path }}'" id="search-listpage-form">
           <input type="text" class="search-listpage-input form-control" data-path="{{ path }}" id="search-listpage-input">
           <span class="input-group-btn search-listpage-submit-group">
             <button type="submit" class="btn btn-default" id="search-listpage-submit">
@@ -103,9 +103,6 @@
         <i class="fa fa-wrench"></i> <span class="caret"></span>
       </a>
       <ul class="dropdown-menu">
-        {% if !isTopPage() %}
-        <li><a href="#" data-target="#renameTree" data-toggle="modal"><i class="fa fa-share"></i> {{ t('Move pages under', path|path2name ) }}</a></li>
-        {% endif %}
         <li><a href="#" data-target="#unportalize" data-toggle="modal"><i class="fa fa-share"></i> {{ t('Unportalize') }}</a></li>
       </ul>
     </li>

--- a/lib/views/page_presentation.html
+++ b/lib/views/page_presentation.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" type="text/css" href="/js/reveal/lib/css/zenburn.css">
     <link rel="stylesheet" type="text/css" href="/css/reveal/css/theme/black.css">
 
+    <script src="{{ assets('/js/runtime.js') }}"></script>
     <script src="{{ assets('/js/bundled.js') }}"></script>
 
     <title>{{ path|path2name }} | {{ path }}</title>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "crowi",
-  "version": "1.7.0-dev",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowi",
-  "version": "1.7.0-dev",
+  "version": "1.7.0",
   "description": "The simple & powerful Wiki",
   "tags": [
     "wiki",

--- a/tools/webpack.client.js
+++ b/tools/webpack.client.js
@@ -58,6 +58,7 @@ const config = {
     }),
     new CopyWebpackPlugin([
       { from: path.join(ROOT, 'node_modules/reveal.js/css'), to: path.join(ROOT, 'public/css/reveal/css') },
+      { from: path.join(ROOT, 'node_modules/reveal.js/lib/font'), to: path.join(ROOT, 'public/css/reveal/lib/font') },
       { from: path.join(ROOT, 'node_modules/reveal.js/lib/css'), to: path.join(ROOT, 'public/js/reveal/lib/css') },
       { from: path.join(ROOT, 'node_modules/reveal.js/lib/js'), to: path.join(ROOT, 'public/js/reveal/lib/js') },
       { from: path.join(ROOT, 'node_modules/reveal.js/plugin'), to: path.join(ROOT, 'public/js/reveal/plugin/') },


### PR DESCRIPTION
Release v1.7.0

## 1.7.0

- Feature: GitHub Authentication (#282)
- Feature: Rename a page hierarchy (#301)
- Feature: Share pages externally (#313, #334)
- Feature: Group search results by page type (#312)
- Improve: Support pagination on the search api (Thank you @hirakiuc, #293)
- Improve: Support bearer token (Thank you @hirakiuc, #299)
- Fix: Can't add page grant correctly with mongodb 3.6 (#326)
- Updates: Elasticsearch v6 (#336)
- Updates: FontAwesome v5 (#288)
- API Changes:
    - Add `bookmarks.list` (Thank you @hirakiuc, #296)
- Dev: Introduce Prettier and ESLint instead of JSHint (#297)
- And some document updates, package updates. Thank you @onsd @inductor.

----

Related issues: close #269