### PR TITLE
Fix an issue that can't create "share" object

### DIFF
--- a/lib/models/share.js
+++ b/lib/models/share.js
@@ -107,12 +107,7 @@ module.exports = function(crowi) {
           select: User.USER_PUBLIC_FIELDS,
         },
       ])
-      .exec((err, shareData) => {
-        if (err) {
-          throw err
-        }
-        return shareData
-      })
+      .exec()
 
     if (shareData === null) {
       const shareNotFoundError = new Error('Share Not Found')


### PR DESCRIPTION
# Overview
This problem occurs in the branch under `dev/1.8`.
I consider that the cause is an update of MongoDB and mongoose.
