### PR TITLE
performance improvement: reduce the call of localstorage

### DIFF
--- a/client/util/Crowi.js
+++ b/client/util/Crowi.js
@@ -56,10 +56,10 @@ export default class Crowi {
     const keys = ['userByName', 'userById', 'users', 'draft']
 
     keys.forEach(key => {
-      const keyContent = this.localStorage[key];
+      const keyContent = this.localStorage[key]
       if (keyContent) {
         try {
-          this[key] = JSON.parse(keyContent);
+          this[key] = JSON.parse(keyContent)
         } catch (e) {
           this.localStorage.removeItem(key)
         }

--- a/client/util/Crowi.js
+++ b/client/util/Crowi.js
@@ -56,9 +56,10 @@ export default class Crowi {
     const keys = ['userByName', 'userById', 'users', 'draft']
 
     keys.forEach(key => {
-      if (this.localStorage[key]) {
+      const keyContent = this.localStorage[key];
+      if (keyContent) {
         try {
-          this[key] = JSON.parse(this.localStorage[key])
+          this[key] = JSON.parse(keyContent);
         } catch (e) {
           this.localStorage.removeItem(key)
         }


### PR DESCRIPTION
Localstorage is a blocking call.
Dont' use it too frequently.

Here is the performance comparison:
<img width="814" alt="recovermethod" src="https://user-images.githubusercontent.com/4190490/49688684-beb09880-fb50-11e8-8f2c-d66564ddddb8.png">

BTW, should find a way to avoid caching large data (almost 2MB in my Mac). Localstorage is not designed for doing such a thing.