### PR TITLE
Fix error on rename

### DIFF
--- a/lib/models/page.ts
+++ b/lib/models/page.ts
@@ -1026,7 +1026,7 @@ export default (crowi: Crowi) => {
 
     if (createRedirectPage) {
       var body = 'redirect ' + newPagePath
-      return Page.create(path, body, user, { redirectTo: newPagePath })
+      return Page.createPage(path, body, user, { redirectTo: newPagePath })
     }
     pageEvent.emit('update', pageData, user) // update as renamed page
     return data


### PR DESCRIPTION
This was occurred because of omission of correction of `Page.create` to `Page.createPage`

```
[0] 2019-08-15T15:39:19.593Z crowi:routes:page ObjectParameterError: Parameter "obj" to Document() must be an object, got /user/sotarok/memo/2019/08/16-2
[0]     at new ObjectParameterError (crowi/crowi/node_modules/mongoose/lib/error/objectParameter.js:25:11)
[0]     at model.Document (crowi/crowi/node_modules/mongoose/lib/document.js:74:11)
[0]     at model.Model (crowi/crowi/node_modules/mongoose/lib/model.js:92:12)
[0]     at new model (crowi/crowi/node_modules/mongoose/lib/model.js:4394:15)
[0]     at toExecute.push.callback (crowi/crowi/node_modules/mongoose/lib/model.js:3034:22)
[0]     at crowi/crowi/node_modules/mongoose/node_modules/async/internal/parallel.js:31:39
[0]     at eachOfArrayLike (crowi/crowi/node_modules/mongoose/node_modules/async/eachOf.js:65:9)
[0]     at exports.default (crowi/crowi/node_modules/mongoose/node_modules/async/eachOf.js:9:5)
[0]     at _parallel (crowi/crowi/node_modules/mongoose/node_modules/async/internal/parallel.js:30:5)
[0]     at parallelLimit (crowi/crowi/node_modules/mongoose/node_modules/async/parallel.js:88:26)
[0]     at utils.promiseOrCallback.cb (crowi/crowi/node_modules/mongoose/lib/model.js:3044:5)
[0]     at Promise (crowi/crowi/node_modules/mongoose/lib/utils.js:271:5)
[0]     at new Promise (<anonymous>)
[0]     at Object.promiseOrCallback (crowi/crowi/node_modules/mongoose/lib/utils.js:270:10)
[0]     at Function.create (crowi/crowi/node_modules/mongoose/lib/model.js:3005:16)
[0]     at Function.pageSchema.statics.rename (crowi/crowi/lib/models/page.ts:1029:19)
[0]     at process._tickCallback (internal/process/next_tick.js:68:7)
```