### PR TITLE
Fix notification layout

### DIFF
--- a/lib/views/me/notifications.html
+++ b/lib/views/me/notifications.html
@@ -1,4 +1,4 @@
-{% extends '../layout/2column.html' %}
+{% extends '../layout/single.html' %}
 
 {% block html_title %}Notifications · {{ path }}{% endblock %}
 


### PR DESCRIPTION
# Overview

`/me`, `/me/password` and `/me/apiToken` uses single layout.
I changed `/me/notifications` layout.