### PR TITLE
Change short path format

### DIFF
--- a/client/components/PageList/PagePath.js
+++ b/client/components/PageList/PagePath.js
@@ -5,19 +5,19 @@ export default class PagePath extends React.Component {
   getShortPath(path) {
     const name = path
 
-    // /.../hoge/YYYY/MM/DD 形式のページ
-    if (name.match(/.+\/([^/]+\/\d{4}\/\d{2}\/\d{2})\/?$/)) {
-      return name.replace(/.+\/([^/]+\/\d{4}\/\d{2}\/\d{2})\/?$/, '$1')
+    // /.../YYYY/MM/DD 形式のページ
+    if (name.match(/^.*?([^/]+\/\d{4}\/\d{2}\/\d{2})\/?$/)) {
+      return name.replace(/^.*?([^/]+\/\d{4}\/\d{2}\/\d{2})\/?$/, '$1')
     }
 
-    // /.../hoge/YYYY/MM 形式のページ
-    if (name.match(/.+\/([^/]+\/\d{4}\/\d{2})\/?$/)) {
-      return name.replace(/.+\/([^/]+\/\d{4}\/\d{2})\/?$/, '$1')
+    // /.../YYYY/MM 形式のページ
+    if (name.match(/^.*?([^/]+\/\d{4}\/\d{2})\/?$/)) {
+      return name.replace(/^.*?([^/]+\/\d{4}\/\d{2})\/?$/, '$1')
     }
 
-    // /.../hoge/YYYY 形式のページ
-    if (name.match(/.+\/([^/]+\/\d{4})\/?$/)) {
-      return name.replace(/.+\/([^/]+\/\d{4})\/?$/, '$1')
+    // /.../YYYY 形式のページ
+    if (name.match(/^.*?([^/]+\/\d{4})\/?$/)) {
+      return name.replace(/^.*?([^/]+\/\d{4})\/?$/, '$1')
     }
 
     // ページの末尾を拾う

--- a/lib/util/middlewares.js
+++ b/lib/util/middlewares.js
@@ -60,17 +60,21 @@ exports.swigFilters = function(app, swig) {
     swig.setFilter('path2name', function(string) {
       const name = string
 
-      if (name.match(/.+\/([^/]+\/\d{4}\/\d{2}\/\d{2})\/?$/)) {
-        // /.../hoge/YYYY/MM/DD 形式のページ
-        return name.replace(/.+\/([^/]+\/\d{4}\/\d{2}\/\d{2})\/?$/, '$1')
+      console.log(name)
+
+      // /.../YYYY/MM/DD 形式のページ
+      if (name.match(/^.*?([^/]+\/\d{4}\/\d{2}\/\d{2})\/?$/)) {
+        return name.replace(/^.*?([^/]+\/\d{4}\/\d{2}\/\d{2})\/?$/, '$1')
       }
-      if (name.match(/.+\/([^/]+\/\d{4}\/\d{2})\/?$/)) {
-        // /.../hoge/YYYY/MM 形式のページ
-        return name.replace(/.+\/([^/]+\/\d{4}\/\d{2})\/?$/, '$1')
+
+      // /.../YYYY/MM 形式のページ
+      if (name.match(/^.*?([^/]+\/\d{4}\/\d{2})\/?$/)) {
+        return name.replace(/^.*?([^/]+\/\d{4}\/\d{2})\/?$/, '$1')
       }
-      if (name.match(/.+\/([^/]+\/\d{4})\/?$/)) {
-        // /.../hoge/YYYY 形式のページ
-        return name.replace(/.+\/([^/]+\/\d{4})\/?$/, '$1')
+
+      // /.../YYYY 形式のページ
+      if (name.match(/^.*?([^/]+\/\d{4})\/?$/)) {
+        return name.replace(/^.*?([^/]+\/\d{4})\/?$/, '$1')
       }
 
       // ページの末尾を拾う


### PR DESCRIPTION
# Overview

Currently, a short path got from path `hoge/YYYY/MM/DD` is `DD`.
In this PR, it path pattern will be shortened to `hoge/YYY/MM/DD`.

# Cases

| Path | Before | After |
|:--|:--|:--|
| `hoge/YYYY/MM/DD` | `DD` | `hoge/YYYY/MM/DD` |
| `hoge/YYYY/MM` | `MM` | `hoge/YYYY/MM` |
| `hoge/YYYY` | `YYYY` | `hoge/YYYY` |
| `hoge/huga/YYYY/MM/DD` | `huga/YYYY/MM/DD` | `huga/YYYY/MM/DD` |
| `hoge/huga/YYYY/MM` | `huga/YYYY/MM/DD` | `huga/YYYY/MM/DD` |
| `hoge/huga/YYYY` | `huga/YYYY/MM/DD` | `huga/YYYY/MM/DD` |

# Test

Since Jest has not been introduced yet, I will write the test code here.
It is available from v1.8. See #373.

```javascript
const assert = require('assert')

const cases = [
  ['/hoge/huga', 'huga'],
  ['/hoge/2019/06/01', 'hoge/2019/06/01'],
  ['/hoge/2019/06', 'hoge/2019/06'],
  ['/hoge/2019', 'hoge/2019'],
  ['/hoge/huga/2019/06/01', 'huga/2019/06/01'],
  ['/hoge/huga/2019/06', 'huga/2019/06'],
  ['/hoge/huga/2019', 'huga/2019'],
]

function getShortPath(name) {
  const YYYYMMDD = /^.*?([^/]+\/\d{4}\/\d{2}\/\d{2})\/?$/
  const YYYYMM = /^.*?([^/]+\/\d{4}\/\d{2})\/?$/
  const YYYY = /^.*?([^/]+\/\d{4})\/?$/

  if (name.match(YYYYMMDD)) return name.replace(YYYYMMDD, '$1')
  if (name.match(YYYYMM)) return name.replace(YYYYMM, '$1')
  if (name.match(YYYY)) return name.replace(YYYY, '$1')

  const suffix = name.replace(/.+\/(.+)?$/, '$1')
  return suffix || name
}

for (const [input, output] of cases) {
  assert.equal(getShortPath(input), output)
}
```