### PR TITLE
Set the language on pages

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -21,6 +21,7 @@ import SecretKeywordFormContainer from 'components/ExternalShare/SecretKeywordFo
 import AdminShare from 'components/Admin/Share/AdminShare'
 import RenameTree from 'components/RenameTree/RenameTree'
 import Backlink from './components/Backlink'
+import PageLocale from './components/PageLocale/PageLocale'
 
 if (!window) {
   window = {}
@@ -74,6 +75,7 @@ const componentMappings = {
   'share-box': <ShareBox pageId={pageId} crowi={crowi} />,
   'secret-keyword-form-container': <SecretKeywordFormContainer pageId={pageId} crowi={crowi} />,
   'admin-share': <AdminShare pageId={pageId} crowi={crowi} />,
+  'page-locale': <PageLocale pageId={pageId} crowi={crowi} />,
 }
 
 Object.keys(componentMappings).forEach(key => {

--- a/client/app.js
+++ b/client/app.js
@@ -27,7 +27,9 @@ if (!window) {
   window = {}
 }
 
-i18n()
+const { user = {}, config: userConfig = {} } = JSON.parse(document.getElementById('user-context-hydrate').textContent || '{}')
+
+i18n(userConfig)
 
 moment.locale(navigator.userLanguage || navigator.language)
 
@@ -42,10 +44,9 @@ if (mainContent !== null) {
   }
 }
 
-const { user = {} } = JSON.parse(document.getElementById('user-context-hydrate').textContent || '{}')
 const csrfToken = $('#content-main').data('csrftoken')
 // FIXME
-const crowi = new Crowi({ user, csrfToken }, window)
+const crowi = new Crowi({ user, userConfig, csrfToken }, window)
 window.crowi = crowi
 crowi.setConfig(JSON.parse(document.getElementById('crowi-context-hydrate').textContent || '{}'))
 const isSharePage = !!$('#content-main').data('is-share-page') || !!$('#secret-keyword-form-container').data('share-id')

--- a/client/app.js
+++ b/client/app.js
@@ -21,7 +21,7 @@ import SecretKeywordFormContainer from 'components/ExternalShare/SecretKeywordFo
 import AdminShare from 'components/Admin/Share/AdminShare'
 import RenameTree from 'components/RenameTree/RenameTree'
 import Backlink from './components/Backlink'
-import PageLocale from './components/PageLocale/PageLocale'
+import PageLanguage from './components/PageLanguage/PageLanguage'
 
 if (!window) {
   window = {}
@@ -76,7 +76,7 @@ const componentMappings = {
   'share-box': <ShareBox pageId={pageId} crowi={crowi} />,
   'secret-keyword-form-container': <SecretKeywordFormContainer pageId={pageId} crowi={crowi} />,
   'admin-share': <AdminShare pageId={pageId} crowi={crowi} />,
-  'page-locale': <PageLocale pageId={pageId} crowi={crowi} />,
+  'page-language': <PageLanguage pageId={pageId} crowi={crowi} />,
 }
 
 Object.keys(componentMappings).forEach(key => {

--- a/client/components/PageLanguage/PageLanguage.js
+++ b/client/components/PageLanguage/PageLanguage.js
@@ -10,6 +10,7 @@ class PageLanguage extends React.Component {
 
     const languages = this.props.crowi.getLanguages()
     const language = document.getElementById('page-language').dataset.language || this.detectLanguage()
+    const isEditPage = this.isEditPage()
     this.state = {
       rendered: false,
       language,
@@ -18,6 +19,7 @@ class PageLanguage extends React.Component {
         auto: true,
         awaiting: null,
       },
+      isEditPage,
       popoverOpen: false,
     }
 
@@ -26,6 +28,25 @@ class PageLanguage extends React.Component {
     this.toggle = this.toggle.bind(this)
     this.approve = this.approve.bind(this)
     this.reject = this.reject.bind(this)
+
+    this.observeMainContent()
+  }
+
+  isEditPage(element) {
+    element = element || document.getElementById('content-main')
+    return element.className.split(' ').includes('on-edit')
+  }
+
+  observeMainContent() {
+    const observer = new MutationObserver(mutations => {
+      const isEditPage = mutations.some(m => this.isEditPage(m.target))
+      if (isEditPage) {
+        this.onEnter()
+      } else {
+        this.onExit()
+      }
+    })
+    observer.observe(document.getElementById('content-main'), { attributes: true })
   }
 
   removeCodeBlock(markdown) {
@@ -49,7 +70,7 @@ class PageLanguage extends React.Component {
     } = this.state
     if (auto) {
       if (language !== this.state.language) {
-        this.setState({ detector: { awaiting: language } })
+        this.setState({ detector: { auto, awaiting: language } })
         this.show()
       } else {
         this.hide()
@@ -58,7 +79,16 @@ class PageLanguage extends React.Component {
   }
 
   onChange(e) {
-    this.setState({ language: e.target.value })
+    this.setState({ language: e.target.value, detector: { auto: false, awaiting: null } })
+  }
+
+  onEnter() {
+    this.setState({ isEditPage: true })
+    this.updateLanguageField()
+  }
+
+  onExit() {
+    this.setState({ isEditPage: false })
   }
 
   resolveLanguage(language) {
@@ -101,7 +131,7 @@ class PageLanguage extends React.Component {
 
   componentDidMount() {
     document.getElementById('form-body').addEventListener('input', throttle(1000, this.updateLanguageField))
-    setTimeout(this.updateLanguageField, 100)
+    setTimeout(this.updateLanguageField, 400)
   }
 
   render() {
@@ -109,10 +139,12 @@ class PageLanguage extends React.Component {
     const {
       language: languageCode,
       languages,
+      isEditPage,
       popoverOpen,
       detector: { awaiting: detected },
     } = this.state
     const languageName = code => t(`languages.${code}`)
+    const isOpen = isEditPage && popoverOpen
     return (
       <>
         <Input id="pageLanguage" className="mr-2" type="select" name="pageForm[language]" value={languageCode} onChange={this.onChange}>
@@ -122,31 +154,33 @@ class PageLanguage extends React.Component {
             </option>
           ))}
         </Input>
-        <Popover placement="top" isOpen={popoverOpen} target="pageLanguage" toggle={this.toggle}>
-          <PopoverHeader>{t('page_locale.detected_a_new_language')}</PopoverHeader>
-          <PopoverBody>
-            <Table className="mb-2" borderless>
-              <tbody>
-                <tr>
-                  <th scope="row">{t('page_locale.current_language')}</th>
-                  <td>{languageName(languageCode)}</td>
-                </tr>
-                <tr>
-                  <th scope="row">{t('page_locale.detected_language')}</th>
-                  <td>{languageName(detected)}</td>
-                </tr>
-              </tbody>
-            </Table>
-            <div className="d-flex justify-content-end">
-              <Button className="mr-2" color="secondary" size="sm" outline onClick={this.reject}>
-                {t('Cancel')}
-              </Button>
-              <Button color="primary" size="sm" onClick={this.approve}>
-                {t('Change')}
-              </Button>
-            </div>
-          </PopoverBody>
-        </Popover>
+        {isOpen && (
+          <Popover placement="top" isOpen={isOpen} target="pageLanguage" toggle={this.toggle}>
+            <PopoverHeader>{t('page_locale.detected_a_new_language')}</PopoverHeader>
+            <PopoverBody>
+              <Table className="mb-2" borderless>
+                <tbody>
+                  <tr>
+                    <th scope="row">{t('page_locale.current_language')}</th>
+                    <td>{languageName(languageCode)}</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">{t('page_locale.detected_language')}</th>
+                    <td>{languageName(detected)}</td>
+                  </tr>
+                </tbody>
+              </Table>
+              <div className="d-flex justify-content-end">
+                <Button className="mr-2" color="secondary" size="sm" outline onClick={this.reject}>
+                  {t('Cancel')}
+                </Button>
+                <Button color="primary" size="sm" onClick={this.approve}>
+                  {t('Change')}
+                </Button>
+              </div>
+            </PopoverBody>
+          </Popover>
+        )}
       </>
     )
   }

--- a/client/components/PageLanguage/PageLanguage.js
+++ b/client/components/PageLanguage/PageLanguage.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types'
 import { translate } from 'react-i18next'
 import { Input } from 'reactstrap'
 
-class PageLocale extends React.Component {
+class PageLanguage extends React.Component {
   constructor(props) {
     super(props)
 
     const languages = this.props.crowi.getLanguages()
     this.state = {
-      language: document.getElementById('page-locale').dataset.language,
+      language: document.getElementById('page-language').dataset.language,
       languages,
     }
 
@@ -48,12 +48,12 @@ class PageLocale extends React.Component {
   }
 }
 
-PageLocale.propTypes = {
+PageLanguage.propTypes = {
   crowi: PropTypes.object.isRequired,
   pageId: PropTypes.string,
   t: PropTypes.func.isRequired,
 }
 
-PageLocale.defaultProps = {}
+PageLanguage.defaultProps = {}
 
-export default translate()(PageLocale)
+export default translate()(PageLanguage)

--- a/client/components/PageLanguage/PageLanguage.js
+++ b/client/components/PageLanguage/PageLanguage.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { translate } from 'react-i18next'
 import { Input } from 'reactstrap'
+import { throttle } from 'throttle-debounce'
 
 class PageLanguage extends React.Component {
   constructor(props) {
@@ -15,6 +16,7 @@ class PageLanguage extends React.Component {
 
     this.removeCodeBlock = this.removeCodeBlock.bind(this)
     this.updateLanguageField = this.updateLanguageField.bind(this)
+    this.onChange = this.onChange.bind(this)
   }
 
   removeCodeBlock(markdown) {
@@ -31,10 +33,15 @@ class PageLanguage extends React.Component {
     if (language !== this.state.language) {
       this.setState({ language })
     }
+    console.log(language)
+  }
+
+  onChange(e) {
+    this.setState({ language: e.target.value })
   }
 
   componentDidMount() {
-    document.getElementById('form-body').addEventListener('change', this.updateLanguageField)
+    document.getElementById('form-body').addEventListener('input', throttle(1000, this.updateLanguageField))
     this.updateLanguageField()
   }
 
@@ -43,7 +50,7 @@ class PageLanguage extends React.Component {
     const { language: languageCode, languages } = this.state
     const languageName = code => t(`languages.${code}`)
     return (
-      <Input className="mr-2" type="select" name="pageForm[language]" defaultValue={languageCode}>
+      <Input className="mr-2" type="select" name="pageForm[language" value={languageCode} onChange={this.onChange}>
         {languages.map(code => (
           <option key={code} value={code}>
             {languageName(code)}

--- a/client/components/PageLanguage/PageLanguage.js
+++ b/client/components/PageLanguage/PageLanguage.js
@@ -13,11 +13,17 @@ class PageLanguage extends React.Component {
       languages,
     }
 
+    this.removeCodeBlock = this.removeCodeBlock.bind(this)
     this.updateLanguageField = this.updateLanguageField.bind(this)
   }
 
-  async updateLanguageField() {
-    const markdown = document.getElementById('form-body').value
+  removeCodeBlock(markdown) {
+    return markdown.replace(/```\w*\n[\s\S]*?\n```/g, '')
+  }
+
+  updateLanguageField() {
+    const formBody = document.getElementById('form-body').value
+    const markdown = this.removeCodeBlock(formBody)
     const japansese = markdown.match(/[\u30a0-\u30ff\u3040-\u309f\u3005-\u3006\u30e0-\u9fcf]+/g)
     const japaneseLength = japansese === null ? 0 : japansese.map(({ length }) => length).reduce((p, c) => p + c)
     const contentsLength = markdown.length

--- a/client/components/PageLocale/PageLocale.js
+++ b/client/components/PageLocale/PageLocale.js
@@ -1,13 +1,16 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { InputGroup, Input } from 'reactstrap'
+import { translate } from 'react-i18next'
+import { Input } from 'reactstrap'
 
 class PageLocale extends React.Component {
   constructor(props) {
     super(props)
 
+    const languages = this.props.crowi.getLanguages()
     this.state = {
-      language: '',
+      language: document.getElementById('page-locale').dataset.language,
+      languages,
     }
 
     this.updateLanguageField = this.updateLanguageField.bind(this)
@@ -16,7 +19,7 @@ class PageLocale extends React.Component {
   async updateLanguageField() {
     const markdown = document.getElementById('form-body').value
     const japansese = markdown.match(/[\u30a0-\u30ff\u3040-\u309f\u3005-\u3006\u30e0-\u9fcf]+/g)
-    const japaneseLength = japansese.map(({ length }) => length).reduce((p, c) => p + c)
+    const japaneseLength = japansese === null ? 0 : japansese.map(({ length }) => length).reduce((p, c) => p + c)
     const contentsLength = markdown.length
     const language = japaneseLength / contentsLength > 0.1 ? 'ja' : 'en'
     if (language !== this.state.language) {
@@ -30,11 +33,17 @@ class PageLocale extends React.Component {
   }
 
   render() {
-    const { language } = this.state
+    const { t } = this.props
+    const { language: languageCode, languages } = this.state
+    const languageName = code => t(`languages.${code}`)
     return (
-      <InputGroup className="mr-2">
-        <Input defaultValue={language} />
-      </InputGroup>
+      <Input className="mr-2" type="select" name="pageForm[language]" defaultValue={languageCode}>
+        {languages.map(code => (
+          <option key={code} value={code}>
+            {languageName(code)}
+          </option>
+        ))}
+      </Input>
     )
   }
 }
@@ -42,8 +51,9 @@ class PageLocale extends React.Component {
 PageLocale.propTypes = {
   crowi: PropTypes.object.isRequired,
   pageId: PropTypes.string,
+  t: PropTypes.func.isRequired,
 }
 
 PageLocale.defaultProps = {}
 
-export default PageLocale
+export default translate()(PageLocale)

--- a/client/components/PageLocale/PageLocale.js
+++ b/client/components/PageLocale/PageLocale.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { InputGroup, Input } from 'reactstrap'
+
+class PageLocale extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      language: '',
+    }
+
+    this.updateLanguageField = this.updateLanguageField.bind(this)
+  }
+
+  async updateLanguageField() {
+    const markdown = document.getElementById('form-body').value
+    const japansese = markdown.match(/[\u30a0-\u30ff\u3040-\u309f\u3005-\u3006\u30e0-\u9fcf]+/g)
+    const japaneseLength = japansese.map(({ length }) => length).reduce((p, c) => p + c)
+    const contentsLength = markdown.length
+    const language = japaneseLength / contentsLength > 0.1 ? 'ja' : 'en'
+    if (language !== this.state.language) {
+      this.setState({ language })
+    }
+  }
+
+  componentDidMount() {
+    document.getElementById('form-body').addEventListener('change', this.updateLanguageField)
+    this.updateLanguageField()
+  }
+
+  render() {
+    const { language } = this.state
+    return (
+      <InputGroup className="mr-2">
+        <Input defaultValue={language} />
+      </InputGroup>
+    )
+  }
+}
+
+PageLocale.propTypes = {
+  crowi: PropTypes.object.isRequired,
+  pageId: PropTypes.string,
+}
+
+PageLocale.defaultProps = {}
+
+export default PageLocale

--- a/client/components/SearchPage/SearchLanguageDropdown.js
+++ b/client/components/SearchPage/SearchLanguageDropdown.js
@@ -1,0 +1,76 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { translate } from 'react-i18next'
+import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap'
+
+class SearchLanguageDropdown extends React.Component {
+  constructor(props) {
+    super(props)
+
+    const { language: current, crowi } = this.props
+    const languages = crowi.getLanguages()
+    this.state = {
+      open: false,
+      current: current || 'all',
+      languages,
+    }
+
+    this.toggle = this.toggle.bind(this)
+    this.onClick = this.onClick.bind(this)
+  }
+
+  toggle() {
+    this.setState({
+      open: !this.state.open,
+    })
+  }
+
+  onClick(language) {
+    const { changeLanguage } = this.props
+    return () => {
+      if (changeLanguage) {
+        this.setState({ current: language })
+        changeLanguage(language === 'all' ? '' : language)
+      }
+    }
+  }
+
+  getOptions() {
+    const { current, languages } = this.state
+    const all = current !== 'all' ? ['all'] : []
+    const selectable = languages.filter(language => language !== current)
+    return [...all, ...selectable]
+  }
+
+  renderDropdownItem(language) {
+    const { t } = this.props
+    return (
+      <DropdownItem key={language} onClick={this.onClick(language)}>
+        {t(`languages.${language}`)}
+      </DropdownItem>
+    )
+  }
+
+  render() {
+    const { open, current } = this.state
+    const { t } = this.props
+    return (
+      <Dropdown className="search-language-dropdown" isOpen={open} toggle={this.toggle}>
+        <DropdownToggle tag="div" caret>
+          {t(`languages.${current}`)}
+        </DropdownToggle>
+        <DropdownMenu right>{this.getOptions().map(language => this.renderDropdownItem(language))}</DropdownMenu>
+      </Dropdown>
+    )
+  }
+}
+
+SearchLanguageDropdown.propTypes = {
+  language: PropTypes.string,
+  changeLanguage: PropTypes.func.isRequired,
+  t: PropTypes.func.isRequired,
+  crowi: PropTypes.object.isRequired,
+}
+SearchLanguageDropdown.defaultProps = {}
+
+export default translate()(SearchLanguageDropdown)

--- a/client/components/SearchPage/SearchToolbar.js
+++ b/client/components/SearchPage/SearchToolbar.js
@@ -1,33 +1,46 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { translate } from 'react-i18next'
-import { Nav, NavItem, NavLink } from 'reactstrap'
 import Icon from 'components/Common/Icon'
+import SearchTypeTabs from './SearchTypeTabs'
+import SearchLanguageDropdown from './SearchLanguageDropdown'
 
 class SearchToolbar extends React.Component {
   constructor(props) {
     super(props)
 
-    this.searchTypes = ['', 'portal', 'public', 'user']
+    this.state = {
+      query: {},
+    }
 
-    this.getActiveType = this.getActiveType.bind(this)
-    this.onClick = this.onClick.bind(this)
+    this.search = this.search.bind(this)
+    this.changeType = this.changeType.bind(this)
+    this.changeLanguage = this.changeLanguage.bind(this)
   }
 
-  getActiveType() {
-    const defaultType = this.searchTypes[0]
-    const { type } = this.props
-    return this.searchTypes.includes(type) ? type : defaultType
+  search(override) {
+    const { search } = this.props
+    const query = {
+      ...this.state.query,
+      ...override,
+    }
+    this.setState(query)
+    if (search) {
+      search(query)
+    }
   }
 
-  onClick(type) {
-    const { changeType } = this.props
-    return () => changeType && changeType(type)
+  changeType(type) {
+    this.search({ type })
+  }
+
+  changeLanguage(language) {
+    this.search({ language })
   }
 
   render() {
-    const actionType = this.getActiveType()
-    const { t } = this.props
+    const { changeType, changeLanguage } = this
+    const { crowi, t, type, language } = this.props
     return (
       <div className="search-toolbar row">
         <div className="search-meta col-4">
@@ -36,50 +49,27 @@ class SearchToolbar extends React.Component {
             {(this.props.searching && <Icon name="spinner" spin />) || t('search.toolbar.results', { value: this.props.total })}
           </small>
         </div>
-        <nav className="search-navbar col-8">
-          <Nav className="nav navbar-nav">
-            <NavItem active={actionType === this.searchTypes[0]} onClick={this.onClick(this.searchTypes[0])}>
-              <NavLink>
-                <Icon name="th" />
-                {t('page_types.all')}
-              </NavLink>
-            </NavItem>
-            <NavItem active={actionType === this.searchTypes[1]} onClick={this.onClick(this.searchTypes[1])}>
-              <NavLink>
-                <Icon name="circle" regular />
-                {t('page_types.portal')}
-              </NavLink>
-            </NavItem>
-            <NavItem active={actionType === this.searchTypes[2]} onClick={this.onClick(this.searchTypes[2])}>
-              <NavLink>
-                <Icon name="file" regular />
-                {t('page_types.public')}
-              </NavLink>
-            </NavItem>
-            <NavItem active={actionType === this.searchTypes[3]} onClick={this.onClick(this.searchTypes[3])}>
-              <NavLink>
-                <Icon name="user" regular />
-                {t('page_types.user')}
-              </NavLink>
-            </NavItem>
-          </Nav>
-        </nav>
+        <SearchTypeTabs type={type} changeType={changeType} />
+        <SearchLanguageDropdown crowi={crowi} language={language} changeLanguage={changeLanguage} />
       </div>
     )
   }
 }
 
 SearchToolbar.propTypes = {
+  crowi: PropTypes.object.isRequired,
   keyword: PropTypes.string,
+  language: PropTypes.string,
   type: PropTypes.string,
   total: PropTypes.number,
-  changeType: PropTypes.func,
+  search: PropTypes.func,
   searching: PropTypes.bool,
   t: PropTypes.func.isRequired,
 }
 SearchToolbar.defaultProps = {
   keyword: '',
   type: '',
+  language: '',
   searching: false,
   total: 0,
 }

--- a/client/components/SearchPage/SearchTypeTabs.js
+++ b/client/components/SearchPage/SearchTypeTabs.js
@@ -1,0 +1,74 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { translate } from 'react-i18next'
+import { Nav, NavItem, NavLink } from 'reactstrap'
+import Icon from 'components/Common/Icon'
+
+class SearchTypeTabs extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.searchTypes = ['', 'portal', 'public', 'user']
+
+    this.getActiveType = this.getActiveType.bind(this)
+    this.onClick = this.onClick.bind(this)
+  }
+
+  getActiveType() {
+    const defaultType = this.searchTypes[0]
+    const { type } = this.props
+    return this.searchTypes.includes(type) ? type : defaultType
+  }
+
+  onClick(type) {
+    const { changeType } = this.props
+    return () => changeType && changeType(type)
+  }
+
+  render() {
+    const activeType = this.getActiveType()
+    const { t } = this.props
+    return (
+      <nav className="search-type-tabs">
+        <Nav className="nav navbar-nav">
+          <NavItem active={activeType === this.searchTypes[0]} onClick={this.onClick(this.searchTypes[0])}>
+            <NavLink>
+              <Icon name="th" />
+              {t('page_types.all')}
+            </NavLink>
+          </NavItem>
+          <NavItem active={activeType === this.searchTypes[1]} onClick={this.onClick(this.searchTypes[1])}>
+            <NavLink>
+              <Icon name="circle" regular />
+              {t('page_types.portal')}
+            </NavLink>
+          </NavItem>
+          <NavItem active={activeType === this.searchTypes[2]} onClick={this.onClick(this.searchTypes[2])}>
+            <NavLink>
+              <Icon name="file" regular />
+              {t('page_types.public')}
+            </NavLink>
+          </NavItem>
+          <NavItem active={activeType === this.searchTypes[3]} onClick={this.onClick(this.searchTypes[3])}>
+            <NavLink>
+              <Icon name="user" regular />
+              {t('page_types.user')}
+            </NavLink>
+          </NavItem>
+        </Nav>
+      </nav>
+    )
+  }
+}
+
+SearchTypeTabs.propTypes = {
+  type: PropTypes.string.isRequired,
+  changeType: PropTypes.func.isRequired,
+  t: PropTypes.func.isRequired,
+}
+SearchTypeTabs.defaultProps = {
+  keyword: '',
+  type: '',
+}
+
+export default translate()(SearchTypeTabs)

--- a/client/i18n.js
+++ b/client/i18n.js
@@ -5,13 +5,12 @@ import { reactI18nextModule } from 'react-i18next'
 import en from 'locales/en/translation.yml'
 import ja from 'locales/ja/translation.yml'
 
-export default () => {
+export default userConfig => {
   const lngDetector = new LngDetector()
   lngDetector.addDetector({
     name: 'userSetting',
     lookup(options) {
-      const { config = {} } = JSON.parse(document.getElementById('user-context-hydrate').textContent || '{}')
-      const { lang = null } = config
+      const { lang = null } = userConfig
       return lang
     },
     cacheUserLanguage(lng, options) {},

--- a/client/util/Crowi.js
+++ b/client/util/Crowi.js
@@ -26,6 +26,7 @@ export default class Crowi {
     this.userByName = {}
     this.userById = {}
     this.draft = {}
+    this.languages = ['en', 'ja']
 
     this.recoverData()
 
@@ -33,7 +34,7 @@ export default class Crowi {
   }
 
   getContext() {
-    return context
+    return this.context
   }
 
   setConfig(config) {
@@ -148,6 +149,15 @@ export default class Crowi {
     }
 
     return null
+  }
+
+  getLanguages(reorder = true) {
+    const { userConfig = {} } = this.context
+    const { lang = '' } = userConfig
+    if (!reorder) {
+      return this.languages
+    }
+    return [...this.languages.filter(l => l === lang), ...this.languages.filter(l => l !== lang)]
   }
 
   async apiGet(path, params) {

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -819,11 +819,12 @@ module.exports = function(crowi) {
   }
 
   pageSchema.statics.create = function(path, body, user, options) {
-    var Page = this
-    var Revision = crowi.model('Revision')
-    var format = options.format || 'markdown'
-    var grant = options.grant || GRANT_PUBLIC
-    var redirectTo = options.redirectTo || null
+    const Page = this
+    const Revision = crowi.model('Revision')
+    const format = options.format || 'markdown'
+    let grant = options.grant || GRANT_PUBLIC
+    const language = options.language || null
+    const redirectTo = options.redirectTo || null
 
     // force public
     if (isPortalPath(path)) {
@@ -836,7 +837,7 @@ module.exports = function(crowi) {
           return reject(new Error('Cannot create new page to existed path'))
         }
 
-        var newPage = new Page()
+        const newPage = new Page()
         newPage.path = path
         newPage.creator = user
         newPage.lastUpdateUser = user
@@ -853,7 +854,7 @@ module.exports = function(crowi) {
             return reject(err)
           }
 
-          var newRevision = Revision.prepareRevision(newPage, body, user, { format: format })
+          const newRevision = Revision.prepareRevision(newPage, body, user, { format, language })
           Page.pushRevision(newPage, newRevision, user)
             .then(function(data) {
               resolve(data)
@@ -873,8 +874,9 @@ module.exports = function(crowi) {
     const Revision = crowi.model('Revision')
     const Bookmark = crowi.model('Bookmark')
     const grant = options.grant || null
+    const language = options.language || null
     // update existing page
-    const newRevision = Revision.prepareRevision(pageData, body, user)
+    const newRevision = Revision.prepareRevision(pageData, body, user, { language })
 
     return new Promise(async (resolve, reject) => {
       Page.pushRevision(pageData, newRevision, user)

--- a/lib/models/revision.js
+++ b/lib/models/revision.js
@@ -9,7 +9,7 @@ module.exports = function(crowi) {
     body: { type: String, required: true },
     format: { type: String, default: 'markdown' },
     author: { type: ObjectId, ref: 'User' },
-    language: { type: String, enum: ['en', 'ja'] },
+    language: { type: String, enum: ['en', 'ja', ''], default: '' },
     createdAt: { type: Date, default: Date.now },
   })
 

--- a/lib/models/revision.js
+++ b/lib/models/revision.js
@@ -9,6 +9,7 @@ module.exports = function(crowi) {
     body: { type: String, required: true },
     format: { type: String, default: 'markdown' },
     author: { type: ObjectId, ref: 'User' },
+    language: { type: String, enum: ['en', 'ja'] },
     createdAt: { type: Date, default: Date.now },
   })
 
@@ -99,22 +100,24 @@ module.exports = function(crowi) {
   }
 
   revisionSchema.statics.prepareRevision = function(pageData, body, user, options) {
-    var Revision = this
+    const Revision = this
 
     if (!options) {
       options = {}
     }
-    var format = options.format || 'markdown'
+    const format = options.format || 'markdown'
+    const language = options.language || ''
 
     if (!user._id) {
       throw new Error('Error: user should have _id')
     }
 
-    var newRevision = new Revision()
+    const newRevision = new Revision()
     newRevision.path = pageData.path
     newRevision.body = body
     newRevision.format = format
     newRevision.author = user._id
+    newRevision.language = language
     newRevision.createdAt = Date.now()
 
     return newRevision

--- a/lib/routes/admin.js
+++ b/lib/routes/admin.js
@@ -500,5 +500,32 @@ module.exports = function(crowi, app) {
     return res.redirect('/admin/backlink')
   }
 
+  actions.language = {}
+  actions.language.index = function(req, res) {
+    return res.render('admin/language')
+  }
+
+  actions.language.buildLanguages = async function(req, res) {
+    const Revision = crowi.model('Revision')
+
+    const estimateLanguage = document => {
+      const japansese = document.match(/[\u30a0-\u30ff\u3040-\u309f\u3005-\u3006\u30e0-\u9fcf]+/g)
+      const japaneseLength = japansese === null ? 0 : japansese.map(({ length }) => length).reduce((p, c) => p + c)
+      const contentsLength = document.length
+      const language = japaneseLength / contentsLength > 0.1 ? 'ja' : 'en'
+      return language
+    }
+
+    const updater = document => (req.body.delete ? '' : estimateLanguage(document))
+
+    const conditions = req.body.delete ? [{ language: 'en' }, { language: 'ja' }] : [{ language: null }, { language: '' }]
+
+    const revisions = await Revision.find({ $or: conditions })
+    revisions.map(({ _id, body }) => Revision.update({ _id }, { $set: { language: updater(body) } }, err => err && debug(err)))
+
+    req.flash('successMessage', `Now updating ${revisions.length} pages ... this takes a while. Please rebuild elasticsearch indices too.`)
+    return res.redirect('/admin/language')
+  }
+
   return actions
 }

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -91,6 +91,9 @@ module.exports = function(crowi, app) {
   app.get('/admin/backlink', loginRequired(crowi, app), middleware.adminRequired(), admin.backlink.index)
   app.post('/admin/backlink/build', loginRequired(crowi, app), middleware.adminRequired(), csrf, admin.backlink.buildBacklinks)
 
+  app.get('/admin/language', loginRequired(crowi, app), middleware.adminRequired(), admin.language.index)
+  app.post('/admin/language/build', loginRequired(crowi, app), middleware.adminRequired(), csrf, admin.language.buildLanguages)
+
   app.get('/me', loginRequired(crowi, app), me.index)
   app.get('/me/password', loginRequired(crowi, app), me.password)
   app.get('/me/apiToken', loginRequired(crowi, app), me.apiToken)

--- a/lib/routes/page.js
+++ b/lib/routes/page.js
@@ -1,14 +1,14 @@
 module.exports = function(crowi, app) {
   'use strict'
 
-  var debug = require('debug')('crowi:routes:page')
-  var Page = crowi.model('Page')
-  var User = crowi.model('User')
-  var Revision = crowi.model('Revision')
-  var Bookmark = crowi.model('Bookmark')
-  var ApiResponse = require('../util/apiResponse')
-  var sprintf = require('sprintf')
-  var actions = {}
+  const debug = require('debug')('crowi:routes:page')
+  const Page = crowi.model('Page')
+  const User = crowi.model('User')
+  const Revision = crowi.model('Revision')
+  const Bookmark = crowi.model('Bookmark')
+  const ApiResponse = require('../util/apiResponse')
+  const sprintf = require('sprintf')
+  const actions = {}
 
   // register page events
 
@@ -326,21 +326,18 @@ module.exports = function(crowi, app) {
   }
 
   actions.pageEdit = function(req, res) {
-    var pageForm = req.body.pageForm
-    var body = pageForm.body
-    var currentRevision = pageForm.currentRevision
-    var grant = pageForm.grant
-    var path = pageForm.path
+    const { pageForm } = req.body
+    const { body, currentRevision, grant, path, language } = pageForm
 
     // TODO: make it pluggable
-    var notify = pageForm.notify || {}
+    const notify = pageForm.notify || {}
 
     debug('notify: ', notify)
 
-    var redirectPath = encodeURI(path)
-    var pageData = {}
-    var updateOrCreate
-    var previousRevision = false
+    const redirectPath = encodeURI(path)
+    let pageData = {}
+    let updateOrCreate
+    let previousRevision = false
 
     // set to render
     res.locals.pageForm = pageForm
@@ -348,7 +345,6 @@ module.exports = function(crowi, app) {
     // 削除済みページはここで編集不可判定される
     if (!Page.isCreatableName(path)) {
       res.redirect(redirectPath)
-      return
     }
 
     var ignoreNotFound = true
@@ -369,11 +365,11 @@ module.exports = function(crowi, app) {
 
         if (data) {
           previousRevision = data.revision
-          return Page.updatePage(data, body, req.user, { grant: grant })
+          return Page.updatePage(data, body, req.user, { grant, language })
         } else {
           // new page
           updateOrCreate = 'create'
-          return Page.create(path, body, req.user, { grant: grant })
+          return Page.create(path, body, req.user, { grant, language })
         }
       })
       .then(function(data) {

--- a/lib/routes/search.js
+++ b/lib/routes/search.js
@@ -31,7 +31,7 @@ module.exports = function(crowi, app) {
    * @apiParam {String} limit
    */
   api.search = function(req, res) {
-    const { q: keyword = null, tree = null, type = null } = req.query
+    const { q: keyword = null, tree = null, type = null, language } = req.query
     let paginateOpts
 
     try {
@@ -49,7 +49,7 @@ module.exports = function(crowi, app) {
       return res.json(ApiResponse.error('Configuration of ELASTICSEARCH_URI is required.'))
     }
 
-    const searchOpts = { ...paginateOpts, type }
+    const searchOpts = { ...paginateOpts, type, language }
     let doSearch
     if (tree) {
       doSearch = search.searchKeywordUnderPath(keyword, tree, searchOpts)

--- a/lib/util/search.js
+++ b/lib/util/search.js
@@ -148,6 +148,7 @@ SearchClient.prototype.prepareBodyForUpdate = function(body, page) {
       bookmark_count: page.bookmarkCount || 0,
       like_count: page.liker.length || 0,
       updated_at: page.updatedAt,
+      language: page.revision.language,
     },
     doc_as_upsert: true,
   }
@@ -537,14 +538,24 @@ SearchClient.prototype.filterPagesByType = function(query, type) {
   }
 }
 
+SearchClient.prototype.filterPagesByLanguage = function(query, language) {
+  if (language) {
+    query = this.initializeBoolQuery(query)
+    query.body.query.bool.filter.push({ term: { language } })
+  }
+  return query
+}
+
 SearchClient.prototype.searchKeyword = function(keyword, option) {
   const from = option.offset || null
   const size = option.limit || null
   const type = option.type || null
+  const language = option.language || null
   const query = this.createSearchQuerySortedByScore()
   this.appendCriteriaForKeywordContains(query, keyword)
 
   this.filterPagesByType(query, type)
+  this.filterPagesByLanguage(query, language)
 
   this.appendResultSize(query, from, size)
 
@@ -564,11 +575,13 @@ SearchClient.prototype.searchKeywordUnderPath = function(keyword, path, option) 
   const from = option.offset || null
   const size = option.limit || null
   const type = option.type || null
+  const language = option.language || null
   const query = this.createSearchQuerySortedByScore()
   this.appendCriteriaForKeywordContains(query, keyword)
   this.appendCriteriaForPathFilter(query, path)
 
   this.filterPagesByType(query, type)
+  this.filterPagesByLanguage(query, language)
 
   this.appendResultSize(query, from, size)
 

--- a/lib/util/search.js
+++ b/lib/util/search.js
@@ -180,6 +180,7 @@ SearchClient.prototype.prepareBodyForCreate = function(body, page) {
     like_count: page.liker.length || 0,
     created_at: page.createdAt,
     updated_at: page.updatedAt,
+    language: page.revision.language,
   }
 
   body.push(command)

--- a/lib/views/_form.html
+++ b/lib/views/_form.html
@@ -21,6 +21,7 @@
       </button>#}
 
       <div class="form-inline page-form-setting ml-auto" id="page-form-setting" data-slack-configured="{{ slackConfigured() }}">
+        <div id="page-locale"></div>
         {% if slackConfigured() %}
         <span class="input-group extended-setting mr-2">
           <span class="input-group-prepend">

--- a/lib/views/_form.html
+++ b/lib/views/_form.html
@@ -21,7 +21,7 @@
       </button>#}
 
       <div class="form-inline page-form-setting ml-auto" id="page-form-setting" data-slack-configured="{{ slackConfigured() }}">
-        <div id="page-locale"></div>
+        <div id="page-locale" data-language="{{ page.revision.language }}"></div>
         {% if slackConfigured() %}
         <span class="input-group extended-setting mr-2">
           <span class="input-group-prepend">

--- a/lib/views/_form.html
+++ b/lib/views/_form.html
@@ -21,7 +21,7 @@
       </button>#}
 
       <div class="form-inline page-form-setting ml-auto" id="page-form-setting" data-slack-configured="{{ slackConfigured() }}">
-        <div id="page-locale" data-language="{{ page.revision.language }}"></div>
+        <div id="page-language" data-language="{{ page.revision.language }}"></div>
         {% if slackConfigured() %}
         <span class="input-group extended-setting mr-2">
           <span class="input-group-prepend">

--- a/lib/views/admin/backlink.html
+++ b/lib/views/admin/backlink.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block content_main %}
-<div class="content-main">
+<div class="content-main content-form">
   <div class="row">
     <div class="col-md-3">
       {% include './widget/menu.html' with {current: 'backlink'} %}
@@ -39,11 +39,11 @@
       <form action="/admin/backlink/build" method="post" class="form-horizontal" role="form">
       <fieldset>
         <legend>Backlinks Build</legend>
-        <div class="form-group">
-          <label for="" class="col-xs-3 control-label">Backlinks Build</label>
-          <div class="col-xs-6">
+        <div class="form-group row">
+          <label for="" class="offset-1 col-3 control-label">Backlinks Build</label>
+          <div class="col-8">
             <button type="submit" class="btn btn-primary">Build Now</button>
-            <p class="help-block">
+            <p class="help-block mt-2">
               Force rebuild backlinks.<br>
               Click "Build Now" to delete all backlinks and create backlinks by all pages.<br>
               This may take a while.

--- a/lib/views/admin/language.html
+++ b/lib/views/admin/language.html
@@ -1,0 +1,66 @@
+{% extends '../layout/admin.html' %}
+
+{% block html_title %}ページの言語設定 · {{ path }}{% endblock %}
+
+{% block content_head %}
+<div class="header-wrap">
+  <header id="page-header">
+    <h1 class="title" id="">言語設定</h1>
+  </header>
+</div>
+{% endblock %}
+
+{% block content_main %}
+<div class="content-main content-form">
+  <div class="row">
+    <div class="col-md-3">
+      {% include './widget/menu.html' with {current: 'language'} %}
+    </div>
+    <div class="col-md-9">
+
+      {% set smessage = req.flash('successMessage') %}
+      {% if smessage.length %}
+      <div class="alert alert-success">
+        {% for e in smessage %}
+          {{ e }}<br>
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      {% set emessage = req.flash('errorMessage') %}
+      {% if emessage.length %}
+      <div class="alert alert-danger">
+        {% for e in emessage %}
+        {{ e }}<br>
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      <form action="/admin/language/build" method="post" class="form-horizontal" role="form">
+      <fieldset>
+        <legend>Languages Build</legend>
+        <div class="form-group row">
+          <label for="" class="offset-1 col-3 control-label">Languages Build</label>
+          <div class="col-8">
+            <button type="submit" class="btn btn-primary">Build Now</button>
+            <p class="help-block">
+              Click "Build Now" to delete all page language settings and add language settings to all pages.<br>
+              This may take a while.
+            </p>
+          </div>
+          <div class="offset-4 col-8">
+            <button type="submit" class="btn btn-danger" name="delete" value="1">Delete All</button>
+          </div>
+        </div>
+      </fieldset>
+      <input type="hidden" name="_csrf" value="{{ csrf() }}">
+      </form>
+
+    </div>
+  </div>
+
+</div>
+{% endblock content_main %}
+
+{% block content_footer %}
+{% endblock content_footer %}

--- a/lib/views/admin/language.html
+++ b/lib/views/admin/language.html
@@ -38,9 +38,9 @@
 
       <form action="/admin/language/build" method="post" class="form-horizontal" role="form">
       <fieldset>
-        <legend>Languages Build</legend>
+        <legend>Languages Settings</legend>
         <div class="form-group row">
-          <label for="" class="offset-1 col-3 control-label">Languages Build</label>
+          <label for="" class="offset-1 col-3 control-label">Language Settings</label>
           <div class="col-8">
             <button type="submit" class="btn btn-primary">Build Now</button>
             <p class="help-block">

--- a/lib/views/admin/language.html
+++ b/lib/views/admin/language.html
@@ -43,7 +43,7 @@
           <label for="" class="offset-1 col-3 control-label">Language Settings</label>
           <div class="col-8">
             <button type="submit" class="btn btn-primary">Build Now</button>
-            <p class="help-block">
+            <p class="help-block mt-2">
               Click "Build Now" to delete all page language settings and add language settings to all pages.<br>
               This may take a while.
             </p>

--- a/lib/views/admin/search.html
+++ b/lib/views/admin/search.html
@@ -43,7 +43,7 @@
           <label for="" class="offset-1 col-3 control-label">Index Build</label>
           <div class="col-8">
             <button type="submit" class="btn btn-primary">Build Now</button>
-            <p class="help-block">
+            <p class="help-block mt-2">
               Force rebuild index.<br>
               Click "Build Now" to delete and create mapping file and add all pages.<br>
               This may take a while.

--- a/lib/views/admin/widget/menu.html
+++ b/lib/views/admin/widget/menu.html
@@ -11,4 +11,5 @@
   {% endif %}
   <a class="nav-link {% if current == 'share'%}active{% endif %}" href="/admin/share"><i class="fa fa-lock"></i> 外部共有管理</a>
   <a class="nav-link {% if current == 'backlink'%}active{% endif %}" href="/admin/backlink"><i class="fa fa-anchor"></i> バックリンク管理</a>
+  <a class="nav-link {% if current == 'language'%}active{% endif %}" href="/admin/language"><i class="fa fa-language"></i> 言語設定</a>
 </div>

--- a/locales/en-US/translation.yml
+++ b/locales/en-US/translation.yml
@@ -9,6 +9,7 @@ Unlinked: Unlinked
 Seen by: Seen by
 Cancel: Cancel
 Create: Create
+Change: Change
 Admin: Admin
 New: New
 Update: Update
@@ -209,6 +210,11 @@ search:
 admin:
   share:
     enable_external_share: 'Enable to share wiki pages to anonymouse users.'
+
+page_locale:
+  detected_a_new_language: Detected a new language
+  current_language: Current language
+  detected_language: Detected language
 
 languages:
   all: All languages

--- a/locales/en-US/translation.yml
+++ b/locales/en-US/translation.yml
@@ -209,3 +209,8 @@ search:
 admin:
   share:
     enable_external_share: 'Enable to share wiki pages to anonymouse users.'
+
+languages:
+  all: All languages
+  en: English
+  ja: Japanese

--- a/locales/ja/translation.yml
+++ b/locales/ja/translation.yml
@@ -209,3 +209,8 @@ search:
 admin:
   share:
     enable_external_share: 'Wikiページの外部ユーザーへの共有を有効にする。'
+
+languages:
+  all: すべての言語
+  en: 英語
+  ja: 日本語

--- a/locales/ja/translation.yml
+++ b/locales/ja/translation.yml
@@ -9,6 +9,7 @@ Unlinked: リダイレクト削除
 Seen by: 見た人
 Cancel: キャンセル
 Create: 作成
+Change: 変更
 Admin: 管理
 New: 作成
 Update: 更新
@@ -209,6 +210,12 @@ search:
 admin:
   share:
     enable_external_share: 'Wikiページの外部ユーザーへの共有を有効にする。'
+
+page_locale:
+  detected_a_new_language: 新しい言語を検出しました
+  current_language: 現在の言語
+  detected_language: 検出された言語
+
 
 languages:
   all: すべての言語

--- a/package-lock.json
+++ b/package-lock.json
@@ -13608,6 +13608,11 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "throttle-debounce": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.0.1.tgz",
+      "integrity": "sha512-Sr6jZBlWShsAaSXKyNXyNicOrJW/KtkDqIEwHt4wYwWA2wa/q67Luhqoujg48V8hTk60wB56tYrJJn6jc2R7VA=="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10787,7 +10787,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -13468,7 +13468,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "sprintf": "~0.1.5",
     "style-loader": "~0.22.1",
     "swig": "~1.4.0",
+    "throttle-debounce": "^2.0.1",
     "uuid": "^3.2.1",
     "webpack": "^4.16.1",
     "webpack-cli": "^3.1.0",

--- a/resource/css/_search.scss
+++ b/resource/css/_search.scss
@@ -111,7 +111,7 @@
 
 .search-toolbar {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   padding: 0 20px 12px;
   margin: 0 15px 16px;
   border-bottom: 1px solid $border-color;
@@ -131,12 +131,13 @@
     }
   }
 
-  .search-navbar {
+  .search-type-tabs {
     display: flex;
     flex-wrap: wrap;
     position: relative;
     align-items: center;
     padding: 0;
+    flex: 1;
 
     .navbar-nav {
       display: flex;
@@ -148,6 +149,8 @@
       > li {
         white-space: nowrap;
         margin: 4px 0;
+        user-select: none;
+        cursor: pointer;
 
         &:not(:last-child) {
           margin-right: 10px;
@@ -176,6 +179,11 @@
         }
       }
     }
+  }
+
+  .search-language-dropdown {
+    user-select: none;
+    cursor: pointer;
   }
 }
 


### PR DESCRIPTION
# Overview
In order to support multilingualization of contents, implement the function to set the language on the page.

## Features
- Set the language on pages
- Automatic judgment of language
  - The system automatically judges the content language during user editing and suggests it to users
- Migration support
- Specify language and filter search results

## Screens
### Edit Page
<img width="321" src="https://user-images.githubusercontent.com/2351326/45807878-66ab8800-bcff-11e8-8687-9949c2623365.png">

## Search Page
<img width="200" src="https://user-images.githubusercontent.com/2351326/45807895-7034f000-bcff-11e8-8a98-a64086edb2d3.png">

## Admin Page
<img src="https://user-images.githubusercontent.com/2351326/45807935-85aa1a00-bcff-11e8-9b7e-e93bdb39fa33.png">
