### PR TITLE
Disable resize of editor textarea

### DIFF
--- a/resource/css/_form.scss
+++ b/resource/css/_form.scss
@@ -55,6 +55,7 @@
           padding-top: 18px;
           border: none;
           box-shadow: none;
+          resize: none;
 
           &.dragover {
             border: dashed 6px #ccc;


### PR DESCRIPTION
Description
---
画像のようになると戻せないため、これを防ぎたい意図です。
<img width="1269" alt="2018-10-02 12 24 13" src="https://user-images.githubusercontent.com/15062473/46327718-1e189680-c63e-11e8-9e06-fa6e8102ea28.png">

What things I want you to see
---
リサイズ可能であることに意図があるか
