### PR TITLE
fix: correct shortpath for portals

### DIFF
--- a/client/components/PageList/PagePath.js
+++ b/client/components/PageList/PagePath.js
@@ -21,7 +21,7 @@ export default class PagePath extends React.Component {
     }
 
     // ページの末尾を拾う
-    const suffix = name.replace(/.+\/(.+)?$/, '$1')
+    const suffix = name.replace(/.+\/(.+)$/, '$1')
     return suffix || name
   }
 


### PR DESCRIPTION
currently, `shortpath()` for portal path doesn't work correctly.