### PR TITLE
Improve url representation

### DIFF
--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -21,6 +21,7 @@ module.exports = function(crowi, app) {
   var backlink = require('./backlink')(crowi, app)
   var loginRequired = middleware.loginRequired
   var fileAccessRightOrLoginRequired = middleware.fileAccessRightOrLoginRequired(crowi, app)
+  var encodeSpace = middleware.encodeSpace
   var accessTokenParser = middleware.accessTokenParser(crowi, app)
   var csrf = middleware.csrfVerify(crowi, app)
 
@@ -176,7 +177,7 @@ module.exports = function(crowi, app) {
   app.post('/_/edit', form.revision, loginRequired(crowi, app), csrf, page.pageEdit)
   app.get('/trash/$', loginRequired(crowi, app), page.deletedPageListShow)
   app.get('/trash/*/$', loginRequired(crowi, app), page.deletedPageListShow)
-  app.get('/*/$', loginRequired(crowi, app), page.pageListShow)
+  app.get('/*/$', loginRequired(crowi, app), encodeSpace, page.pageListShow)
   app.get('/user/:username([^/]+)', loginRequired(crowi, app), page.userPageShow)
-  app.get('/*', loginRequired(crowi, app), page.pageShow)
+  app.get('/*', loginRequired(crowi, app), encodeSpace, page.pageShow)
 }

--- a/lib/routes/page.js
+++ b/lib/routes/page.js
@@ -7,6 +7,7 @@ module.exports = function(crowi, app) {
   const Bookmark = crowi.model('Bookmark')
   const Watcher = crowi.model('Watcher')
   const ApiResponse = require('../util/apiResponse')
+  const { decodeSpace } = require('../util/path')
   const sprintf = require('sprintf')
   const actions = {}
 
@@ -18,8 +19,11 @@ module.exports = function(crowi, app) {
   })
 
   function getPathFromRequest(req) {
-    var path = '/' + (req.params[0] || '')
-    return path.replace(/\.md$/, '')
+    let path
+    path = '/' + (req.params[0] || '')
+    path = decodeSpace(path)
+    path = path.replace(/\.md$/, '')
+    return path
   }
 
   // TODO: total とかでちゃんと計算する
@@ -230,66 +234,64 @@ module.exports = function(crowi, app) {
     })
   }
 
-  actions.pageShow = function(req, res) {
-    var path = getPathFromRequest(req)
+  actions.pageShow = async function(req, res) {
+    const path = getPathFromRequest(req)
 
     // FIXME: せっかく getPathFromRequest になってるのにここが生 params[0] だとダサイ
     var isMarkdown = req.params[0].match(/.+\.md$/) || false
 
     res.locals.path = path
-    Page.findPage(path, req.user, req.query.revision)
-      .then(function(page) {
-        debug('Page found', page._id, page.path)
+    try {
+      const page = await Page.findPage(path, req.user, req.query.revision)
+      debug('Page found', page._id, page.path)
 
-        if (isMarkdown) {
-          res.set('Content-Type', 'text/plain')
-          return res.send(page.revision.body)
+      if (isMarkdown) {
+        res.set('Content-Type', 'text/plain')
+        return res.send(page.revision.body)
+      }
+
+      return renderPage(page, req, res)
+    } catch (err) {
+      const normalizedPath = Page.normalizePath(path)
+      if (normalizedPath !== path) {
+        return res.redirect(normalizedPath)
+      }
+
+      // pageShow は /* にマッチしてる最後の砦なので、creatableName でない routing は
+      // これ以前に定義されているはずなので、こうしてしまって問題ない。
+      if (!Page.isCreatableName(path)) {
+        // 削除済みページの場合 /trash 以下に移動しているので creatableName になっていないので、表示を許可
+        debug('Page is not creatable name.', path)
+        res.redirect('/')
+        return
+      }
+      if (req.query.revision) {
+        return res.redirect(encodeURI(path))
+      }
+
+      if (isMarkdown) {
+        return res.redirect('/')
+      }
+
+      try {
+        const portalPage = await Page.hasPortalPage(path + '/', req.user)
+        if (portalPage) {
+          return res.redirect(encodeURI(path) + '/')
+        } else {
+          const fixed = Page.fixToCreatableName(path)
+          if (fixed !== path) {
+            debug('fixed page name', fixed)
+            res.redirect(encodeURI(fixed))
+            return
+          }
+
+          debug('There no page for', `${path}`)
+          return renderPage(null, req, res)
         }
-
-        return renderPage(page, req, res)
-      })
-      .catch(function(err) {
-        const normalizedPath = Page.normalizePath(path)
-        if (normalizedPath !== path) {
-          return res.redirect(normalizedPath)
-        }
-
-        // pageShow は /* にマッチしてる最後の砦なので、creatableName でない routing は
-        // これ以前に定義されているはずなので、こうしてしまって問題ない。
-        if (!Page.isCreatableName(path)) {
-          // 削除済みページの場合 /trash 以下に移動しているので creatableName になっていないので、表示を許可
-          debug('Page is not creatable name.', path)
-          res.redirect('/')
-          return
-        }
-        if (req.query.revision) {
-          return res.redirect(encodeURI(path))
-        }
-
-        if (isMarkdown) {
-          return res.redirect('/')
-        }
-
-        Page.hasPortalPage(path + '/', req.user)
-          .then(function(page) {
-            if (page) {
-              return res.redirect(encodeURI(path) + '/')
-            } else {
-              var fixed = Page.fixToCreatableName(path)
-              if (fixed !== path) {
-                debug('fixed page name', fixed)
-                res.redirect(encodeURI(fixed))
-                return
-              }
-
-              debug('There no page for', `${path}`)
-              return renderPage(null, req, res)
-            }
-          })
-          .catch(function(err) {
-            debug('Error on rendering pageShow (redirect to portal)', err)
-          })
-      })
+      } catch (err) {
+        debug('Error on rendering pageShow (redirect to portal)', err)
+      }
+    }
   }
 
   actions.pageEdit = function(req, res) {

--- a/lib/util/linkDetector.js
+++ b/lib/util/linkDetector.js
@@ -2,7 +2,8 @@ module.exports = function(crowi) {
   'use strict'
 
   // const debug = require('debug')('crowi:lib:url')
-  var linkDetector = {}
+  const linkDetector = {}
+  const { decodeSpace } = require('../util/path')
 
   linkDetector.getLinkRegexp = () => {
     const appUrl = crowi.config.crowi['app:url']
@@ -27,7 +28,7 @@ module.exports = function(crowi) {
     const objectIdRegexp = linkDetector.getObjectIdRegexp()
 
     while (linkRegexp.exec(text)) {
-      var path = decodeURIComponent(RegExp.$1)
+      const path = decodeSpace(decodeURIComponent(RegExp.$1))
       if (objectIdRegexp.test(path)) {
         objectIds.push(RegExp.$1)
       } else {

--- a/lib/util/middlewares.js
+++ b/lib/util/middlewares.js
@@ -1,4 +1,5 @@
-var debug = require('debug')('crowi:lib:middlewares')
+const debug = require('debug')('crowi:lib:middlewares')
+const { encodeSpace } = require('../util/path')
 
 exports.loginChecker = function(crowi, app) {
   return function(req, res, next) {
@@ -300,4 +301,15 @@ exports.awsEnabled = function() {
 
     return next()
   }
+}
+
+exports.encodeSpace = (req, res, next) => {
+  const path = decodeURIComponent(req.originalUrl || '')
+  const encodedPath = encodeSpace(path)
+
+  if (path !== encodedPath) {
+    return res.redirect(encodedPath)
+  }
+
+  return next()
 }

--- a/lib/util/path.js
+++ b/lib/util/path.js
@@ -1,0 +1,8 @@
+module.exports = {
+  encodeSpace(s) {
+    return s.replace(/ /g, '+')
+  },
+  decodeSpace(s) {
+    return s.replace(/\+/g, ' ')
+  },
+}


### PR DESCRIPTION
# Overview
Spaces included in paths are encoded in `%20` in URLs.
In this pull request, replace `%20` with `+` because `%20` is annoying.

# Behaviours

- Paths including spaces or `%20` are redirected to paths replaced spaces and `%20` with `+`
  - In fact, spaces equals `%20` when server recieve requests
  - So we need to think only about `%20`

- Paths not including spaces or `%20` are decoded instead of being redirected