### PR TITLE
Rename tree by preserving timestamp

### DIFF
--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -1010,15 +1010,18 @@ module.exports = function(crowi) {
   }
 
   pageSchema.statics.rename = function(pageData, newPagePath, user, options) {
-    var Page = this
-    var Revision = crowi.model('Revision')
-    var path = pageData.path
-    var createRedirectPage = options.createRedirectPage || 0
-    // var moveUnderTrees = options.moveUnderTrees || 0
+    const Page = this
+    const Revision = crowi.model('Revision')
+    const path = pageData.path
+    const createRedirectPage = options.createRedirectPage || false
+    const preserveUpdatedAt = options.preserveUpdatedAt || false
 
     return new Promise(function(resolve, reject) {
+      const updatedAt = preserveUpdatedAt ? {} : { updatedAt: Date.now() }
+      const updateData = { path: newPagePath, lastUpdateUser: user, ...updatedAt }
+
       // pageData の path を変更
-      Page.updatePageProperty(pageData, { updatedAt: Date.now(), path: newPagePath, lastUpdateUser: user })
+      Page.updatePageProperty(pageData, updateData)
         .then(function(data) {
           // reivisions の path を変更
           return Revision.updateRevisionListByPath(path, { path: newPagePath }, {})
@@ -1073,7 +1076,7 @@ module.exports = function(crowi) {
 
   pageSchema.statics.renameTree = async function(pathMap, user, options) {
     const Page = this
-    const { createRedirectPage = false } = options
+    const { createRedirectPage = false, preserveUpdatedAt = true } = options
     await Promise.all(
       Object.values(pathMap).map(async newPath => {
         if (await Page.exists({ path: newPath })) {
@@ -1089,7 +1092,10 @@ module.exports = function(crowi) {
     return Promise.all(
       Object.entries(pathMap).map(async ([oldPath, newPath]) => {
         try {
-          const options = { createRedirectPage: !isPortalPath(newPath) && createRedirectPage }
+          const options = {
+            createRedirectPage: !isPortalPath(newPath) && createRedirectPage,
+            preserveUpdatedAt,
+          }
           const oldPage = await Page.findPageByPath(oldPath)
           await Page.rename(oldPage, newPath, user, options)
           return oldPage

--- a/test/models/page.test.js
+++ b/test/models/page.test.js
@@ -339,7 +339,8 @@ describe('Page', () => {
       const grant = Page.GRANT_PUBLIC
       const grantedUsers = [user]
       const creator = user
-      return paths.map(path => ({ path, grant, grantedUsers, creator }))
+      const updatedAt = Date.now()
+      return paths.map(path => ({ path, grant, grantedUsers, creator, updatedAt }))
     }
 
     before(async () => {
@@ -401,6 +402,29 @@ describe('Page', () => {
       })
 
       afterEach(async () => Page.remove({}))
+    })
+
+    context('Last updated date and time of pages', () => {
+      beforeEach(async () => {
+        await Page.remove({})
+        const paths = ['/hoge', '/hoge/huga', '/hoge/piyo']
+        await testDBUtil.generateFixture(conn, 'Page', generatePages(paths))
+      })
+
+      describe('last updated date and time', () => {
+        it('should not changed', async () => {
+          const pages = await Page.findChildrenByPath('/hoge', user, {})
+
+          const pathMap = Page.getPathMap(pages, '/hoge', '/huga')
+          await Page.renameTree(pathMap, user, {})
+
+          const renamedPages = await Page.findChildrenByPath('/huga', user, {})
+
+          const selectUpdatedAt = pages => pages.map(page => page.updatedAt)
+
+          expect(selectUpdatedAt(pages)).to.deep.equal(selectUpdatedAt(renamedPages))
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
# Overview
The rename tree feature was implemented using the rename feature as it is (https://github.com/crowi/crowi/pull/301).
Therefore, update date and time of each page are updated when renamed tree.

We want to change a hierarchy rather than updating the page when renaming a tree.
In these changes applied, date and time of an updating page will not be updated when renaming a tree.