### PR TITLE
Fix: error on emitting page update event when grant changed

### DIFF
--- a/lib/models/page.ts
+++ b/lib/models/page.ts
@@ -797,6 +797,8 @@ export default (crowi: Crowi) => {
     const data = await page.save()
 
     debug('Page.updateGrant, saved grantedUsers.', (data && data.path) || {})
+
+    return data
   }
 
   // Instance method でいいのでは


### PR DESCRIPTION
On update page with changing grant, page event emitted with incorrect page variable.

```
[0] 2019-08-13T16:49:11.634Z crowi:models:page Page.updateGrant, saved grantedUsers. /user/sotarok/memo/2019/08/14/虎ノ門ヒルズ
[0] 2019-08-13T16:49:11.634Z crowi:routes:page Page create or edit error. TypeError: Cannot read property 'path' of undefined
[0]     at SearchClient.syncPageUpdated (crowi/crowi/lib/util/search.ts:811:46)
[0]     at PageEvent.emit (events.js:203:15)
[0]     at PageEvent.EventEmitter.emit (domain.js:448:20)
[0]     at Function.pageSchema.statics.updatePage (crowi/crowi/lib/models/page.ts:885:17)
[0]     at process._tickCallback (internal/process/next_tick.js:68:7)
```

this caused because `updateGrant()` method returns no data.