### PR TITLE
Fix search suggest styles

### DIFF
--- a/client/components/HeaderSearchBox/RecentlyViewedPageList.tsx
+++ b/client/components/HeaderSearchBox/RecentlyViewedPageList.tsx
@@ -10,6 +10,7 @@ interface Props extends WithTranslation {
 
 interface State {
   pages: []
+  loading: boolean
 }
 
 class RecentlyViewedPageList extends React.Component<Props, State> {
@@ -18,26 +19,25 @@ class RecentlyViewedPageList extends React.Component<Props, State> {
 
     this.state = {
       pages: [],
+      loading: true,
     }
   }
 
   async componentDidMount() {
     const { pages } = await this.props.crowi.apiGet('/user/recentlyViewed', {})
-    this.setState({ pages })
+    this.setState({ pages, loading: false })
   }
 
   render() {
     const { t } = this.props
-    const { pages } = this.state
+    const { pages, loading } = this.state
     return (
-      pages.length > 0 && (
-        <div className="grouped-page-list">
-          <h6>
-            <Icon name="history" /> <span className="title">{t('Recently Viewed Pages')}</span>
-          </h6>
-          <ListView pages={pages} />
-        </div>
-      )
+      <div className="grouped-page-list">
+        <h6>
+          <Icon name="history" /> <span className="title">{t('Recently Viewed Pages')}</span>
+        </h6>
+        {loading ? <Icon name="loading" spin /> : pages.length === 0 ? 'No recently viewed pages' : <ListView pages={pages} />}
+      </div>
     )
   }
 }

--- a/client/components/HeaderSearchBox/SearchSuggest.tsx
+++ b/client/components/HeaderSearchBox/SearchSuggest.tsx
@@ -84,6 +84,7 @@ class SearchSuggest extends React.Component<Props> {
         </div>
       )
     }
+
     if (searchError !== null) {
       return (
         <div>
@@ -91,9 +92,11 @@ class SearchSuggest extends React.Component<Props> {
         </div>
       )
     }
+
     if (numberOfResults === 0) {
       return <div>No results for &quot;{searchingKeyword}&quot;.</div>
     }
+
     return [
       this.renderList(t('page_types.portal'), 'file-document-box-multiple-outline', 'portal', portalPages),
       this.renderList(t('page_types.public'), 'file-document-box-outline', 'public', publicPages),
@@ -103,6 +106,7 @@ class SearchSuggest extends React.Component<Props> {
 
   render() {
     const { focused } = this.props
+
     if (!focused) {
       return <div />
     }

--- a/resource/css/_page_list.scss
+++ b/resource/css/_page_list.scss
@@ -78,7 +78,6 @@
 
   h6 {
     display: flex;
-    max-height: 1rem;
     font-weight: bold;
     color: #888;
 

--- a/resource/css/_search.scss
+++ b/resource/css/_search.scss
@@ -34,7 +34,7 @@
     width: 100%;
 
     // for SearchSuggest
-    @include media-breakpoint-up(md) {
+    @include media-breakpoint-up(lg) {
       position: relative;
     }
 
@@ -93,7 +93,7 @@
 
 .search-suggest {
   width: 100%;
-  @include media-breakpoint-down(sm) {
+  @include media-breakpoint-down(md) {
     left: 1em;
     width: calc(100% - 2em);
   }

--- a/resource/css/_search.scss
+++ b/resource/css/_search.scss
@@ -33,6 +33,11 @@
   .search-top {
     width: 100%;
 
+    // for SearchSuggest
+    @include media-breakpoint-up(md) {
+      position: relative;
+    }
+
     .search-top-input-group {
       display: flex;
       position: relative;
@@ -87,15 +92,13 @@
 }
 
 .search-suggest {
-  max-width: 500px;
+  width: 100%;
   @include media-breakpoint-down(sm) {
     left: 1em;
     width: calc(100% - 2em);
-    max-width: none;
   }
   position: absolute;
   margin-top: 2px;
-  border-top: solid 1px #ccc;
   border: none;
   box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1), 0px 8px 20px rgba(0, 0, 0, 0.2);
 


### PR DESCRIPTION
# Changes

- Stretch the search suggest to maximum on desktop
- Show loading and no result message on the recently viewed pages list

# Screens

## Loading

![localhost_3000_ (2)](https://user-images.githubusercontent.com/2351326/63228770-f79e2280-c232-11e9-8771-1b22bd255eec.png)

## Loaded

![localhost_3000_ (1)](https://user-images.githubusercontent.com/2351326/63228771-f967e600-c232-11e9-85ff-efaa62a4b7fb.png)

## No results

![localhost_3000_](https://user-images.githubusercontent.com/2351326/63228772-fb31a980-c232-11e9-9a68-77100055a851.png)

# Related

https://github.com/crowi/crowi/pull/523#issuecomment-521934843