### PR TITLE
Unfurling links in slack messages

### DIFF
--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -713,11 +713,11 @@ module.exports = function(crowi) {
     return this.findListByStartWith(path, userData, { limit: 0, ...option })
   }
 
-  pageSchema.statics.findUnfurlablePages = async function(type, array) {
+  pageSchema.statics.findUnfurlablePages = async function(type, array, grants = [GRANT_PUBLIC, GRANT_RESTRICTED]) {
     const Page = this
     const page = await Page.find({
       [type]: { $in: array },
-      $or: [{ grant: GRANT_PUBLIC }, { grant: GRANT_RESTRICTED }],
+      $or: grants.map(grant => ({ grant }))
     })
     return page
   }
@@ -729,7 +729,8 @@ module.exports = function(crowi) {
 
   pageSchema.statics.findUnfurlablePagesByPaths = async function(paths) {
     const Page = this
-    return Page.findUnfurlablePages('path', paths)
+    // `GRANT_RESTRICTED` pages can not be accessed using path
+    return Page.findUnfurlablePages('path', paths, [GRANT_PUBLIC])
   }
 
   pageSchema.statics.updatePageProperty = function(page, updateData) {

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -713,20 +713,23 @@ module.exports = function(crowi) {
     return this.findListByStartWith(path, userData, { limit: 0, ...option })
   }
 
-  pageSchema.statics.findUnfurlablePages = async function(paths) {
+  pageSchema.statics.findUnfurlablePages = async function(type, array) {
     const Page = this
     const page = await Page.find({
-      path: { $in: paths },
+      [type]: { $in: array },
       $or: [{ grant: GRANT_PUBLIC }, { grant: GRANT_RESTRICTED }],
     })
-
-    if (page.length === 0) {
-      const pageNotFoundError = new Error('Page Not Found')
-      pageNotFoundError.name = 'Crowi:Page:NotFound'
-      throw pageNotFoundError
-    }
-
     return page
+  }
+
+  pageSchema.statics.findUnfurlablePagesByIds = async function(ids) {
+    const Page = this
+    return Page.findUnfurlablePages('_id', ids)
+  }
+
+  pageSchema.statics.findUnfurlablePagesByPaths = async function(paths) {
+    const Page = this
+    return Page.findUnfurlablePages('path', paths)
   }
 
   pageSchema.statics.updatePageProperty = function(page, updateData) {

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -698,6 +698,19 @@ module.exports = function(crowi) {
     return this.findListByStartWith(path, userData, { limit: 0, ...option })
   }
 
+  pageSchema.statics.findUnfurlablePage = async function(path) {
+    const Page = this
+    const page = await Page.findOne({ path, $or: [{ grant: GRANT_PUBLIC }, { grant: GRANT_RESTRICTED }] })
+
+    if (page === null) {
+      const pageNotFoundError = new Error('Page Not Found')
+      pageNotFoundError.name = 'Crowi:Page:NotFound'
+      throw pageNotFoundError
+    }
+
+    return page
+  }
+
   pageSchema.statics.updatePageProperty = function(page, updateData) {
     var Page = this
     return new Promise(function(resolve, reject) {

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -717,7 +717,7 @@ module.exports = function(crowi) {
     const Page = this
     const page = await Page.find({
       [type]: { $in: array },
-      $or: grants.map(grant => ({ grant }))
+      $or: grants.map(grant => ({ grant })),
     })
     return page
   }

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -301,6 +301,21 @@ module.exports = function(crowi) {
     })
   }
 
+  pageSchema.statics.populatePagesRevision = function(pages, revisions) {
+    const Page = this
+    if (pages.length !== revisions.length) {
+      throw new TypeError('page.length must be equal revisions.length')
+    }
+    pages = pages.map((page, i) => {
+      const revision = revisions[i]
+      if (revision) {
+        page.revision = revision
+      }
+      return page
+    })
+    return Page.populate(pages, { path: 'revision', model: 'Revision' })
+  }
+
   pageSchema.statics.populatePageListToAnyObjects = function(pageIdObjectArray) {
     var Page = this
     var pageIdMappings = {}
@@ -698,11 +713,14 @@ module.exports = function(crowi) {
     return this.findListByStartWith(path, userData, { limit: 0, ...option })
   }
 
-  pageSchema.statics.findUnfurlablePage = async function(path) {
+  pageSchema.statics.findUnfurlablePages = async function(paths) {
     const Page = this
-    const page = await Page.findOne({ path, $or: [{ grant: GRANT_PUBLIC }, { grant: GRANT_RESTRICTED }] })
+    const page = await Page.find({
+      path: { $in: paths },
+      $or: [{ grant: GRANT_PUBLIC }, { grant: GRANT_RESTRICTED }],
+    })
 
-    if (page === null) {
+    if (page.length === 0) {
       const pageNotFoundError = new Error('Page Not Found')
       pageNotFoundError.name = 'Crowi:Page:NotFound'
       throw pageNotFoundError

--- a/lib/routes/admin.js
+++ b/lib/routes/admin.js
@@ -1,15 +1,15 @@
 module.exports = function(crowi, app) {
   'use strict'
 
-  var debug = require('debug')('crowi:routes:admin')
-  var models = crowi.models
-  var User = models.User
-  var Config = models.Config
-  var ApiResponse = require('../util/apiResponse')
-  var MAX_PAGE_LIST = 5
-  var actions = {}
+  const debug = require('debug')('crowi:routes:admin')
+  const models = crowi.models
+  const User = models.User
+  const Config = models.Config
+  const ApiResponse = require('../util/apiResponse')
+  const MAX_PAGE_LIST = 5
+  const actions = {}
 
-  var searchEvent = crowi.event('search')
+  const searchEvent = crowi.event('search')
 
   function createPager(total, limit, page, pagesCount, maxPageList) {
     const pager = {
@@ -99,13 +99,14 @@ module.exports = function(crowi, app) {
   // app.get('/admin/notification'               , admin.notification.index);
   actions.notification = {}
   actions.notification.index = function(req, res) {
-    var config = crowi.getConfig()
-    var UpdatePost = crowi.model('UpdatePost')
-    var slackSetting = Config.setupCofigFormData('notification', config)
-    var hasSlackConfig = Config.hasSlackConfig(config)
-    var hasSlackToken = Config.hasSlackToken(config)
-    var slack = crowi.slack
-    var slackAuthUrl = ''
+    const config = crowi.getConfig()
+    const UpdatePost = crowi.model('UpdatePost')
+    let slackSetting = Config.setupCofigFormData('notification', config)
+    const hasSlackConfig = Config.hasSlackConfig(config)
+    const hasSlackToken = Config.hasSlackToken(config)
+    const slack = crowi.slack
+    let slackAuthUrl = ''
+    const appUrl = config.crowi['app:url']
 
     if (!Config.hasSlackConfig(req.config)) {
       slackSetting['slack:clientId'] = ''
@@ -126,6 +127,7 @@ module.exports = function(crowi, app) {
         hasSlackConfig,
         hasSlackToken,
         slackAuthUrl,
+        appUrl,
       })
     })
   }

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -28,24 +28,42 @@ module.exports = function(crowi, app) {
     res.send(req.body.challenge)
   }
 
+  function parseLink(link) {
+    const { pathname, query } = url.parse(link, true)
+    const pagePath = decodeURIComponent(pathname) || null
+    const revisionId = query.revision || null
+    return { pagePath, revisionId }
+  }
+
+  function parseLinks(links) {
+    const results = {}
+    links.forEach(({ url }) => {
+      const { pagePath, revisionId } = parseLink(url)
+      results[pagePath] = { url, pagePath, revisionId }
+    })
+    return results
+  }
+
   async function unfurl(req, res) {
     const { event } = req.body
     const { links, channel, message_ts: ts } = event
-    const link = links[0]
-    const { pathname, query } = url.parse(link.url, true)
-    const pagePath = decodeURIComponent(pathname) || null
-    const revisionId = query.revision || null
+    const results = parseLinks(links)
+    const pagePaths = Object.keys(results)
 
     try {
-      const page = await Page.findUnfurlablePage(pagePath)
-      const pageData = await Page.populatePageData(page, revisionId)
+      const pages = await Page.findUnfurlablePages(pagePaths)
+      const revisionIds = pages.map(page => page.path).map(path => results[path].revisionId)
+      const revisionIds = pages.map(({ path }) => results[path].revision)
+      const revisionIds = pages.map(({ path }) => results[path].revisionId)
+      const pagesData = await Page.populatePagesRevision(pages, revisionIds)
 
-      const unfurls = {
-        [link.url]: {
-          title: pageData.path,
-          text: slack.prepareAttachmentTextForCreate(pageData),
-        },
-      }
+      const unfurls = {}
+      pagesData.forEach(page => {
+        const { path } = page
+        const { url, pagePath: title } = results[path]
+        const text = slack.prepareAttachmentTextForCreate(page)
+        unfurls[url] = { title, text }
+      })
 
       await slack.unfurl(channel, unfurls, ts)
 

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -34,7 +34,7 @@ module.exports = function(crowi, app) {
     const link = links[0]
     const { pathname, query } = url.parse(link.url, true)
     const pagePath = decodeURIComponent(pathname) || null
-    const revisionId = query.revision_id || null
+    const revisionId = query.revision || null
 
     try {
       const page = await Page.findUnfurlablePage(pagePath)

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -1,14 +1,12 @@
 module.exports = function(crowi, app) {
   'use strict'
 
-  var slack = crowi.slack,
-    Page = crowi.model('Page'),
-    User = crowi.model('User'),
-    actions = {}
+  const { slack } = crowi
+  const Page = crowi.model('Page')
+  const User = crowi.model('User')
 
-  var api = (actions.api = {})
-
-  function fetchPage(link) {}
+  const actions = {}
+  const api = (actions.api = {})
 
   api.handleEvent = function(req, res) {
     if (req.body.type != null && req.body.type == 'url_verification') {
@@ -16,8 +14,8 @@ module.exports = function(crowi, app) {
       return
     }
 
-    let event = req.body.event
-    switch (event.type) {
+    const { type } = req.body.event
+    switch (type) {
       case 'link_shared':
         unfurl(req, res)
         break
@@ -39,33 +37,31 @@ module.exports = function(crowi, app) {
     const channel = req.body.event.channel
     const url = require('url').parse(link.url, true)
 
-    var pagePath = url.path || null
-    var pageId = url.query.page_id || null // TODO: handling
-    var revisionId = url.query.revision_id || null
+    const pagePath = url.path || null
+    const revisionId = url.query.revision_id || null
 
     User.findAllUsers()
       .then(function(users) {
         return Page.findPage(pagePath, users[0], revisionId)
       })
       .then(function(pageData) {
-        let unfurls = {}
-        unfurls[link.url] = {
-          title: pageData.path,
-          text: slack.prepareAttachmentTextForCreate(pageData),
+        const unfurls = {
+          [link.url]: {
+            title: pageData.path,
+            text: slack.prepareAttachmentTextForCreate(pageData),
+          },
         }
 
-        let config = crowi.getConfig()
-        let token = config.notification['slack:token']
-        let postData = {
-          token: token,
-          channel: channel,
+        const config = crowi.getConfig()
+        const token = config.notification['slack:token']
+        const postData = {
+          token,
+          channel,
           ts: req.body.event.message_ts,
           unfurls: encodeURIComponent(JSON.stringify(unfurls)),
         }
 
-        let postDataStr = JSON.stringify(postData)
-
-        let options = {
+        const options = {
           host: HOST,
           port: 443,
           path: PATH + '?token=' + postData['token'] + '&channel=' + postData['channel'] + '&ts=' + postData['ts'] + '&unfurls=' + postData['unfurls'],
@@ -75,7 +71,7 @@ module.exports = function(crowi, app) {
           },
         }
 
-        let slackReq = https.request(options, slackRes => {
+        const slackReq = https.request(options, slackRes => {
           slackRes.setEncoding('utf8')
         })
         slackReq.on('error', e => {

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -48,19 +48,35 @@ module.exports = function(crowi, app) {
     const { event } = req.body
     const { links, channel, message_ts: ts } = event
     const results = parseLinks(links)
-    const pagePaths = Object.keys(results)
+    const keys = Object.keys(results)
+
+    const isObjectId = key => new RegExp('/([0-9a-fA-F]{24})').test(key)
+    const extractObjectId = key => (isObjectId(key) ? RegExp.$1 : null)
+    const isCreatablePath = key => Page.isCreatableName(key)
+
+    const pageIds = keys.map(extractObjectId).filter(key => key !== null)
+    const pagePaths = keys.filter(isCreatablePath)
+
+    const getResult = ({ _id, path }) => (_id && results[`/${_id}`]) || (path && results[path])
 
     try {
-      const pages = await Page.findUnfurlablePages(pagePaths)
-      const revisionIds = pages.map(page => page.path).map(path => results[path].revisionId)
-      const revisionIds = pages.map(({ path }) => results[path].revision)
-      const revisionIds = pages.map(({ path }) => results[path].revisionId)
+      const pagesById = await Page.findUnfurlablePagesByIds(pageIds)
+      const pagesByPaths = await Page.findUnfurlablePagesByPaths(pagePaths)
+      const pages = [...pagesById, ...pagesByPaths]
+
+      if (pages.length === 0) {
+        const pageNotFoundError = new Error('Page Not Found')
+        pageNotFoundError.name = 'Crowi:Page:NotFound'
+        throw pageNotFoundError
+      }
+
+      const revisionIds = pages.map(page => getResult(page).revisionId)
       const pagesData = await Page.populatePagesRevision(pages, revisionIds)
 
       const unfurls = {}
       pagesData.forEach(page => {
-        const { path } = page
-        const { url, pagePath: title } = results[path]
+        const { url } = getResult(page)
+        const { path: title } = page
         const text = slack.prepareAttachmentTextForCreate(page)
         unfurls[url] = { title, text }
       })

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -1,6 +1,7 @@
 module.exports = function(crowi, app) {
   'use strict'
 
+  const debug = require('debug')('crowi:routes:slack')
   const url = require('url')
   const { slack } = crowi
   const Page = crowi.model('Page')
@@ -85,7 +86,7 @@ module.exports = function(crowi, app) {
 
       res.sendStatus(200)
     } catch (err) {
-      console.error('failed to unfurl link: ' + err)
+      debug('Failed to unfurl link:', err)
       res.sendStatus(404)
     }
   }

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -29,12 +29,9 @@ module.exports = function(crowi, app) {
   }
 
   async function unfurl(req, res) {
-    const https = require('https')
-    const HOST = 'slack.com'
-    const PATH = '/api/chat.unfurl'
-
-    const link = req.body.event.links[0]
-    const channel = req.body.event.channel
+    const { event } = req.body
+    const { links, channel, message_ts: ts } = event
+    const link = links[0]
     const url = require('url').parse(link.url, true)
 
     const pagePath = url.path || null
@@ -50,35 +47,11 @@ module.exports = function(crowi, app) {
         },
       }
 
-      const config = crowi.getConfig()
-      const token = config.notification['slack:token']
-      const postData = {
-        token,
-        channel,
-        ts: req.body.event.message_ts,
-        unfurls: encodeURIComponent(JSON.stringify(unfurls)),
-      }
+      await slack.unfurl(channel, unfurls, ts)
 
-      const options = {
-        host: HOST,
-        port: 443,
-        path: PATH + '?token=' + postData['token'] + '&channel=' + postData['channel'] + '&ts=' + postData['ts'] + '&unfurls=' + postData['unfurls'],
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json;charset=utf-8',
-        },
-      }
-
-      const slackReq = https.request(options, slackRes => {
-        slackRes.setEncoding('utf8')
-      })
-      slackReq.on('error', e => {
-        console.error('failed to send a request to Slack: ' + e.message)
-      })
-      slackReq.end()
       res.sendStatus(200)
     } catch (err) {
-      console.error('failed in fetching page: ' + err)
+      console.error('failed to unfurl link: ' + err)
       res.sendStatus(404)
     }
   }

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -1,6 +1,7 @@
 module.exports = function(crowi, app) {
   'use strict'
 
+  const url = require('url')
   const { slack } = crowi
   const Page = crowi.model('Page')
   const User = crowi.model('User')
@@ -32,10 +33,9 @@ module.exports = function(crowi, app) {
     const { event } = req.body
     const { links, channel, message_ts: ts } = event
     const link = links[0]
-    const url = require('url').parse(link.url, true)
-
-    const pagePath = url.path || null
-    const revisionId = url.query.revision_id || null
+    const { pathname, query } = url.parse(link.url, true)
+    const pagePath = decodeURIComponent(pathname) || null
+    const revisionId = query.revision_id || null
 
     try {
       const users = await User.findAllUsers()

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -4,7 +4,6 @@ module.exports = function(crowi, app) {
   const url = require('url')
   const { slack } = crowi
   const Page = crowi.model('Page')
-  const User = crowi.model('User')
 
   const actions = {}
   const api = (actions.api = {})
@@ -38,8 +37,9 @@ module.exports = function(crowi, app) {
     const revisionId = query.revision_id || null
 
     try {
-      const users = await User.findAllUsers()
-      const pageData = await Page.findPage(pagePath, users[0], revisionId)
+      const page = await Page.findUnfurlablePage(pagePath)
+      const pageData = await Page.populatePageData(page, revisionId)
+
       const unfurls = {
         [link.url]: {
           title: pageData.path,

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -78,11 +78,11 @@ module.exports = function(crowi, app) {
           console.error('failed to send a request to Slack: ' + e.message)
         })
         slackReq.end()
-        res.send(200)
+        res.sendStatus(200)
       })
       .catch(function(err) {
         console.error('failed in fetching page: ' + err)
-        res.send(404)
+        res.sendStatus(404)
       })
   }
 

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -1,7 +1,7 @@
 module.exports = function(crowi, app) {
   'use strict'
 
-  var slackHelper = require('../util/slack')(crowi),
+  var slack = crowi.slack,
     Page = crowi.model('Page'),
     User = crowi.model('User'),
     actions = {}
@@ -51,7 +51,7 @@ module.exports = function(crowi, app) {
         let unfurls = {}
         unfurls[link.url] = {
           title: pageData.path,
-          text: slackHelper.prepareAttachmentTextForCreate(pageData),
+          text: slack.prepareAttachmentTextForCreate(pageData),
         }
 
         let config = crowi.getConfig()

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -28,7 +28,7 @@ module.exports = function(crowi, app) {
     res.send(req.body.challenge)
   }
 
-  function unfurl(req, res) {
+  async function unfurl(req, res) {
     const https = require('https')
     const HOST = 'slack.com'
     const PATH = '/api/chat.unfurl'
@@ -40,50 +40,47 @@ module.exports = function(crowi, app) {
     const pagePath = url.path || null
     const revisionId = url.query.revision_id || null
 
-    User.findAllUsers()
-      .then(function(users) {
-        return Page.findPage(pagePath, users[0], revisionId)
-      })
-      .then(function(pageData) {
-        const unfurls = {
-          [link.url]: {
-            title: pageData.path,
-            text: slack.prepareAttachmentTextForCreate(pageData),
-          },
-        }
+    try {
+      const users = await User.findAllUsers()
+      const pageData = await Page.findPage(pagePath, users[0], revisionId)
+      const unfurls = {
+        [link.url]: {
+          title: pageData.path,
+          text: slack.prepareAttachmentTextForCreate(pageData),
+        },
+      }
 
-        const config = crowi.getConfig()
-        const token = config.notification['slack:token']
-        const postData = {
-          token,
-          channel,
-          ts: req.body.event.message_ts,
-          unfurls: encodeURIComponent(JSON.stringify(unfurls)),
-        }
+      const config = crowi.getConfig()
+      const token = config.notification['slack:token']
+      const postData = {
+        token,
+        channel,
+        ts: req.body.event.message_ts,
+        unfurls: encodeURIComponent(JSON.stringify(unfurls)),
+      }
 
-        const options = {
-          host: HOST,
-          port: 443,
-          path: PATH + '?token=' + postData['token'] + '&channel=' + postData['channel'] + '&ts=' + postData['ts'] + '&unfurls=' + postData['unfurls'],
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json;charset=utf-8',
-          },
-        }
+      const options = {
+        host: HOST,
+        port: 443,
+        path: PATH + '?token=' + postData['token'] + '&channel=' + postData['channel'] + '&ts=' + postData['ts'] + '&unfurls=' + postData['unfurls'],
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json;charset=utf-8',
+        },
+      }
 
-        const slackReq = https.request(options, slackRes => {
-          slackRes.setEncoding('utf8')
-        })
-        slackReq.on('error', e => {
-          console.error('failed to send a request to Slack: ' + e.message)
-        })
-        slackReq.end()
-        res.sendStatus(200)
+      const slackReq = https.request(options, slackRes => {
+        slackRes.setEncoding('utf8')
       })
-      .catch(function(err) {
-        console.error('failed in fetching page: ' + err)
-        res.sendStatus(404)
+      slackReq.on('error', e => {
+        console.error('failed to send a request to Slack: ' + e.message)
       })
+      slackReq.end()
+      res.sendStatus(200)
+    } catch (err) {
+      console.error('failed in fetching page: ' + err)
+      res.sendStatus(404)
+    }
   }
 
   return actions

--- a/lib/util/slack.js
+++ b/lib/util/slack.js
@@ -48,8 +48,9 @@ module.exports = function(crowi) {
     if (Config.hasSlackConfig(config)) {
       const slackClientId = config.notification['slack:clientId']
       const redirectUri = slack.getSlackAuthCallbackUrl()
+      const scope = ['chat:write:bot', 'links:write', 'links:read'].join(',')
 
-      return `${SLACK_URL}/oauth/authorize?client_id=${slackClientId}&redirect_uri=${redirectUri}&scope=chat:write:bot`
+      return `${SLACK_URL}/oauth/authorize?client_id=${slackClientId}&redirect_uri=${redirectUri}&scope=${scope}`
     } else {
       return ''
     }

--- a/lib/util/slack.js
+++ b/lib/util/slack.js
@@ -196,5 +196,11 @@ module.exports = function(crowi) {
     return text
   }
 
+  slack.unfurl = function(channel, unfurls, ts) {
+    const client = slack.getClient()
+
+    return client.chat.unfurl({ ts, channel, unfurls })
+  }
+
   return slack
 }

--- a/lib/views/admin/notification.html
+++ b/lib/views/admin/notification.html
@@ -160,9 +160,22 @@
       <h4>2. Get <code>clientId</code> and <code>clientSecret</code></h4>
       <h4>3. After clientId and clientSecret set, click "Connect to Slack" button to start OAuth process.</h4>
       <h4>4. Configure Slack on this notification setting screen</h4>
+
+      <h3>How to enable unfurling links feature</h3>
+      <h4>1. Add permission scopes</h4>
+      <p>
+        Add <code>links:read</code> and <code>links:write</code> permission scopes in <strong>Features > OAuth & Permissions</strong>.
+      </p>
+      <h4>2. Subscribe events from Slack</h4>
+      <p>
+        Fill the form in <strong>Features > Event Subscriptions</strong> out as below:
+      </p>
+      <dl class="dl-horizontal">
+        <dt>Request URL</dt> <dd><code>{{ appUrl }}/_api/slack/event</code> </dd>
+        <dt>Workspace Events</dt> <dd><code>link_shared</code> </dd>
+        <dt>Domains</dt> <dd>Your crowi domains </dd>
+      </dl>
       {% endif %}
-
-
 
     </div>
   </div>

--- a/lib/views/admin/notification.html
+++ b/lib/views/admin/notification.html
@@ -162,11 +162,7 @@
       <h4>4. Configure Slack on this notification setting screen</h4>
 
       <h3>How to enable unfurling links feature</h3>
-      <h4>1. Add permission scopes</h4>
-      <p>
-        Add <code>links:read</code> and <code>links:write</code> permission scopes in <strong>Features > OAuth & Permissions</strong>.
-      </p>
-      <h4>2. Subscribe events from Slack</h4>
+      <h4>1. Subscribe events from Slack</h4>
       <p>
         Fill the form in <strong>Features > Event Subscriptions</strong> out as below:
       </p>


### PR DESCRIPTION
# Overview
Unfurling links in slack messages.

This pull request is based on the following. (#204)
 
@mootoh I took over your commits arbitrarily🙏. Thanks for your great ideas and implementations!

# Changes from the base

- Support encoded characters
- Support multiple paths
- Support page id path style
  - ex. `/5c5040680a258d086c013aba`
- Unfurl page only that it is public or restricted
- Fix revision specification bug
- Some refactorings

# Screens
![lightnet328 slack com_messages_ccc5mjn91_](https://user-images.githubusercontent.com/2351326/52028554-c68a2900-2552-11e9-9a8a-b6e4075476f3.png)
Multiple paths and two path styles

![lightnet328 slack com_messages_ccc5mjn91_ 1](https://user-images.githubusercontent.com/2351326/52028547-beca8480-2552-11e9-9cd3-97ce0b5eb3f5.png)
Links to the same page will be gathered together

# Closes

- Close #204 