### PR TITLE
Fix border image for safari

### DIFF
--- a/resource/css/_layout.scss
+++ b/resource/css/_layout.scss
@@ -3,6 +3,7 @@
     min-height: 100vh;
     display: flex;
     flex-direction: column;
+    border: 0;
     border-top: solid $crowiTopBorderHeight $crowiHeaderBackground;
     border-image: linear-gradient(90deg,
       $crowiHeaderBackground,


### PR DESCRIPTION
Safari displays the following:

<img src="https://user-images.githubusercontent.com/2351326/67268381-4ac07a00-f4ef-11e9-96d1-146c3adc093d.png" height="400px" />
