### PR TITLE
Fix broken layout on extra small devices

### DIFF
--- a/client/components/SearchPage/SearchToolbar.js
+++ b/client/components/SearchPage/SearchToolbar.js
@@ -1,53 +1,60 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { translate } from 'react-i18next'
-import { Nav, NavItem } from 'react-bootstrap'
 import Icon from 'components/Common/Icon'
+import SearchTypeNav from 'components/SearchPage/SearchTypeNav/SearchTypeNav'
 
 class SearchToolbar extends React.Component {
   constructor(props) {
     super(props)
 
-    this.searchTypes = ['', 'portal', 'public', 'user']
+    const { t } = this.props
+    this.searchTypes = [
+      {
+        key: '',
+        icon: <Icon name="th" />,
+        name: t('page_types.all'),
+      },
+      {
+        key: 'portal',
+        icon: <Icon name="circle" regular />,
+        name: t('page_types.portal'),
+      },
+      {
+        key: 'public',
+        icon: <Icon name="file" regular />,
+        name: t('page_types.public'),
+      },
+      {
+        key: 'user',
+        icon: <Icon name="user" regular />,
+        name: t('page_types.user'),
+      },
+    ]
 
     this.getActiveType = this.getActiveType.bind(this)
   }
 
   getActiveType() {
     const defaultType = this.searchTypes[0]
-    const { type } = this.props
-    return this.searchTypes.includes(type) ? type : defaultType
+    const searchTypes = this.searchTypes.reduce((object, { key, icon, name }) => ({ ...object, [key]: { key, icon, name } }), {})
+    const { type: searchType } = this.props
+    return searchType in searchTypes ? searchTypes[searchType] : defaultType
   }
 
   render() {
-    const { t } = this.props
+    const { t, changeType } = this.props
+    const activeType = this.getActiveType()
     return (
       <div className="search-toolbar row">
-        <div className="search-meta col-xs-4">
+        <div className="search-meta col-md-4">
           <h3 className="search-keyword">{this.props.keyword}</h3>
           <small className="text-muted">
             {(this.props.searching && <Icon name="spinner" spin />) || t('search.toolbar.results', { value: this.props.total })}
           </small>
         </div>
-        <nav className="search-navbar col-xs-8">
-          <Nav bsClass="nav navbar-nav" activeKey={this.getActiveType()} onSelect={this.props.changeType}>
-            <NavItem eventKey={this.searchTypes[0]} href="#">
-              <Icon name="th" />
-              {t('page_types.all')}
-            </NavItem>
-            <NavItem eventKey={this.searchTypes[1]} href="#">
-              <Icon name="circle" regular />
-              {t('page_types.portal')}
-            </NavItem>
-            <NavItem eventKey={this.searchTypes[2]} href="#">
-              <Icon name="file" regular />
-              {t('page_types.public')}
-            </NavItem>
-            <NavItem eventKey={this.searchTypes[3]} href="#">
-              <Icon name="user" regular />
-              {t('page_types.user')}
-            </NavItem>
-          </Nav>
+        <nav className="search-navbar col-md-8">
+          <SearchTypeNav searchTypes={this.searchTypes} activeType={activeType} changeType={changeType} />
         </nav>
       </div>
     )

--- a/client/components/SearchPage/SearchTypeNav/SearchTypeButtons.js
+++ b/client/components/SearchPage/SearchTypeNav/SearchTypeButtons.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Nav, NavItem } from 'react-bootstrap'
+
+class SearchTypeButtons extends React.Component {
+  render() {
+    const { searchTypes, activeType, changeType } = this.props
+    const { key: activeKey } = activeType
+    return (
+      <Nav bsClass="nav navbar-nav hidden-xs" activeKey={activeKey} onSelect={changeType}>
+        {searchTypes.map(({ key, icon, name }) => (
+          <NavItem key={key} eventKey={key} href="#">
+            {icon}
+            {name}
+          </NavItem>
+        ))}
+      </Nav>
+    )
+  }
+}
+
+SearchTypeButtons.propTypes = {
+  searchTypes: PropTypes.array.isRequired,
+  activeType: PropTypes.object.isRequired,
+  changeType: PropTypes.func.isRequired,
+}
+SearchTypeButtons.defaultProps = {}
+
+export default SearchTypeButtons

--- a/client/components/SearchPage/SearchTypeNav/SearchTypeDropdown.js
+++ b/client/components/SearchPage/SearchTypeNav/SearchTypeDropdown.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { translate } from 'react-i18next'
+import { DropdownButton, MenuItem } from 'react-bootstrap'
+
+class SearchTypeDropdown extends React.Component {
+  render() {
+    const { t, searchTypes, activeType, changeType } = this.props
+    const { key } = activeType
+    return (
+      <div className="pull-right hidden-sm hidden-md hidden-lg">
+        <DropdownButton title={t('page_type')} key={key} id="search-type-dropdown" pullRight>
+          {searchTypes.map(({ key, icon, name }) => (
+            <MenuItem key={key} eventKey={key} onClick={() => changeType(key)} active={key === activeType.key}>
+              {icon}
+              {name}
+            </MenuItem>
+          ))}
+        </DropdownButton>
+      </div>
+    )
+  }
+}
+
+SearchTypeDropdown.propTypes = {
+  t: PropTypes.func.isRequired,
+  searchTypes: PropTypes.array.isRequired,
+  activeType: PropTypes.object.isRequired,
+  changeType: PropTypes.func.isRequired,
+}
+SearchTypeDropdown.defaultProps = {}
+
+export default translate()(SearchTypeDropdown)

--- a/client/components/SearchPage/SearchTypeNav/SearchTypeNav.js
+++ b/client/components/SearchPage/SearchTypeNav/SearchTypeNav.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import SearchTypeButtons from 'components/SearchPage/SearchTypeNav/SearchTypeButtons'
+import SearchTypeDropdown from 'components/SearchPage/SearchTypeNav/SearchTypeDropdown'
+
+class SearchTypeNav extends React.Component {
+  render() {
+    return (
+      <div>
+        <SearchTypeButtons {...this.props} />
+        <SearchTypeDropdown {...this.props} />
+      </div>
+    )
+  }
+}
+
+SearchTypeNav.propTypes = {
+  searchTypes: PropTypes.array.isRequired,
+  activeType: PropTypes.object.isRequired,
+  changeType: PropTypes.func.isRequired,
+}
+SearchTypeNav.defaultProps = {}
+
+export default SearchTypeNav

--- a/locales/en-US/translation.yml
+++ b/locales/en-US/translation.yml
@@ -169,6 +169,7 @@ share:
     can_not_create: Can't create a link.
     can_not_delete: Can't delete this link.
 
+page_type: Page type
 page_types:
   all: All
   portal: Portal

--- a/locales/ja/translation.yml
+++ b/locales/ja/translation.yml
@@ -169,6 +169,7 @@ share:
     can_not_create: リンクを作成できませんでした。
     can_not_delete: リンクを削除できませんでした。
 
+page_type: ページの種類
 page_types:
   all: すべて
   portal: ポータル

--- a/resource/css/_search.scss
+++ b/resource/css/_search.scss
@@ -128,17 +128,14 @@
 }
 
 .search-toolbar {
-  display: flex;
-  align-items: flex-end;
   padding: 0 20px 12px;
-  margin: 0 15px 16px;
+  margin: 0 0 16px;
   border-bottom: 1px solid $navbar-default-border;
 
   .search-meta {
     display: flex;
     align-items: center;
     padding: 0;
-    padding-right: 40px;
     margin: 4px 0;
 
     h3.search-keyword {
@@ -150,10 +147,7 @@
   }
 
   .search-navbar {
-    display: flex;
-    flex-wrap: wrap;
     position: relative;
-    align-items: center;
     padding: 0;
 
     .navbar-nav {
@@ -175,11 +169,6 @@
           border-radius: 20px;
           border: 1px solid transparent;
 
-          i {
-            width: 14px;
-            margin-right: 8px;
-          }
-
           &:hover {
             background: transparent;
             border-color: $navbar-default-link-active-bg;
@@ -192,6 +181,27 @@
           background: $brand-primary;
         }
       }
+    }
+  }
+
+  .dropdown-menu,
+  .navbar-nav {
+    i {
+      width: 14px;
+      margin-right: 8px;
+    }
+  }
+}
+
+@media (min-width: $screen-md-min) {
+  .search-toolbar {
+    display: flex;
+    align-items: flex-end;
+    margin-right: 15px;
+    margin-left: 15px;
+
+    .search-meta {
+      padding-right: 40px;
     }
   }
 }


### PR DESCRIPTION
# Overview

In the search result page, layout is broken on extra small devices(<768px).

# Changes

1. Use flex layout except for extra small devices
2. Use a dropdown menu instead of buttons on extra small devices

# Screens

![fix-search-result-02](https://user-images.githubusercontent.com/2351326/46781679-caa0f980-cd5d-11e8-9ab5-bc42f33f772a.png)
![fix-search-result-01](https://user-images.githubusercontent.com/2351326/46781680-caa0f980-cd5d-11e8-9f23-280c13951736.png)
