### PR TITLE
Fix: error on uploading files

### DIFF
--- a/lib/controllers/attachment.ts
+++ b/lib/controllers/attachment.ts
@@ -125,12 +125,12 @@ export default (crowi: Crowi, app: Express) => {
       const fileName = tmpFile.filename + tmpFile.originalname
       const fileType = tmpFile.mimetype
       const fileSize = tmpFile.size
-      const page = pageData._id
+      const pageId = pageData._id
       const creator = req.user.id
       const fileFormat = fileType
 
       try {
-        const filePath = Attachment.createAttachmentFilePath(pageData._id, fileName, fileType)
+        const filePath = Attachment.createAttachmentFilePath(pageId, fileName, fileType)
         const tmpFileStream = fs.createReadStream(tmpPath, {
           flags: 'r',
           mode: 666,
@@ -141,7 +141,7 @@ export default (crowi: Crowi, app: Express) => {
         debug('Uploaded data is: ', data)
 
         // TODO size
-        const attachment = await Attachment.create({ page, creator, filePath, originalName, fileName, fileFormat, fileSize })
+        const attachment = await Attachment.create({ pageId, creator, filePath, originalName, fileName, fileFormat, fileSize })
         let fileUrl = attachment.fileUrl
         const config = crowi.getConfig()
 
@@ -151,8 +151,8 @@ export default (crowi: Crowi, app: Express) => {
         }
 
         const result = {
-          page: page.toObject(),
-          attachment: data.toObject(),
+          page: pageData.toObject(),
+          attachment: attachment.toObject(),
           url: fileUrl,
           pageCreated: pageCreated,
         }

--- a/local_modules/crowi-fileupload-aws/index.js
+++ b/local_modules/crowi-fileupload-aws/index.js
@@ -64,11 +64,13 @@ module.exports = function(crowi) {
     const s3 = S3Factory()
     const awsConfig = getAwsConfig()
 
-    var params = { Bucket: awsConfig.bucket }
-    params.ContentType = contentType
-    params.Key = filePath
-    params.Body = fileStream
-    params.ACL = 'public-read'
+    const params = {
+      Bucket: awsConfig.bucket,
+      ContentType: contentType,
+      Key: filePath,
+      Body: fileStream,
+      ACL: 'public-read',
+    }
 
     return new Promise(function(resolve, reject) {
       s3.putObject(params, function(err, data) {


### PR DESCRIPTION
Fixed error below:

```
Error on saving attachment data TypeError: page.toObject is not a function
    at api.add (crowi/lib/controllers/attachment.ts:154:22)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```
And then fixed below:

```
Error on saving attachment data TypeError: data.toObject is not a function
     at api.add (crowi/crowi/lib/controllers/attachment.ts:155:28)
     at process._tickCallback (internal/process/next_tick.js:68:7)
```

Note: this branch is based on #508 so merge after the base branch merged.