### PR TITLE
Index revisions path

### DIFF
--- a/lib/models/revision.js
+++ b/lib/models/revision.js
@@ -5,7 +5,7 @@ module.exports = function(crowi) {
   var revisionSchema
 
   revisionSchema = new mongoose.Schema({
-    path: { type: String, required: true },
+    path: { type: String, required: true, index: true },
     body: { type: String, required: true },
     format: { type: String, default: 'markdown' },
     author: { type: ObjectId, ref: 'User' },


### PR DESCRIPTION
# Overview
Index revisions path.
Since revision paths are referenced when pages delete or rename, it can be expected that the speed of these operations will be improved.
