### PR TITLE
Import blockquote styles from bootstrap3

### DIFF
--- a/resource/css/_wiki.scss
+++ b/resource/css/_wiki.scss
@@ -95,6 +95,8 @@ div.body {
     margin-bottom: 9px;
   }
 
+  // Imported from bootstrap3
+  // Ref: https://github.com/twbs/bootstrap/blob/v3.3.7/dist/css/bootstrap.css#L1477-L1487
   blockquote {
     padding: 10px 20px;
     margin: 0 0 20px;

--- a/resource/css/_wiki.scss
+++ b/resource/css/_wiki.scss
@@ -94,8 +94,18 @@ div.body {
     font-weight: normal;
     margin-bottom: 9px;
   }
+
   blockquote {
-    font-size: .9em;
+    padding: 10px 20px;
+    margin: 0 0 20px;
+    font-size: 0.9em;
+    border-left: 5px solid #eeeeee;
+
+    p, ul, ol {
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
   }
 
   a {


### PR DESCRIPTION
# Overview
Bootstrap 4 does not have the style of blockquote.

# Screens

## Before

![blockquote-before](https://user-images.githubusercontent.com/2351326/47832446-ed608400-ddd8-11e8-8ba9-f8664680b64e.png)

## After 

![blockquote-after](https://user-images.githubusercontent.com/2351326/47832447-ed608400-ddd8-11e8-9fe0-aafb7aac95c4.png)
