### PR TITLE
improve: merge unrelated awaits to speed up response

### DIFF
--- a/lib/routes/page.js
+++ b/lib/routes/page.js
@@ -69,8 +69,10 @@ module.exports = function(crowi, app) {
     }
 
     try {
-      const portalPage = await Page.hasPortalPage(path, req.user, req.query.revision)
-      const pageList = await Page.findListByStartWith(path, req.user, queryOptions)
+      const [portalPage, pageList] = await Promise.all([
+        Page.hasPortalPage(path, req.user, req.query.revision),
+        Page.findListByStartWith(path, req.user, queryOptions),
+      ])
 
       if (pageList.length > limit) {
         pageList.pop()
@@ -210,9 +212,12 @@ module.exports = function(crowi, app) {
     let createdList = []
     try {
       // user いない場合
-      pageUser = await User.findUserByUsername(username)
-      bookmarkList = await Bookmark.findByUser(pageUser, { limit: 10, populatePage: true, requestUser: req.user })
-      createdList = await Page.findListByCreator(pageUser, { limit: 10 }, req.user)
+      pageUser = await User.findUserByUsername(username)(
+        ([bookmarkList, createdList] = await Promise.all([
+          Bookmark.findByUser(pageUser, { limit: 10, populatePage: true, requestUser: req.user }),
+          Page.findListByCreator(pageUser, { limit: 10 }, req.user),
+        ])),
+      )
     } catch (e) {
       debug('Error while loading user page.', username)
     }

--- a/lib/util/search.js
+++ b/lib/util/search.js
@@ -708,8 +708,7 @@ SearchClient.prototype.syncPageDeleted = function(page, user) {
 SearchClient.prototype.syncBookmarkChanged = async function(pageId) {
   const Page = this.crowi.model('Page')
   const Bookmark = this.crowi.model('Bookmark')
-  const page = await Page.findPageById(pageId)
-  const bookmarkCount = await Bookmark.countByPageId(pageId)
+  const [page, bookmarkCount] = await Promise.all([Page.findPageById(pageId), Bookmark.countByPageId(pageId)])
 
   page.bookmarkCount = bookmarkCount
   this.updatePages([page])


### PR DESCRIPTION
For unrelated await calls, it is better to merge them together for better performance.