### PR TITLE
Fix some configs will not be updated on multi apps issue

### DIFF
--- a/lib/crowi/index.js
+++ b/lib/crowi/index.js
@@ -86,9 +86,20 @@ class Crowi {
     }
   }
 
+  applyNewConfig(config) {
+    // FIXME: Make the config object immutable by reassignment.
+    //        We should always get config using `crowi.getConfig()` *just before* referencing config.
+    for (const key of Object.keys(this.config)) {
+      delete this.config[key]
+    }
+    for (const key of Object.keys(config)) {
+      this.config[key] = config[key]
+    }
+  }
+
   setConfig(config) {
     this.publishConfig(config)
-    this.config = config
+    this.applyNewConfig(config)
   }
 
   getConfig() {
@@ -113,7 +124,7 @@ class Crowi {
           if (pubSubId === this.pubSubId) {
             return
           }
-          this.config = config
+          this.applyNewConfig(config)
           await Promise.all([this.setupSlack(), this.setupMailer()])
           debug(`Config updated by ${pubSubId}`)
         })


### PR DESCRIPTION
# Problem

Some configs will not be updated on multi apps issue.

# Reproduce

1. Start Crowi on multiple machines and load config
2. All instances initialize publihser and subscriber and publish config to PubSub
3. Routes initializations are completed
   - *Several routes read config at this time*
4. *Subscribers receives configs and the config is updated except for the last instance started*
   - The first published message is lost because there are no other Subscribers
   - *The config of the last subscribed instance is not updated because other instances already published*
5. When Config is updated, route's config becomes an object different from Config by copy-on-write
6. `config.crowi['app: url']` is set when get an HTTP request
7. Refer to `config.crowi['app: url']` when logging in to Google
8. *An error occurs because `config.crowi['app: url']` becomes `undefined` and so the route's config is different from the Config except for the last instance*

![スクリーンショット 2019-07-05 0 33 00](https://user-images.githubusercontent.com/2351326/60697631-30559700-9f26-11e9-9f58-56c7821d3641.png)
