### PR TITLE
Fix: Can't access files on shared pages if it isn't set secret keyword

### DIFF
--- a/lib/util/middlewares.js
+++ b/lib/util/middlewares.js
@@ -217,12 +217,12 @@ exports.fileAccessRightOrLoginRequired = function(crowi, app) {
       const Attachment = crowi.model('Attachment')
       const Share = crowi.model('Share')
       const attachment = await Attachment.findById(req.params.id)
-      const { uuid, secretKeyword = '' } = await Share.findShareByPageId(attachment.page, {
-        status: Share.STATUS_ACTIVE,
-      })
+      const { uuid, secretKeyword } = await Share.findShareByPageId(attachment.page, { status: Share.STATUS_ACTIVE })
       const { shareIds = [], secretKeywords = {} } = req.session
-      const matchPassword = secretKeywords[uuid] === secretKeyword
-      if (matchPassword && shareIds.includes(uuid)) {
+      const hasKeyword = !!secretKeyword
+      const matchKeyword = secretKeywords[uuid] === secretKeyword
+      const hasAccessRight = (!hasKeyword || matchKeyword) && shareIds.includes(uuid)
+      if (hasAccessRight) {
         return next()
       }
     } catch (err) {


### PR DESCRIPTION
# Overview
If **a keyword was not set** on the shared page, a user who was not logged in could not view files.