### PR TITLE
Fix heroku deploy config

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,7 +19,7 @@
       "description": "A password seed is used by password hash generator. ",
       "generator": "secret"
     },
-    "MONGOMS_DISABLE_POSTINSTALL": 1
+    "MONGOMS_DISABLE_POSTINSTALL": "1"
   },
   "addons": [
     "mongolab",


### PR DESCRIPTION
Heroku is now saying

```
Invalid app.json: config var "MONGOMS_DISABLE_POSTINSTALL" value is not a string
```

And fixed it so

```
       > mongodb-memory-server@5.1.5 postinstall /tmp/build_4452adda8b9ea4925dd4f94447613962/node_modules/mongodb-memory-server
       > node ./postinstall.js
       
       Download is skipped by MONGOMS_DISABLE_POSTINSTALL variable
```

worked expected.