### PR TITLE
Fix app crash when opening notification settings page after installed

### DIFF
--- a/lib/routes/admin.js
+++ b/lib/routes/admin.js
@@ -98,19 +98,14 @@ module.exports = function(crowi, app) {
   actions.notification.index = function(req, res) {
     const config = crowi.getConfig()
     const UpdatePost = crowi.model('UpdatePost')
-    let slackSetting = config.notification || {}
     const hasSlackConfig = Config.hasSlackConfig(config)
     const hasSlackToken = Config.hasSlackToken(config)
     const slack = crowi.slack
-    let slackAuthUrl = ''
     const appUrl = config.crowi['app:url']
 
-    if (!Config.hasSlackConfig(config)) {
-      slackSetting['slack:clientId'] = ''
-      slackSetting['slack:clientSecret'] = ''
-    } else {
-      slackAuthUrl = slack.getAuthorizeURL()
-    }
+    const defaultSlackSetting = { 'slack:clientId': '', 'slack:clientSecret': '' }
+    let slackSetting = hasSlackConfig ? config.notification : defaultSlackSetting
+    const slackAuthUrl = hasSlackConfig ? slack.getAuthorizeURL() : ''
 
     if (req.session.slackSetting) {
       slackSetting = req.session.slackSetting
@@ -135,7 +130,7 @@ module.exports = function(crowi, app) {
 
     req.session.slackSetting = slackSetting
     if (req.form.isValid) {
-      Config.updateConfigByNamespace('notification', slackSetting)
+      await Config.updateConfigByNamespace('notification', slackSetting)
       req.session.slackSetting = null
 
       await crowi.setupSlack()


### PR DESCRIPTION
# Overview
Fix app crash when opening notification settings page after installed.
This issue occurs after #435 is merged and does not affect existing releases.