### PR TITLE
Fix: TS compile error when run with FILE_UPLOAD=aws

### DIFF
--- a/local_modules/crowi-fileupload-aws/index.js
+++ b/local_modules/crowi-fileupload-aws/index.js
@@ -64,11 +64,13 @@ module.exports = function(crowi) {
     const s3 = S3Factory()
     const awsConfig = getAwsConfig()
 
-    var params = { Bucket: awsConfig.bucket }
-    params.ContentType = contentType
-    params.Key = filePath
-    params.Body = fileStream
-    params.ACL = 'public-read'
+    const params = {
+      Bucket: awsConfig.bucket,
+      ContentType: contentType,
+      Key: filePath,
+      Body: fileStream,
+      ACL: 'public-read',
+    }
 
     return new Promise(function(resolve, reject) {
       s3.putObject(params, function(err, data) {


### PR DESCRIPTION
When run with `FILE_UPLOAD=aws`, error happens below:

```
[0] TSError: ⨯ Unable to compile TypeScript:
[0] local_modules/crowi-fileupload-aws/index.js(74,20): error TS2345: Argument of type '{ Bucket: any; }' is not assignable to parameter of type 'PutObjectRequest'.
[0]   Property 'Key' is missing in type '{ Bucket: any; }' but required in type 'PutObjectRequest'.
```