### PR TITLE
Not to allow input on API key form

### DIFF
--- a/lib/views/me/api_token.html
+++ b/lib/views/me/api_token.html
@@ -48,7 +48,7 @@
         <label for="" class="col-xs-3 control-label">{{ t('Current API Token') }}</label>
         <div class="col-xs-6">
           {% if user.apiToken %}
-            <input class="form-control" type="text" value="{{ user.apiToken }}">
+            <input class="form-control" type="text" value="{{ user.apiToken }}" readonly>
           {% else %}
           <p class="form-control-static">
             {{ t('page_me_apitoken.notice.apitoken_issued') }}


### PR DESCRIPTION
Can the API key form in `/me/apiToken` be readonly? 
The value is fixed and auto-generated.