### PR TITLE
Limit node memory usage for heroku

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,0 +1,2 @@
+# Add npm path as environment variable
+export NPM=$(which npm)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run start
+web: node --max_old_space_size=300 --optimize_for_size --gc_interval=100 $NPM start


### PR DESCRIPTION
Only 512MB memory can be used with Heroku Free, Hobby, and Standard 1X plan. 
But Node.js uses 1.5GB heap memory at most by default. I limited it to 300MB.