### PR TITLE
Add dnscache support

### DIFF
--- a/lib/crowi/index.js
+++ b/lib/crowi/index.js
@@ -90,6 +90,9 @@ Crowi.prototype.init = function() {
     .then(function() {
       return self.setupCsrf()
     })
+    .then(function() {
+      return self.setupDNSCache()
+    })
 }
 
 Crowi.prototype.isPageId = function(pageId) {
@@ -273,6 +276,18 @@ Crowi.prototype.setupCsrf = function() {
   this.tokens = new Tokens()
 
   return Promise.resolve()
+}
+
+Crowi.prototype.setupDNSCache = async function() {
+  /**
+   * Enable dnscache
+   * To prevent slow dns resolution in vm on linux.
+   * In December 2018, linux kernel may have race in conntrack.
+   * See: https://www.weave.works/blog/racy-conntrack-and-dns-lookup-timeouts
+   */
+  if (this.env.ENABLE_DNSCACHE !== 'true') return
+
+  require('dnscache')({ enable: true })
 }
 
 Crowi.prototype.getTokens = function() {


### PR DESCRIPTION
To prevent slow dns resolution in vm on linux.
In December 2018, linux kernel may have race in conntrack.
See: https://www.weave.works/blog/racy-conntrack-and-dns-lookup-timeouts

At crowi, this problem causes very slow responses from `/files/:id`.
