### PR TITLE
Fix an issue that error occurs in admin/share page after a shared page was completely deleted

### DIFF
--- a/client/components/Admin/Share/AccessLog.js
+++ b/client/components/Admin/Share/AccessLog.js
@@ -50,9 +50,7 @@ class AccessLog extends React.Component {
     return (
       <tr key={index}>
         <td>{index}</td>
-        <td>
-          <a href={path}>{path}</a>
-        </td>
+        <td>{path ? <a href={path}>{path}</a> : '(Deleted)'}</td>
         <td>{info.name}</td>
         <td>{info.os.toString()}</td>
         <td>{remoteAddress}</td>

--- a/client/components/Admin/Share/AccessLog.js
+++ b/client/components/Admin/Share/AccessLog.js
@@ -66,15 +66,17 @@ class AccessLog extends React.Component {
     const start = (current - 1) * limit + 1
     return (
       <tbody>
-        {this.state.accesses.map(({ share: { page }, tracking: { userAgent, remoteAddress }, lastAccessedAt }, i) =>
-          this.renderRecord({
+        {this.state.accesses.map(({ share, tracking: { userAgent, remoteAddress }, lastAccessedAt }, i) => {
+          const { page } = share || {}
+          const { path = '' } = page || {}
+          return this.renderRecord({
             index: start + i,
-            path: page.path,
+            path,
             info: platform.parse(userAgent),
             remoteAddress,
             date: moment(lastAccessedAt).format('llll'),
-          }),
-        )}
+          })
+        })}
       </tbody>
     )
   }

--- a/client/components/Admin/Share/ShareList.js
+++ b/client/components/Admin/Share/ShareList.js
@@ -56,9 +56,7 @@ class ShareList extends React.Component {
     return (
       <tr key={index}>
         <td>{index}</td>
-        <td>
-          <a href={path}>{path}</a>
-        </td>
+        <td>{path ? <a href={path}>{path}</a> : '(Deleted)'}</td>
         <td>
           <a href={`/user/${username}`}>{name}</a>
         </td>

--- a/client/components/Admin/Share/ShareList.js
+++ b/client/components/Admin/Share/ShareList.js
@@ -73,16 +73,17 @@ class ShareList extends React.Component {
     const start = (current - 1) * limit + 1
     return (
       <tbody>
-        {this.state.shares.map(({ page: { path }, creator: { username, name }, status, createdAt }, i) =>
-          this.renderRecord({
+        {this.state.shares.map(({ page, creator: { username, name }, status, createdAt }, i) => {
+          const { path = '' } = page || {}
+          return this.renderRecord({
             index: start + i,
             path,
             username,
             name,
             date: moment(createdAt).format('llll'),
             isActive: status === 'active',
-          }),
-        )}
+          })
+        })}
       </tbody>
     )
   }

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -928,36 +928,25 @@ module.exports = function(crowi) {
   /**
    * This is danger.
    */
-  pageSchema.statics.completelyDeletePage = function(pageData, user, options) {
+  pageSchema.statics.completelyDeletePage = async function(pageData, user, options) {
     // Delete Bookmarks, Attachments, Revisions, Pages and emit delete
-    var Bookmark = crowi.model('Bookmark')
-    var Attachment = crowi.model('Attachment')
-    var Comment = crowi.model('Comment')
-    var Page = this
-    var pageId = pageData._id
+    const Bookmark = crowi.model('Bookmark')
+    const Attachment = crowi.model('Attachment')
+    const Comment = crowi.model('Comment')
+    const Page = this
+    const pageId = pageData._id
 
     debug('Completely delete', pageData.path)
 
-    return new Promise(function(resolve, reject) {
-      Bookmark.removeBookmarksByPageId(pageId)
-        .then(function(done) {
-          return Attachment.removeAttachmentsByPageId(pageId)
-        })
-        .then(function(done) {
-          return Comment.removeCommentsByPageId(pageId)
-        })
-        .then(function(done) {
-          return Page.removePageById(pageId)
-        })
-        .then(function(done) {
-          return Page.removeRedirectOriginPageByPath(pageData.path)
-        })
-        .then(function(done) {
-          pageEvent.emit('delete', pageData, user) // update as renamed page
-          resolve(pageData)
-        })
-        .catch(reject)
-    })
+    await Bookmark.removeBookmarksByPageId(pageId)
+    await Attachment.removeAttachmentsByPageId(pageId)
+    await Comment.removeCommentsByPageId(pageId)
+    await Page.removePageById(pageId)
+    await Page.removeRedirectOriginPageByPath(pageData.path)
+
+    pageEvent.emit('delete', pageData, user) // update as renamed page
+
+    return pageData
   }
 
   pageSchema.statics.removePage = async function(pageData) {


### PR DESCRIPTION
# Overview
Page ref becomes null when populate share document after shared page deleted.
Therefore, an error occurs in admin/share page.
In this PR, fix this issue.

# Changes

- Show completely deleted pages path as '(Deleted)'

# Screens

![localhost_3000_admin_share ipad](https://user-images.githubusercontent.com/2351326/49564858-6cad1e80-f968-11e8-9e22-3ab3a3951335.png)
