### PR TITLE
parseMarkdown  empty table cell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7369,9 +7369,9 @@
       }
     },
     "marked": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.5.2.tgz",
+      "integrity": "sha512-fdZvBa7/vSQIZCi4uuwo2N3q+7jJURpMVCcbaX0S1Mg65WZ5ilXvC67MviJAsdjqqgD+CEq4RKo5AYGgINkVAA=="
     },
     "math-random": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "jquery": "~3.3.1",
     "jquery.cookie": "~1.4.1",
     "json-loader": "^0.5.7",
-    "marked": "~0.4.0",
+    "marked": "^0.5.2",
     "method-override": "~3.0.0",
     "mkdirp": "~0.5.1",
     "moment": "^2.22.2",


### PR DESCRIPTION
## Overview

upgrade marked

marked  0.5.0 fixed empty table cells
https://github.com/markedjs/marked/releases/tag/v0.5.0

## Screens

### before

![2018-12-17 11 05 30](https://user-images.githubusercontent.com/7417867/50062745-31261600-01ec-11e9-8970-c2654419732f.png)

### after

![2018-12-17 11 08 25](https://user-images.githubusercontent.com/7417867/50062748-35523380-01ec-11e9-8779-63ea18011bd7.png)

