### PR TITLE
Server-side rendering for first contentful paint

### DIFF
--- a/client/app.tsx
+++ b/client/app.tsx
@@ -26,6 +26,8 @@ import WatchButton from 'components/Notification/WatchButton'
 import AdminShare from 'components/Admin/Share/AdminShare'
 import AdminRebuildSearch from 'components/Admin/AdminRebuildSearch'
 
+import hydrateComponents from './hydrateComponents'
+
 i18n()
 
 moment.locale(navigator.userLanguage || navigator.language)
@@ -89,6 +91,8 @@ Object.entries(componentMappings).forEach(([key, component]) => {
     ReactDOM.render(component, elem)
   }
 })
+
+hydrateComponents()
 
 // うわーもうー
 $('a[data-toggle="tab"][href="#revision-history"]').on('show.bs.tab', function() {

--- a/client/hydrateComponents.tsx
+++ b/client/hydrateComponents.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import * as SSR from 'common/ssr'
+
+export default () => {
+  const getTextContent = (element: HTMLElement | null) => (element ? element.textContent : null)
+  const ssrContext = JSON.parse(getTextContent(document.getElementById('ssr-context-hydrate')) || '[]')
+
+  for (const { componentId, props } of ssrContext) {
+    if (SSR.hasComponent(componentId)) {
+      ReactDOM.hydrate(SSR.createElement(componentId, props), document.getElementById(props.id))
+    }
+  }
+}

--- a/common/ssr/index.ts
+++ b/common/ssr/index.ts
@@ -1,0 +1,22 @@
+import React from 'react'
+import Icon from 'components/Common/Icon'
+
+export const components = {
+  Icon,
+}
+
+export const hasComponent = (componentId: string) => {
+  return componentId in components
+}
+
+export const getComponent = (componentId: string) => {
+  return components[componentId]
+}
+
+export const createElement = (componentId: string, props) => {
+  if (hasComponent(componentId)) {
+    return React.createElement(getComponent(componentId), props)
+  }
+
+  return React.createElement('')
+}

--- a/lib/crowi/express-init.ts
+++ b/lib/crowi/express-init.ts
@@ -83,4 +83,5 @@ export default (crowi: Crowi, app: Express) => {
 
   app.use(middlewares.I18next)
   app.use(middlewares.ClientContext)
+  app.use(middlewares.SsrContext)
 }

--- a/lib/middlewares/index.ts
+++ b/lib/middlewares/index.ts
@@ -14,6 +14,7 @@ import FileAccessRightOrLoginRequired from './fileAccessRightOrLoginRequired'
 import I18next from './i18next'
 import LoginChecker from './loginChecker'
 import LoginRequired from './loginRequired'
+import SsrContext from './ssrContext'
 import SwigFilters from './swigFilters'
 import SwigFunctions from './swigFunctions'
 
@@ -31,6 +32,7 @@ export default (crowi: Crowi, app: Express) => ({
   I18next: I18next(crowi, app),
   LoginChecker: LoginChecker(crowi, app),
   LoginRequired: LoginRequired(crowi),
+  SsrContext: SsrContext(),
   SwigFilters: SwigFilters(crowi, app),
   SwigFunctions: SwigFunctions(crowi, app),
 })

--- a/lib/middlewares/ssrContext.ts
+++ b/lib/middlewares/ssrContext.ts
@@ -1,0 +1,7 @@
+export default () => {
+  return (req, res, next) => {
+    res.locals.ssr_id = 0
+    res.locals.ssr_context = []
+    next()
+  }
+}

--- a/lib/middlewares/swigFunctions.ts
+++ b/lib/middlewares/swigFunctions.ts
@@ -4,7 +4,7 @@ import functions from '../util/swigFunctions'
 
 export default (crowi: Crowi, app: Express) => {
   return (req, res, next) => {
-    functions(crowi, app, req, res.locals)
+    functions(crowi, app, req, res)
     next()
   }
 }

--- a/lib/util/ssr.ts
+++ b/lib/util/ssr.ts
@@ -1,0 +1,13 @@
+import ReactDOMServer from 'react-dom/server'
+import * as SSR from 'common/ssr'
+
+export default res => (componentId: string, baseProps) => {
+  if (SSR.hasComponent(componentId)) {
+    const id = `ssr-${res.locals.ssr_id++}`
+    const props = { ...baseProps, id }
+
+    res.locals.ssr_context.push({ componentId, props })
+
+    return ReactDOMServer.renderToString(SSR.createElement(componentId, props))
+  }
+}

--- a/lib/util/swigFunctions.ts
+++ b/lib/util/swigFunctions.ts
@@ -1,11 +1,13 @@
 import Crowi from 'server/crowi'
 import { Express } from 'express'
+import ssr from './ssr'
 
-export default (crowi: Crowi, app: Express, req, locals) => {
+export default (crowi: Crowi, app: Express, req, res) => {
   // const debug = Debug('crowi:lib:swigFunctions')
   const Page = crowi.model('Page')
   const Config = crowi.model('Config')
   const User = crowi.model('User')
+  const { locals } = res
 
   // token getter
   locals.csrf = function() {
@@ -149,4 +151,6 @@ export default (crowi: Crowi, app: Express, req, locals) => {
       return ''
     },
   }
+
+  locals.Component = ssr(res)
 }

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "jsx": "react",
     "allowJs": true,
     "checkJs": true
   },

--- a/views/layout/2column.html
+++ b/views/layout/2column.html
@@ -19,7 +19,7 @@
   <div id="footer-container" class="footer">
     <footer class="">
       <p>
-      <a href="" data-target="#help-modal" data-toggle="modal"><i class="mdi mdi-help-circle"></i> {{ t('Help') }}</a>
+      <a href="" data-target="#help-modal" data-toggle="modal">{{ Component('Icon', { name: "help-circle"}) }} {{ t('Help') }}</a>
       &copy; {{ now|date('Y') }} {{ config.crowi['app:title']|default('Crowi') }} <img src="/logo/100x11_g.png" alt="powered by Crowi"> </p>
     </footer>
   </div>

--- a/views/layout/layout.html
+++ b/views/layout/layout.html
@@ -139,6 +139,9 @@
 <script type="application/json" id="user-context-hydrate">
 {{ user_context|json|safe }}
 </script>
+<script type="application/json" id="ssr-context-hydrate">
+{{ ssr_context|json|safe }}
+</script>
 
 <script src="{{ assets('/js/app.js') }}"></script>
 <script src="{{ assets('/js/crowi.js') }}"></script>

--- a/views/layout/single.html
+++ b/views/layout/single.html
@@ -20,7 +20,7 @@
 <div id="footer-container" class="footer">
   <footer class="">
     <p>
-    <a href="" data-target="#help-modal" data-toggle="modal"><i class="mdi mdi-help-circle"></i> {{ t('Help') }}</a>
+    <a href="" data-target="#help-modal" data-toggle="modal">{{ Component('Icon', { name: "help-circle"}) }} {{ t('Help') }}</a>
     &copy; {{ now|date('Y') }} {{ config.crowi['app:title'] }} <img src="/logo/100x11_g.png" alt="powered by Crowi"> </p>
   </footer>
 </div>

--- a/views/page_list.html
+++ b/views/page_list.html
@@ -226,7 +226,7 @@
 <div class="portal-side">
   <div class="portal-form-button">
     <button class="btn btn-primary" id="create-portal-button">Create Portal</button>
-    <p class="help-block"><a href="#" data-target="#help-portal" data-toggle="modal"><i class="mdi mdi-help-circle"></i> What is Portal?</a></p>
+    <p class="help-block"><a href="#" data-target="#help-portal" data-toggle="modal">{{ Component('Icon', { name: "help-circle"}) }} What is Portal?</a></p>
   </div>
 
 </div>

--- a/webpack/server/webpack.config.js
+++ b/webpack/server/webpack.config.js
@@ -20,12 +20,12 @@ const config = {
   resolve: {
     plugins: [new TsconfigPathsPlugin({ configFile: path.join(ROOT, 'tsconfig.server.json') })],
     modules: ['./node_modules'],
-    extensions: ['.ts', '.js', '.json'],
+    extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
   },
   module: {
     rules: [
       {
-        test: /\.(js|ts)$/,
+        test: /.(ts|js)x?$/,
         exclude: /node_modules/,
         loader: 'ts-loader',
         options: {


### PR DESCRIPTION
# Overview

Support server-side rendering for first contentful paint.

After this PR is merged, I'll replace icon fonts with SVG icons using SSR.

# How to use

For example, there is the following swig template.

```
<i class="mdi mdi-help-circle"></i>
```

Then, you can use the `Component` function for rendering React component.

```
{{ Component('Icon', { name: "help-cirle" }) }}
```
