### PR TITLE
Reload config when config updated on other instance

### DIFF
--- a/lib/crowi/index.js
+++ b/lib/crowi/index.js
@@ -79,10 +79,10 @@ class Crowi {
     }
   }
 
-  publishConfig(config) {
+  notifyConfigUpdated() {
     if (this.publisher) {
       const { configPubSubChannel, pubSubId } = this
-      this.publisher.publish(configPubSubChannel, JSON.stringify({ pubSubId, config }))
+      this.publisher.publish(configPubSubChannel, JSON.stringify({ pubSubId }))
     }
   }
 
@@ -98,7 +98,7 @@ class Crowi {
   }
 
   setConfig(config) {
-    this.publishConfig(config)
+    this.notifyConfigUpdated(config)
     this.applyNewConfig(config)
   }
 
@@ -107,6 +107,8 @@ class Crowi {
   }
 
   setupConfigPubSub() {
+    const Config = this.model('Config')
+
     if (this.redisOpts) {
       const redis = require('redis')
       this.publisher = redis.createClient(this.redisOpts)
@@ -119,13 +121,17 @@ class Crowi {
           if (channel !== this.configPubSubChannel) {
             return
           }
-          const { pubSubId, config } = JSON.parse(message)
 
+          const { pubSubId } = JSON.parse(message)
           if (pubSubId === this.pubSubId) {
             return
           }
+
+          const config = await Config.loadAllConfig()
           this.applyNewConfig(config)
+
           await Promise.all([this.setupSlack(), this.setupMailer()])
+
           debug(`Config updated by ${pubSubId}`)
         })
 

--- a/lib/crowi/index.js
+++ b/lib/crowi/index.js
@@ -5,7 +5,6 @@ const pkg = require('../../package.json')
 const path = require('path')
 const sep = path.sep
 const mongoose = require('mongoose')
-const uuidv4 = require('uuid/v4')
 const models = require('../models')
 
 class Crowi {
@@ -40,11 +39,6 @@ class Crowi {
     this.redisUrl = this.env.REDISTOGO_URL || this.env.REDIS_URL || null
     this.redisOpts = this.buildRedisOpts(this.redisUrl)
 
-    this.pubSubId = uuidv4()
-    this.publisher = null
-    this.subscriber = null
-    this.configPubSubChannel = 'config'
-
     this.events = {
       user: new (require(this.eventsDir + 'user'))(this),
       page: new (require(this.eventsDir + 'page'))(this),
@@ -59,7 +53,6 @@ class Crowi {
     await this.setupModels()
     await this.setupRedisClient()
     await this.setupSessionConfig()
-    await this.setupConfigPubSub()
     await this.setupConfig()
     await this.setupSearcher()
     await this.setupMailer()
@@ -79,65 +72,12 @@ class Crowi {
     }
   }
 
-  notifyConfigUpdated() {
-    if (this.publisher) {
-      const { configPubSubChannel, pubSubId } = this
-      this.publisher.publish(configPubSubChannel, JSON.stringify({ pubSubId }))
-    }
-  }
-
-  applyNewConfig(config) {
-    // FIXME: Make the config object immutable by reassignment.
-    //        We should always get config using `crowi.getConfig()` *just before* referencing config.
-    for (const key of Object.keys(this.config)) {
-      delete this.config[key]
-    }
-    for (const key of Object.keys(config)) {
-      this.config[key] = config[key]
-    }
-  }
-
   setConfig(config) {
-    this.notifyConfigUpdated(config)
-    this.applyNewConfig(config)
+    this.config.update(config)
   }
 
   getConfig() {
-    return this.config || {}
-  }
-
-  setupConfigPubSub() {
-    const Config = this.model('Config')
-
-    if (this.redisOpts) {
-      const redis = require('redis')
-      this.publisher = redis.createClient(this.redisOpts)
-      this.subscriber = redis.createClient(this.redisOpts)
-
-      debug('PubSubId', this.pubSubId)
-
-      if (this.subscriber) {
-        this.subscriber.on('message', async (channel, message) => {
-          if (channel !== this.configPubSubChannel) {
-            return
-          }
-
-          const { pubSubId } = JSON.parse(message)
-          if (pubSubId === this.pubSubId) {
-            return
-          }
-
-          const config = await Config.loadAllConfig()
-          this.applyNewConfig(config)
-
-          await Promise.all([this.setupSlack(), this.setupMailer()])
-
-          debug(`Config updated by ${pubSubId}`)
-        })
-
-        this.subscriber.subscribe(this.configPubSubChannel)
-      }
-    }
+    return this.config.get()
   }
 
   getEnv() {
@@ -254,9 +194,11 @@ class Crowi {
 
   async setupConfig() {
     this.model('Config', require('../models/config')(this))
-    const Config = this.model('Config')
-    const config = await Config.loadAllConfig()
-    this.setConfig(config)
+
+    const Config = require('../service/config')
+    this.config = new Config(this)
+
+    return this.config.load()
   }
 
   setupSearcher() {

--- a/lib/crowi/index.js
+++ b/lib/crowi/index.js
@@ -193,8 +193,6 @@ class Crowi {
   }
 
   async setupConfig() {
-    this.model('Config', require('../models/config')(this))
-
     const Config = require('../service/config')
     this.config = new Config(this)
 

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -11,4 +11,5 @@ module.exports = {
   Share: require('./share'),
   Tracking: require('./tracking'),
   ShareAccess: require('./shareAccess'),
+  Config: require('./config'),
 }

--- a/lib/service/config.js
+++ b/lib/service/config.js
@@ -1,0 +1,87 @@
+const debug = require('debug')('crowi:service:config')
+const uuidv4 = require('uuid/v4')
+const redis = require('redis')
+
+class Config {
+  constructor(crowi) {
+    this.crowi = crowi
+    this.config = {}
+
+    this.pubSub = {
+      id: uuidv4(),
+      publisher: null,
+      subscriber: null,
+      channel: 'config',
+    }
+
+    this.setupPubSub()
+  }
+
+  async load() {
+    const Config = this.crowi.model('Config')
+    const config = await Config.loadAllConfig()
+    this.set(config)
+  }
+
+  set(config) {
+    // FIXME: Deep copy to avoid deleting itself.
+    config = JSON.parse(JSON.stringify(config))
+    // FIXME: Treat as a mutable object always.
+    //        We should always get config using `crowi.getConfig()` *just before* referencing config.
+    for (const key of Object.keys(this.config)) {
+      delete this.config[key]
+    }
+    for (const key of Object.keys(config)) {
+      this.config[key] = config[key]
+    }
+  }
+
+  get() {
+    return this.config || {}
+  }
+
+  notifyUpdated() {
+    const { publisher, channel, id } = this.pubSub
+    if (publisher) {
+      publisher.publish(channel, JSON.stringify({ id }))
+    }
+  }
+
+  update(config) {
+    this.set(config)
+    this.notifyUpdated(config)
+  }
+
+  setupPubSub() {
+    const { redisOpts } = this.crowi
+
+    if (redisOpts) {
+      this.pubSub.publisher = redis.createClient(redisOpts)
+      this.pubSub.subscriber = redis.createClient(redisOpts)
+
+      const { pubSub } = this
+      const { subscriber } = pubSub
+
+      debug('PubSubId', pubSub.id)
+
+      if (subscriber) {
+        subscriber.on('message', async (channel, message) => {
+          if (channel !== pubSub.channel) return
+
+          const { id } = JSON.parse(message)
+          if (id === pubSub.id) return
+
+          await this.load()
+
+          await Promise.all([this.crowi.setupSlack(), this.crowi.setupMailer()])
+
+          debug(`Config updated by ${pubSub.id}`)
+        })
+
+        subscriber.subscribe(pubSub.channel)
+      }
+    }
+  }
+}
+
+module.exports = Config

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "flow": "flow",
     "format": "eslint --fix \"**/*.js\"",
     "lint": "eslint \"**/*.js\"",
-    "test": "mocha -r test/bootstrap.js --globals chai --reporter dot test/**/*.test.js --timeout 10000",
+    "test": "mocha --exit -r test/bootstrap.js --globals chai --reporter dot test/**/*.test.js --timeout 1000",
     "build": "npm run prod:client",
     "prod:client": "NODE_ENV=production webpack --bail --colors --display-error-details --config tools/webpack.config.js",
     "webpack": "webpack",

--- a/test/crowi/crowi.test.js
+++ b/test/crowi/crowi.test.js
@@ -4,29 +4,38 @@ var sinon = require('sinon')
 var sinonChai = require('sinon-chai')
 var proxyquire = require('proxyquire')
 var path = require('path')
+var utils = require('../utils.js')
 chai.use(sinonChai)
 
 describe('Test for Crowi application context', function() {
   var Crowi = require('../../lib/crowi')
-  var mongoose = require('mongoose')
+  var mongoose = utils.mongoose
+  var crowi = new Crowi(path.normalize(path.join(__dirname, './../../')), process.env)
+
+  before(async () => {
+    crowi.models = utils.models
+    // FIXME: This is a hack
+    crowi.redisOpts = null
+    await crowi.setupConfig()
+    return crowi
+  })
 
   describe('construction', function() {
-    it('initialize crowi context', function() {
-      var crowi = new Crowi(path.normalize(path.join(__dirname, './../../')), process.env)
+    it('initialize crowi context', async function() {
       expect(crowi).to.be.instanceof(Crowi)
       expect(crowi.version).to.equal(require('../../package.json').version)
       expect(crowi.env).to.be.an('Object')
     })
 
-    it('config getter, setter', function() {
-      var crowi = new Crowi(path.normalize(path.join(__dirname, './../../')), process.env)
+    it('config getter, setter', async function() {
+      expect(crowi.getConfig()).to.deep.equals({ crowi: {} })
+      crowi.setConfig({})
       expect(crowi.getConfig()).to.deep.equals({})
       crowi.setConfig({ test: 1 })
       expect(crowi.getConfig()).to.deep.equals({ test: 1 })
     })
 
-    it('model getter, setter', function() {
-      var crowi = new Crowi(path.normalize(path.join(__dirname, './../../')), process.env)
+    it('model getter, setter', async function() {
       // set
       crowi.model('hoge', { fuga: 1 })
       expect(crowi.model('hoge')).to.deep.equals({ fuga: 1 })
@@ -34,27 +43,8 @@ describe('Test for Crowi application context', function() {
   })
 
   describe('.setupDatabase', function() {
-    before(function() {
-      mongoose.disconnect() // avoid error of Trying to open unclosed connection
-    })
-    it('setup completed', function(done) {
-      var crowi = new Crowi(path.normalize(path.join(__dirname, './../../')), process.env)
-      // set
-      var p = crowi.setupDatabase()
-      expect(p).to.instanceof(Promise)
-      p.then(function() {
-        expect(mongoose.connection.readyState).to.equals(1)
-        done()
-      }).catch(function(err) {
-        // console.log('readyState', mongoose.connection.readyState);
-        if (mongoose.connection.readyState === 2 || mongoose.connection.readyState === 1) {
-          // alreaady connected
-          // throught
-        } else {
-          expect(mongoose.connection.readyState).to.equals(0)
-        }
-        done()
-      })
+    it('setup completed', async function() {
+      expect(mongoose.connection.readyState).to.equals(1)
     })
   })
 })

--- a/test/util/slack.test.js
+++ b/test/util/slack.test.js
@@ -9,6 +9,7 @@ describe('Slack Util', function() {
   var crowi = new (require(ROOT_DIR + '/lib/crowi'))(ROOT_DIR, process.env)
   var slack = require(crowi.libDir + '/util/slack')(crowi)
 
+  // FIXME: Mock. Should be changed to use a real Crowi object.
   crowi.config = {
     data: {},
     set(config) {

--- a/test/util/slack.test.js
+++ b/test/util/slack.test.js
@@ -9,6 +9,16 @@ describe('Slack Util', function() {
   var crowi = new (require(ROOT_DIR + '/lib/crowi'))(ROOT_DIR, process.env)
   var slack = require(crowi.libDir + '/util/slack')(crowi)
 
+  crowi.config = {
+    data: {},
+    set(config) {
+      this.data = config
+    },
+    get() {
+      return this.data
+    },
+  }
+
   it('convert markdown', function() {
     var markdown = '# ほげほげ\n\n* aaa\n* bbb\n* ccc\n\n## ほげほげほげ\n\n[Yahoo! Japan](http://www.yahoo.co.jp/) is here\n**Bold** and *Italic*'
     var markdownConverted = '\n*ほげほげ*\n\n• aaa\n• bbb\n• ccc\n\n\n*ほげほげほげ*\n\n<http://www.yahoo.co.jp/|Yahoo! Japan> is here\n**Bold** and *Italic*'

--- a/test/utils.js
+++ b/test/utils.js
@@ -60,6 +60,16 @@ fs.readdirSync(MODEL_DIR).forEach(function(file) {
 
 crowi.models = models
 
+crowi.config = {
+  data: {},
+  set(config) {
+    this.data = config
+  },
+  get() {
+    return this.data
+  },
+}
+
 module.exports = {
   models: models,
   mongoose: mongoose,

--- a/test/utils.js
+++ b/test/utils.js
@@ -60,6 +60,7 @@ fs.readdirSync(MODEL_DIR).forEach(function(file) {
 
 crowi.models = models
 
+// FIXME: Mock. Should be changed to use a real Crowi object.
 crowi.config = {
   data: {},
   set(config) {


### PR DESCRIPTION
# Overview

Reload config when config updated on other instance.
The instances configs may be swapped with each other if configs are updated on different instances in a short period of time.

## Example

1. Update config on instance A and send config to other instances
2. Update config on instance B and send config to other instances
3. Instance A receive B's config and set config with it
4. Instance B receive A's config and set config with it
