### PR TITLE
fix: strict startWith check

### DIFF
--- a/client/components/RenameTree/RenameTree.js
+++ b/client/components/RenameTree/RenameTree.js
@@ -76,10 +76,22 @@ class RenameTree extends React.Component {
     }
     const treeName = path => path.replace(/\\/g, '/').replace(/\/[^/]*\/?$/, '')
     const getParents = (paths, path) =>
-      paths.filter(p => path !== p && path.startsWith(RenameTree.removeTrailingSlash(p)) && treeName(p) !== treeName(path) && !p.endsWith('/')).sort()
+      paths
+        .filter(
+          p =>
+            path !== p &&
+            // add '/' to check strictly: ex: '/aaa' must not be matched to '/aaa_ccc/yes'
+            path.startsWith(RenameTree.removeTrailingSlash(p) + '/') &&
+            // no same rank
+            treeName(p) !== treeName(path) &&
+            !p.endsWith('/'),
+        )
+        .sort()
+
     Object.keys(pathMap)
       .sort()
       .forEach((path, index, paths) => (tree = index === 0 ? generateRoot(path) : assignRecurcive(tree, getParents(paths, path), path)))
+
     return tree
   }
 


### PR DESCRIPTION
Can't show moved tree, when target tree has document with conditions following:

- let P is parent path.
- let SR is list of same rank pathes of P.
- There are pathes staring with P in SR.
