### PR TITLE
Fix: error when Basic auth is required and receive Bearer token

### DIFF
--- a/lib/middlewares/accessTokenParser.js
+++ b/lib/middlewares/accessTokenParser.js
@@ -1,32 +1,10 @@
 const debug = require('debug')('crowi:middlewares:accessTokenParser')
 
-/**
- * Extract Bearer token from Authorization header.
- *
- * @param {Object} headers HTTP request headers
- * @param {string} headers.authorization Authorization header value.
- * @return {?string} found access_token or null.
- */
-const extractBearerToken = headers => {
-  const v = headers.authorization
-  if (!v) {
-    return null
-  }
-
-  const parts = v
-    .trim()
-    .replace(/( )+/g, ' ')
-    .split(' ')
-  if (parts.length !== 2 || parts[0] !== 'Bearer') {
-    return null
-  }
-
-  return parts[1]
-}
+const { parseAccessToken } = require('../util/accessTokenParser')
 
 module.exports = (crowi, app) => {
   return (req, res, next) => {
-    var accessToken = extractBearerToken(req.headers) || req.query.access_token || req.body.access_token || null
+    const accessToken = parseAccessToken(req)
     if (!accessToken) {
       return next()
     }

--- a/lib/middlewares/basicAuth.js
+++ b/lib/middlewares/basicAuth.js
@@ -1,9 +1,12 @@
 const basicAuth = require('basic-auth-connect')
 
+const { parseAccessToken } = require('../util/accessTokenParser')
+
 module.exports = (crowi, app) => {
   return (req, res, next) => {
-    var config = crowi.getConfig()
-    if (req.query.access_token || req.body.access_token) {
+    const config = crowi.getConfig()
+    const accessToken = parseAccessToken(req)
+    if (accessToken) {
       return next()
     }
 

--- a/lib/util/accessTokenParser.js
+++ b/lib/util/accessTokenParser.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const debug = require('debug')('crowi:util:accessTokenParser')
+
+/**
+ * Extract Bearer token from Authorization header.
+ *
+ * @param {Object} headers HTTP request headers
+ * @param {string} headers.authorization Authorization header value.
+ * @return {?string} found access_token or null.
+ */
+const extractBearerToken = headers => {
+  const v = headers.authorization
+  debug('Authorization', v)
+  if (!v) {
+    return null
+  }
+
+  const parts = v
+    .trim()
+    .replace(/( )+/g, ' ')
+    .split(' ')
+  if (parts.length !== 2 || parts[0] !== 'Bearer') {
+    return null
+  }
+
+  return parts[1]
+}
+
+module.exports = {
+  parseAccessToken: req => {
+    if (!req) {
+      throw new Error('req required.')
+    }
+
+    return extractBearerToken(req.headers) || req.query.access_token || req.body.access_token || null
+  },
+}


### PR DESCRIPTION
## Reproduction

- Set `Basic Auth` setting on admin screen.
- Send api request with `Bearer` tokan.

```
$ curl -H "Authorization: Bearer xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx+HvNg=" -v  "http://localhost:3000/_api/comments.get?page_id=xxxxxxxxxxxxxxxxxxxxxxxx"
```

got 400 Bad Request.

```
Error: Bad Request
    at error (crowi/node_modules/basic-auth-connect/index.js:125:13)
    at crowi/node_modules/basic-auth-connect/index.js:76:53
    at crowi/lib/middlewares/basicAuth.js:11:97
    at Layer.handle [as handle_request] (crowi/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (crowi/node_modules/express/lib/router/index.js:317:13)
    at crowi/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (crowi/node_modules/express/lib/router/index.js:335:12)
    at next (crowi/node_modules/express/lib/router/index.js:275:10)
    at session (crowi/node_modules/express-session/index.js:468:7)
    at Layer.handle [as handle_request] (crowi/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (crowi/node_modules/express/lib/router/index.js:317:13)
    at crowi/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (crowi/node_modules/express/lib/router/index.js:335:12)
    at next (crowi/node_modules/express/lib/router/index.js:275:10)
    at cookieParser (crowi/node_modules/cookie-parser/index.js:57:14)
    at Layer.handle [as handle_request] (crowi/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (crowi/node_modules/express/lib/router/index.js:317:13)
    at crowi/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (crowi/node_modules/express/lib/router/index.js:335:12)
    at next (crowi/node_modules/express/lib/router/index.js:275:10)
    at jsonParser (crowi/node_modules/body-parser/lib/types/json.js:110:7)
    at Layer.handle [as handle_request] (crowi/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (crowi/node_modules/express/lib/router/index.js:317:13)
    at crowi/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (crowi/node_modules/express/lib/router/index.js:335:12)
    at next (crowi/node_modules/express/lib/router/index.js:275:10)
    at urlencodedParser (crowi/node_modules/body-parser/lib/types/urlencoded.js:91:7)
    at Layer.handle [as handle_request] (crowi/node_modules/express/lib/router/layer.js:95:5)
```


## Note

This bug also exists on v1.7.x, so we should backport this patch.