### PR TITLE
Dockerfile: Add procps (ps)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ ARG NODE_ENV="production"
 ENV CROWI_VERSION v1.8.0
 ENV NODE_ENV ${NODE_ENV}
 
+# 'ps' command is missing in node:10.16.2-stretch-slim
+# but required by pstree.remy (used from nodemon)
+RUN apt-get update && apt-get install -y procps && apt-get clean
+
 USER node
 
 WORKDIR /crowi


### PR DESCRIPTION
nodemon (used in `dev:server` script) can't boot without ps command.

I didn't notice, but sometime `ps` command left from Docker image.
Please re-build image before testing this PR.