### PR TITLE
Wrap texts in pre tag

### DIFF
--- a/resource/css/_wiki.scss
+++ b/resource/css/_wiki.scss
@@ -132,6 +132,7 @@ div.body {
     padding: 9.5px;
     border-radius: 4px;
     word-wrap: break-word;
+    white-space: pre-wrap;
 
     code {
       background: transparent;


### PR DESCRIPTION
# WHAT

- Wrap texts in `pre` tag

The layout has been fixed correctly:
![localhost_3000__search_q=lorem(iPad Pro) (1)](https://user-images.githubusercontent.com/2351326/68404780-6780d100-01c2-11ea-97fd-48928bc7927f.png)

# WHY

- Search result page's layout will be broken if there are too long texts exists in `pre`

![localhost_3000__search_q=lorem(iPad Pro) (2)](https://user-images.githubusercontent.com/2351326/68404804-6d76b200-01c2-11ea-85e0-f642a54f11f5.png)
