### PR TITLE
Fix short path

### DIFF
--- a/client/components/PageList/PagePath.js
+++ b/client/components/PageList/PagePath.js
@@ -3,33 +3,33 @@ import PropTypes from 'prop-types'
 
 export default class PagePath extends React.Component {
   getShortPath(path) {
-    let name = path.replace(/(\/)$/, '')
+    const name = path
 
     // /.../hoge/YYYY/MM/DD 形式のページ
-    if (name.match(/.+\/([^/]+\/\d{4}\/\d{2}\/\d{2})$/)) {
-      return name.replace(/.+\/([^/]+\/\d{4}\/\d{2}\/\d{2})$/, '$1')
+    if (name.match(/.+\/([^/]+\/\d{4}\/\d{2}\/\d{2})\/?$/)) {
+      return name.replace(/.+\/([^/]+\/\d{4}\/\d{2}\/\d{2})\/?$/, '$1')
     }
 
     // /.../hoge/YYYY/MM 形式のページ
-    if (name.match(/.+\/([^/]+\/\d{4}\/\d{2})$/)) {
-      return name.replace(/.+\/([^/]+\/\d{4}\/\d{2})$/, '$1')
+    if (name.match(/.+\/([^/]+\/\d{4}\/\d{2})\/?$/)) {
+      return name.replace(/.+\/([^/]+\/\d{4}\/\d{2})\/?$/, '$1')
     }
 
     // /.../hoge/YYYY 形式のページ
-    if (name.match(/.+\/([^/]+\/\d{4})$/)) {
-      return name.replace(/.+\/([^/]+\/\d{4})$/, '$1')
+    if (name.match(/.+\/([^/]+\/\d{4})\/?$/)) {
+      return name.replace(/.+\/([^/]+\/\d{4})\/?$/, '$1')
     }
 
     // ページの末尾を拾う
-    return name.replace(/.+\/(.+)?$/, '$1')
+    const suffix = name.replace(/.+\/(.+)?$/, '$1')
+    return suffix || name
   }
 
   render() {
     const page = this.props.page
     const pagePath = page.path.replace(this.props.excludePathString.replace(/^\//, ''), '')
     const shortPath = this.getShortPath(pagePath)
-    const shortPathEscaped = shortPath.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
-    const pathPrefix = pagePath.replace(new RegExp(shortPathEscaped + '(/)?$'), '')
+    const pathPrefix = pagePath.slice(0, -shortPath.length)
 
     return (
       <span className="page-path">

--- a/client/crowi.js
+++ b/client/crowi.js
@@ -364,17 +364,14 @@ $(function() {
 
   // list-link
   $('.page-list-link').each(function() {
-    var $link = $(this)
-    var path = $link.data('path')
-    var shortPath = $link.attr('data-short-path')
+    const $link = $(this)
+    const path = $link.attr('data-path')
+    const shortPath = $link.attr('data-short-path')
 
-    var escape = function(s) {
-      return s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
+    if (path !== undefined && shortPath !== undefined) {
+      const pathPrefix = path.slice(0, -shortPath.length)
+      $link.html(`${Crowi.escape(pathPrefix)}<strong>${Crowi.escape(shortPath)}</strong>`)
     }
-    path = Crowi.escape(path)
-    var pattern = escape(Crowi.escape(shortPath)) + '(/)?$'
-
-    $link.html(path.replace(new RegExp(pattern), '<strong>' + shortPath + '$1</strong>'))
   })
 
   // for list page

--- a/lib/util/middlewares.js
+++ b/lib/util/middlewares.js
@@ -58,22 +58,24 @@ exports.swigFunctions = function(crowi, app) {
 exports.swigFilters = function(app, swig) {
   return function(req, res, next) {
     swig.setFilter('path2name', function(string) {
-      var name = string.replace(/(\/)$/, '')
+      const name = string
 
-      if (name.match(/.+\/([^/]+\/\d{4}\/\d{2}\/\d{2})$/)) {
+      if (name.match(/.+\/([^/]+\/\d{4}\/\d{2}\/\d{2})\/?$/)) {
         // /.../hoge/YYYY/MM/DD 形式のページ
-        return name.replace(/.+\/([^/]+\/\d{4}\/\d{2}\/\d{2})$/, '$1')
+        return name.replace(/.+\/([^/]+\/\d{4}\/\d{2}\/\d{2})\/?$/, '$1')
       }
-      if (name.match(/.+\/([^/]+\/\d{4}\/\d{2})$/)) {
+      if (name.match(/.+\/([^/]+\/\d{4}\/\d{2})\/?$/)) {
         // /.../hoge/YYYY/MM 形式のページ
-        return name.replace(/.+\/([^/]+\/\d{4}\/\d{2})$/, '$1')
+        return name.replace(/.+\/([^/]+\/\d{4}\/\d{2})\/?$/, '$1')
       }
-      if (name.match(/.+\/([^/]+\/\d{4})$/)) {
+      if (name.match(/.+\/([^/]+\/\d{4})\/?$/)) {
         // /.../hoge/YYYY 形式のページ
-        return name.replace(/.+\/([^/]+\/\d{4})$/, '$1')
+        return name.replace(/.+\/([^/]+\/\d{4})\/?$/, '$1')
       }
 
-      return name.replace(/.+\/(.+)?$/, '$1') // ページの末尾を拾う
+      // ページの末尾を拾う
+      const suffix = name.replace(/.+\/(.+)?$/, '$1')
+      return suffix || name
     })
 
     swig.setFilter('normalizeDateInPath', function(path) {


### PR DESCRIPTION
# Overview
Portal page paths are incorrectly displayed in search result pages and search suggests.

# Screens
## Before
### Search Results
![](https://user-images.githubusercontent.com/2351326/51666525-6995ec80-2001-11e9-9fb3-1bcf8a062f5d.png)

### Search Suggests
![](https://user-images.githubusercontent.com/2351326/51666014-6c441200-2000-11e9-8d5b-a593435f3d03.png)

## After
### Search Results
![](https://user-images.githubusercontent.com/2351326/51666520-6864bf80-2001-11e9-865d-a1871c7decec.png)

### Search Suggests
![](https://user-images.githubusercontent.com/2351326/51666020-70702f80-2000-11e9-8f3f-9c9f8fbaf764.png)
