### PR TITLE
chore: Add Redirect URLs help to how to setup Slack Integration

### DIFF
--- a/lib/views/admin/notification.html
+++ b/lib/views/admin/notification.html
@@ -152,6 +152,7 @@
         <dt>Icon</dt> <dd>Upload this image as the icon (Free to download and use it) =&gt; <a href="https://github.com/crowi/crowi/tree/master/resource/logo">Crowi Logo</a></dd>
         <dt>Short description</dt> <dd><code>Crowi's Slack Notification Integration</code> </dd>
         <dt>Long description</dt> <dd><code>Crowi's Slack Notification Integration</code> </dd>
+        <dt>Redirect URL</dt> <dd><code>{{ baseUrl }}/admin/notification/slackAuth</code> </dd>
       </dl>
       <p>
       and <strong>Save</strong> it.


### PR DESCRIPTION
## Overview

I added the explanation about Redirect URL to the explanation flow of Slack integration.

It is necessary setting to enable Slack integration, But it's description is not exist in `How to configure Slack app for Crowi`.

Thanks.

## Screen Shot

### Before

<img width="921" alt="Screen Shot 2019-05-10 at 15 30 51" src="https://user-images.githubusercontent.com/6993514/57507062-a085d900-7338-11e9-81f4-2d52a68c3659.png">

### After

<img width="935" alt="Screen Shot 2019-05-10 at 15 29 02" src="https://user-images.githubusercontent.com/6993514/57506990-5e5c9780-7338-11e9-96e7-9ef87d74f3b3.png">
