### PR TITLE
Remove meaningless self defination

### DIFF
--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -441,8 +441,7 @@ module.exports = function(crowi) {
   }
 
   pageSchema.statics.exists = async function(query) {
-    const self = this
-    const count = await self.count(query)
+    const count = await this.count(query)
     return count > 0
   }
 

--- a/lib/models/share.js
+++ b/lib/models/share.js
@@ -42,13 +42,11 @@ module.exports = function(crowi) {
   }
 
   shareSchema.statics.isExists = async function(query) {
-    const self = this
-    const count = await self.count(query)
+    const count = await this.count(query)
     return count > 0
   }
 
   shareSchema.statics.findShares = async function(query, options = {}) {
-    const self = this
     const User = crowi.model('User')
     const page = options.page || 1
     const limit = options.limit || 50
@@ -65,7 +63,7 @@ module.exports = function(crowi) {
         ]
       : []
 
-    return self.paginate(query, {
+    return this.paginate(query, {
       page,
       limit,
       sort,
@@ -83,7 +81,6 @@ module.exports = function(crowi) {
   }
 
   shareSchema.statics.findShare = async function(query, options = {}) {
-    const self = this
     const User = crowi.model('User')
     const Page = crowi.model('Page')
 
@@ -97,7 +94,7 @@ module.exports = function(crowi) {
         ]
       : []
 
-    const shareData = await self
+    const shareData = await this
       .findOne(query)
       .populate([
         ...optionalDocs,
@@ -125,16 +122,14 @@ module.exports = function(crowi) {
   }
 
   shareSchema.statics.findShareByUuid = async function(uuid, query, options) {
-    const self = this
     query = Object.assign({ uuid }, query !== undefined ? query : {})
-    return self.findShare(query, options)
+    return this.findShare(query, options)
   }
 
   shareSchema.statics.findShareByPageId = async function(pageId, query, options) {
-    const self = this
     query = Object.assign({ page: pageId }, query !== undefined ? query : {})
 
-    return self.findShare(query, options)
+    return this.findShare(query, options)
   }
 
   shareSchema.statics.create = async function(pageId, user) {

--- a/lib/models/share.js
+++ b/lib/models/share.js
@@ -94,8 +94,7 @@ module.exports = function(crowi) {
         ]
       : []
 
-    const shareData = await this
-      .findOne(query)
+    const shareData = await this.findOne(query)
       .populate([
         ...optionalDocs,
         { path: 'page' },

--- a/lib/models/shareAccess.js
+++ b/lib/models/shareAccess.js
@@ -14,12 +14,11 @@ module.exports = function(crowi) {
   shareAccessSchema.plugin(mongoosePaginate)
 
   shareAccessSchema.statics.findAccesses = async function(query, options = {}) {
-    const self = this
     const page = options.page || 1
     const limit = options.limit || 50
     const sort = options.sort || { lastAccessedAt: -1 }
 
-    return self.paginate(query, {
+    return this.paginate(query, {
       page,
       limit,
       sort,
@@ -38,10 +37,9 @@ module.exports = function(crowi) {
   }
 
   shareAccessSchema.statics.access = async function(shareId, trackingId) {
-    const self = this
     const query = { share: shareId, tracking: trackingId }
     const update = { lastAccessedAt: Date.now() }
-    return self.findOneAndUpdate(query, update, { upsert: true, new: true }).exec()
+    return this.findOneAndUpdate(query, update, { upsert: true, new: true }).exec()
   }
 
   return mongoose.model('ShareAccess', shareAccessSchema)


### PR DESCRIPTION
`self = this` is useful for closures.

However, these codes are not involved in any closure. 

Remove such code, in case of misleading others.