### PR TITLE
Change from alpine image to stretch-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.12.0-alpine as builder
+FROM node:10.16.0-stretch-slim as builder
 
 ARG NODE_ENV="production"
 
@@ -16,7 +16,7 @@ ADD . .
 RUN npm run postinstall
 
 
-FROM node:8.12.0-alpine
+FROM node:10.16.0-stretch-slim
 
 ARG NODE_ENV="production"
 

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -24,7 +24,7 @@ services:
       - elasticsearch
       - redis
       - plantuml
-    command: sh -c "npm install && npm run dev"
+    command: bash -c "npm install && npm run dev"
 
   mongodb:
     image: mongo:3.6.3


### PR DESCRIPTION
# Background
We changed the base image of Docker from Debian Stretch to Alpine. #446
As MongoDB does not provide binary files for Alpine, mongodb-memory-server has stopped working.

# Changes
To fix this problem, change the base image to a lightweight Debian Stretch image (stretch-slim).
This change will increase the size of the image by about 100 MB.
