### PR TITLE
Reload fields depends on config even when config updated in another node

### DIFF
--- a/lib/crowi/index.js
+++ b/lib/crowi/index.js
@@ -136,11 +136,12 @@ Crowi.prototype.setupConfigPubSub = function() {
     debug('PubSubId', this.pubSubId)
 
     if (this.subscriber) {
-      this.subscriber.on('message', (channel, message) => {
+      this.subscriber.on('message', async (channel, message) => {
         if (channel !== this.configPubSubChannel) return
         const { pubSubId, config } = JSON.parse(message)
         if (pubSubId === this.pubSubId) return
         this.config = config
+        await Promise.all([this.setupSlack(), this.setupMailer()])
         debug(`Config updated by ${pubSubId}`)
       })
 


### PR DESCRIPTION
Overview
---
#8 was resolved by https://github.com/crowi/crowi/pull/435. But it doesn't include reloading some instances that depends on config.
This PR adds it.
