### PR TITLE
Enable more ESLint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,7 @@
     "prettier",
     "prettier/@typescript-eslint",
     "prettier/standard",
-    "prettier/react",
+    "prettier/react"
   ],
   "env": {
     "browser": true,
@@ -44,8 +44,7 @@
     "react/prop-types": "off",
     "require-jsdoc": "off",
     "standard/no-callback-literal": "off",
-    "valid-jsdoc": "off",
-    "no-var": "off"
+    "valid-jsdoc": "off"
   },
   "settings": {
     "react": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -33,18 +33,12 @@
     "@typescript-eslint/ban-ts-ignore": "off",
     "eqeqeq": "off",
     "handle-callback-err": "off",
-    "jest/valid-describe": "off",
     "no-console": "off",
     "no-global-assign": "off",
-    "no-inner-declarations": "off",
-    "no-redeclare": "off",
     "node/no-deprecated-api": "off",
     "prettier/prettier": "error",
-    "react/prefer-stateless-function": "off",
     "react/prop-types": "off",
-    "require-jsdoc": "off",
-    "standard/no-callback-literal": "off",
-    "valid-jsdoc": "off"
+    "standard/no-callback-literal": "off"
   },
   "settings": {
     "react": {

--- a/client/crowi-admin.ts
+++ b/client/crowi-admin.ts
@@ -23,9 +23,9 @@ $(function() {
   $('#createdUserModal').modal('show')
 
   $('#admin-password-reset-modal').on('show.bs.modal', function(button) {
-    var data = $((button as any).relatedTarget)
-    var userId = data.data('user-id')
-    var email = data.data('user-email')
+    const data = $((button as any).relatedTarget)
+    const userId = data.data('user-id')
+    const email = data.data('user-email')
 
     $('#admin-password-reset-user').text(email)
     $('#admin-users-reset-password input[name=user_id]').val(userId)
@@ -123,7 +123,7 @@ $(function() {
         if (!status) {
           status = 'success'
         }
-        var $message = $('<p class="alert"></p>')
+        const $message = $('<p class="alert"></p>')
         $message.addClass('alert-' + status)
         $message.html(msg.replace('\n', '<br>'))
         $message.insertAfter('#' + formId + ' legend')
@@ -139,9 +139,9 @@ $(function() {
         }
       }
 
-      var $form = $(this)
-      var $id = $form.attr('id')
-      var $button = $('button', this)
+      const $form = $(this)
+      const $id = $form.attr('id')
+      const $button = $('button', this)
       $button.attr('disabled', 'disabled')
       const action = $form.attr('action')
       if (!action) return false

--- a/client/crowi-form.ts
+++ b/client/crowi-form.ts
@@ -10,13 +10,13 @@ $(function() {
   function FetchPagesUpdatePostAndInsert(path) {
     $.get('/_api/pages.updatePost', { path: path }, function(res) {
       if (res.ok) {
-        var $slackChannels = $('#page-form-slack-channel')
+        const $slackChannels = $('#page-form-slack-channel')
         $slackChannels.val(res.updatePost.join(','))
       }
     })
   }
 
-  var slackConfigured = $('#page-form-setting').data('slack-configured')
+  const slackConfigured = $('#page-form-setting').data('slack-configured')
 
   // for new page
   if (!pageId) {
@@ -33,8 +33,8 @@ $(function() {
     $('.content-main').addClass('on-edit')
 
     if (slackConfigured) {
-      var $slackChannels = $('#page-form-slack-channel')
-      var slackChannels = $slackChannels.val()
+      const $slackChannels = $('#page-form-slack-channel')
+      const slackChannels = $slackChannels.val()
       // if slackChannels is empty, then fetch default (admin setting)
       // if not empty, it means someone specified this setting for the page.
       if (slackChannels === '') {
@@ -48,31 +48,31 @@ $(function() {
   })
 
   // preview watch
-  var originalContent = $('#form-body').val()
+  const originalContent = $('#form-body').val()
 
   // restore draft
   // とりあえず、originalContent がない場合のみ復元する。(それ以外の場合は後で考える)
-  var draft = crowi.findDraft(pagePath)
-  var originalRevision = $('#page-form [name="pageForm[currentRevision]"]').val()
+  const draft = crowi.findDraft(pagePath)
+  const originalRevision = $('#page-form [name="pageForm[currentRevision]"]').val()
   if (!originalRevision && draft) {
     // TODO
     $('#form-body').val(draft)
   }
 
-  var prevContent = originalContent
+  let prevContent = originalContent
 
   function renderPreview() {
-    var content = $('#form-body').val() as string
-    var previewBody = $('#preview-body')
-    var previewBodyElement = previewBody[0] as HTMLDivElement
-    var parsedHTML = crowiRenderer.render(content, previewBodyElement)
+    const content = $('#form-body').val() as string
+    const previewBody = $('#preview-body')
+    const previewBodyElement = previewBody[0] as HTMLDivElement
+    const parsedHTML = crowiRenderer.render(content, previewBodyElement)
     previewBody.html(parsedHTML)
   }
 
   // for initialize preview
   renderPreview()
   setInterval(function() {
-    var content = $('#form-body').val()
+    const content = $('#form-body').val()
     if (prevContent != content) {
       renderPreview()
       prevContent = content
@@ -80,7 +80,7 @@ $(function() {
   }, 500)
 
   // edit detection
-  var isFormChanged = false
+  let isFormChanged = false
   $(window).on('beforeunload', function(e) {
     if (isFormChanged) {
       // TODO i18n
@@ -88,7 +88,7 @@ $(function() {
     }
   })
   $('#form-body').on('keyup change', function(e) {
-    var content = $('#form-body').val() as string
+    const content = $('#form-body').val() as string
     if (originalContent != content) {
       isFormChanged = true
       crowi.saveDraft(pagePath, content)
@@ -104,8 +104,8 @@ $(function() {
   })
 
   // This is a temporary implementation until porting to React.
-  var insertText = function(start, end, newText, mode) {
-    var editor = document.querySelector('#form-body') as HTMLTextAreaElement
+  const insertText = function(start, end, newText, mode) {
+    const editor = document.querySelector('#form-body') as HTMLTextAreaElement
     mode = mode || 'after'
 
     switch (mode) {
@@ -122,7 +122,7 @@ $(function() {
 
     editor.focus()
 
-    var inserted = false
+    let inserted = false
     try {
       // Chrome, Safari
       inserted = document.execCommand('insertText', false, newText)
@@ -136,17 +136,17 @@ $(function() {
     }
   }
 
-  var getCurrentLine = function(event) {
-    var $target = $(event.target)
+  const getCurrentLine = function(event) {
+    const $target = $(event.target)
 
-    var text = $target.val() as string
-    var pos = $target.selection('getPos')
+    const text = $target.val() as string
+    const pos = $target.selection('getPos')
     if (text === null || pos.start !== pos.end) {
       return null
     }
 
-    var startPos = text.lastIndexOf('\n', pos.start - 1) + 1
-    var endPos = text.indexOf('\n', pos.start)
+    const startPos = text.lastIndexOf('\n', pos.start - 1) + 1
+    let endPos = text.indexOf('\n', pos.start)
     if (endPos === -1) {
       endPos = text.length
     }
@@ -160,13 +160,13 @@ $(function() {
     }
   }
 
-  var getPrevLine = function(event) {
-    var $target = $(event.target)
-    var currentLine = getCurrentLine(event)
-    var start = currentLine ? currentLine.start : 0
-    var text = ($target.val() as string).slice(0, start)
-    var startPos = text.lastIndexOf('\n', start - 2) + 1
-    var endPos = start
+  const getPrevLine = function(event) {
+    const $target = $(event.target)
+    const currentLine = getCurrentLine(event)
+    const start = currentLine ? currentLine.start : 0
+    const text = ($target.val() as string).slice(0, start)
+    const startPos = text.lastIndexOf('\n', start - 2) + 1
+    const endPos = start
 
     return {
       text: text.slice(startPos, endPos),
@@ -240,18 +240,18 @@ $(function() {
     $target.trigger('input')
   }
 
-  var handleEnterKey = function(event) {
+  const handleEnterKey = function(event) {
     if (event.metaKey || event.ctrlKey || event.shiftKey) {
       return
     }
 
-    var currentLine = getCurrentLine(event)
+    const currentLine = getCurrentLine(event)
     if (!currentLine || currentLine.start === currentLine.caret) {
       return
     }
 
-    var $target = $(event.target)
-    var match = currentLine.text.match(/^(\s*(?:-|\+|\*|\d+\.) (?:\[(?:x| )\] )?)\s*\S/)
+    const $target = $(event.target)
+    const match = currentLine.text.match(/^(\s*(?:-|\+|\*|\d+\.) (?:\[(?:x| )\] )?)\s*\S/)
     if (match) {
       // smart indent with list
       if (currentLine.text.match(/^(\s*(?:-|\+|\*|\d+\.) (?:\[(?:x| )\] ))\s*$/)) {
@@ -260,11 +260,11 @@ $(function() {
         return
       }
       event.preventDefault()
-      var listMark = match[1].replace(/\[x\]/, '[ ]')
-      var listMarkMatch = listMark.match(/^(\s*)(\d+)\./)
+      let listMark = match[1].replace(/\[x\]/, '[ ]')
+      const listMarkMatch = listMark.match(/^(\s*)(\d+)\./)
       if (listMarkMatch) {
-        var indent = listMarkMatch[1]
-        var num = parseInt(listMarkMatch[2])
+        const indent = listMarkMatch[1]
+        const num = parseInt(listMarkMatch[2])
         if (num !== 1) {
           listMark = listMark.replace(/\s*\d+/, indent + (num + 1))
         }
@@ -272,7 +272,7 @@ $(function() {
       // $target.selection('insert', {text: "\n" + listMark, mode: 'before'});
       var pos = $target.selection('getPos')
       insertText(pos.start, pos.start, '\n' + listMark, 'replace')
-      var newPosition = pos.start + ('\n' + listMark).length
+      const newPosition = pos.start + ('\n' + listMark).length
       $target.selection('setPos', { start: newPosition, end: newPosition })
     } else if (currentLine.text.match(/^(\s*(?:-|\+|\*|\d+\.) )/)) {
       // remove list
@@ -287,12 +287,12 @@ $(function() {
         return
       }
       event.preventDefault()
-      var row: string[] = []
-      var cellbarMatch = currentLine.text.match(/\|/g) as RegExpMatchArray
-      for (var i = 0; i < cellbarMatch.length; i++) {
+      const row: string[] = []
+      const cellbarMatch = currentLine.text.match(/\|/g) as RegExpMatchArray
+      for (let i = 0; i < cellbarMatch.length; i++) {
         row.push('|')
       }
-      var prevLine = getPrevLine(event)
+      const prevLine = getPrevLine(event)
       if (!prevLine || (!currentLine.text.match(/---/) && !prevLine.text.match(/\|/g))) {
         // $target.selection('insert', {text: "\n" + row.join(' --- ') + "\n" + row.join('  '), mode: 'before'});
         var pos = $target.selection('getPos')
@@ -312,28 +312,28 @@ $(function() {
     $target.trigger('input')
   }
 
-  var handleEscapeKey = function(event) {
+  const handleEscapeKey = function(event) {
     event.preventDefault()
-    var $target = $(event.target)
+    const $target = $(event.target)
     $target.blur()
   }
 
-  var handleSpaceKey = function(event) {
+  const handleSpaceKey = function(event) {
     // keybind: alt + shift + space
     if (!(event.shiftKey && event.altKey)) {
       return
     }
-    var currentLine = getCurrentLine(event)
+    const currentLine = getCurrentLine(event)
     if (!currentLine) {
       return
     }
 
-    var $target = $(event.target)
-    var match = currentLine.text.match(/^(\s*)(-|\+|\*|\d+\.) (?:\[(x| )\] )(.*)/)
+    const $target = $(event.target)
+    const match = currentLine.text.match(/^(\s*)(-|\+|\*|\d+\.) (?:\[(x| )\] )(.*)/)
     if (match) {
       event.preventDefault()
-      var checkMark = match[3] == ' ' ? 'x' : ' '
-      var replaceTo = match[1] + match[2] + ' [' + checkMark + '] ' + match[4]
+      const checkMark = match[3] == ' ' ? 'x' : ' '
+      const replaceTo = match[1] + match[2] + ' [' + checkMark + '] ' + match[4]
       $target.selection('setPos', { start: currentLine.start, end: currentLine.end })
       // $target.selection('replace', {text: replaceTo, mode: 'keep'});
       insertText(currentLine.start, currentLine.end, replaceTo, 'replace')
@@ -362,16 +362,16 @@ $(function() {
     }
   })
 
-  var handlePasteEvent = function(event) {
-    var currentLine = getCurrentLine(event)
+  const handlePasteEvent = function(event) {
+    const currentLine = getCurrentLine(event)
 
     if (!currentLine) {
       return false
     }
-    var $target = $(event.target)
-    var pasteText = event.clipboardData.getData('text')
+    const $target = $(event.target)
+    let pasteText = event.clipboardData.getData('text')
 
-    var match = currentLine.text.match(/^(\s*(?:>|-|\+|\*|\d+\.) (?:\[(?:x| )\] )?)/)
+    const match = currentLine.text.match(/^(\s*(?:>|-|\+|\*|\d+\.) (?:\[(?:x| )\] )?)/)
     if (match) {
       if (pasteText.match(/(?:\r\n|\r|\n)/)) {
         pasteText = pasteText.replace(/(\r\n|\r|\n)/g, '$1' + match[1])
@@ -381,7 +381,7 @@ $(function() {
     // $target.selection('insert', {text: pasteText, mode: 'after'});
     insertText(currentLine.caret, currentLine.caret, pasteText, 'replace')
 
-    var newPos = currentLine.caret + pasteText.length
+    const newPos = currentLine.caret + pasteText.length
     $target.selection('setPos', { start: newPos, end: newPos })
 
     return true
@@ -396,13 +396,13 @@ $(function() {
     })
   }
 
-  var unbindInlineAttachment = function($form) {
+  const unbindInlineAttachment = function($form) {
     $form.unbind('.inlineattach')
   }
-  var bindInlineAttachment = function($form, attachmentOption) {
-    var editor = createEditorInstance($form)
-    var InlineAttachment = inlineAttachment
-    var inlineattach = new InlineAttachment(attachmentOption, editor)
+  const bindInlineAttachment = function($form, attachmentOption) {
+    const editor = createEditorInstance($form)
+    const InlineAttachment = inlineAttachment
+    const inlineattach = new InlineAttachment(attachmentOption, editor)
     $form.bind({
       'paste.inlineattach': function(e) {
         inlineattach.onPaste(e.originalEvent)
@@ -419,7 +419,7 @@ $(function() {
     })
   }
   var createEditorInstance = function($form) {
-    var $this = $form
+    const $this = $form
 
     return {
       getValue: function() {
@@ -434,12 +434,12 @@ $(function() {
     }
   }
 
-  var $inputForm = $('form.uploadable textarea#form-body')
+  const $inputForm = $('form.uploadable textarea#form-body')
   if ($inputForm.length > 0) {
-    var csrfToken = $('form.uploadable input#edit-form-csrf').val()
+    const csrfToken = $('form.uploadable input#edit-form-csrf').val()
     var pageId = $('#content-main').data('page-id') || 0
     var pagePath = $('#content-main').data('path')
-    var attachmentOption: any = {
+    const attachmentOption: any = {
       uploadUrl: '/_api/attachments.add',
       extraParams: {
         path: pagePath,
@@ -452,7 +452,7 @@ $(function() {
     }
 
     // if files upload is set
-    var { upload } = crowi.getContext()
+    const { upload } = crowi.getContext()
     if (upload.file) {
       attachmentOption.allowedTypes = '*'
     }
@@ -472,11 +472,11 @@ $(function() {
     }
 
     attachmentOption.onFileUploadResponse = function(res) {
-      var result = JSON.parse(res.response)
+      const result = JSON.parse(res.response)
 
       if (result.ok && result.pageCreated) {
-        var page = result.page
-        var pageId = page._id
+        const page = result.page
+        const pageId = page._id
 
         $('#content-main').data('page-id', page._id)
         $('#page-form [name="pageForm[currentRevision]"]').val(page.revision._id)
@@ -499,33 +499,33 @@ $(function() {
     })
   }
 
-  var enableScrollSync = function() {
-    var getMaxScrollTop = function(dom) {
-      var rect = dom.getBoundingClientRect()
+  const enableScrollSync = function() {
+    const getMaxScrollTop = function(dom) {
+      const rect = dom.getBoundingClientRect()
 
       return dom.scrollHeight - rect.height
     }
 
-    var getScrollRate = function(dom) {
-      var maxScrollTop = getMaxScrollTop(dom)
-      var rate = dom.scrollTop / maxScrollTop
+    const getScrollRate = function(dom) {
+      const maxScrollTop = getMaxScrollTop(dom)
+      const rate = dom.scrollTop / maxScrollTop
 
       return rate
     }
 
-    var getScrollTop = function(dom, rate) {
-      var maxScrollTop = getMaxScrollTop(dom)
-      var top = maxScrollTop * rate
+    const getScrollTop = function(dom, rate) {
+      const maxScrollTop = getMaxScrollTop(dom)
+      const top = maxScrollTop * rate
 
       return top
     }
 
-    var editor = document.querySelector('#form-body') as HTMLTextAreaElement
-    var preview = document.querySelector('#preview-body') as HTMLDivElement
+    const editor = document.querySelector('#form-body') as HTMLTextAreaElement
+    const preview = document.querySelector('#preview-body') as HTMLDivElement
 
     editor.addEventListener('scroll', function(event) {
-      var rate = getScrollRate(this)
-      var top = getScrollTop(preview, rate)
+      const rate = getScrollRate(this)
+      const top = getScrollTop(preview, rate)
 
       preview.scrollTop = top
     })

--- a/client/crowi-form.ts
+++ b/client/crowi-form.ts
@@ -3,8 +3,8 @@ $(function() {
   const crowiRenderer = window.crowiRenderer
   const inlineAttachment = window.inlineAttachment
 
-  var pageId = $('#content-main').data('page-id')
-  var pagePath = $('#content-main').data('path')
+  const pageId = $('#content-main').data('page-id')
+  const pagePath = $('#content-main').data('path')
 
   // show/hide
   function FetchPagesUpdatePostAndInsert(path) {
@@ -270,7 +270,7 @@ $(function() {
         }
       }
       // $target.selection('insert', {text: "\n" + listMark, mode: 'before'});
-      var pos = $target.selection('getPos')
+      const pos = $target.selection('getPos')
       insertText(pos.start, pos.start, '\n' + listMark, 'replace')
       const newPosition = pos.start + ('\n' + listMark).length
       $target.selection('setPos', { start: newPosition, end: newPosition })
@@ -295,7 +295,7 @@ $(function() {
       const prevLine = getPrevLine(event)
       if (!prevLine || (!currentLine.text.match(/---/) && !prevLine.text.match(/\|/g))) {
         // $target.selection('insert', {text: "\n" + row.join(' --- ') + "\n" + row.join('  '), mode: 'before'});
-        var pos = $target.selection('getPos')
+        const pos = $target.selection('getPos')
         insertText(pos.start, pos.start, '\n' + row.join(' --- ') + '\n' + row.join('  '), 'after')
         $target.selection('setPos', {
           start: currentLine.caret + 6 * row.length - 1,
@@ -303,7 +303,7 @@ $(function() {
         })
       } else {
         // $target.selection('insert', {text: "\n" + row.join('  '), mode: 'before'});
-        var pos = $target.selection('getPos')
+        const pos = $target.selection('getPos')
         insertText(pos.start, pos.end, '\n' + row.join('  '), 'after')
         $target.selection('setPos', { start: currentLine.caret + 3, end: currentLine.caret + 3 })
       }
@@ -418,7 +418,7 @@ $(function() {
       },
     })
   }
-  var createEditorInstance = function($form) {
+  const createEditorInstance = function($form) {
     const $this = $form
 
     return {
@@ -437,8 +437,8 @@ $(function() {
   const $inputForm = $('form.uploadable textarea#form-body')
   if ($inputForm.length > 0) {
     const csrfToken = $('form.uploadable input#edit-form-csrf').val()
-    var pageId = $('#content-main').data('page-id') || 0
-    var pagePath = $('#content-main').data('path')
+    const pageId = $('#content-main').data('page-id') || 0
+    const pagePath = $('#content-main').data('path')
     const attachmentOption: any = {
       uploadUrl: '/_api/attachments.add',
       extraParams: {

--- a/client/crowi-installer.ts
+++ b/client/crowi-installer.ts
@@ -3,7 +3,7 @@ import renderIcon from 'common/functions/renderIcon'
 
 $(function() {
   $('#register-form input[name="registerForm[username]"]').change(function(e) {
-    var username = $(this).val()
+    const username = $(this).val()
     $('#input-group-username').removeClass('has-error')
     $('#help-block-username').html('')
 

--- a/client/crowi-presentation.ts
+++ b/client/crowi-presentation.ts
@@ -45,7 +45,7 @@ Reveal.initialize({
 Reveal.addEventListener('ready', function(event) {
   // event.currentSlide, event.indexh, event.indexv
   $('.reveal section').each(function(e) {
-    var $self = $(this)
+    const $self = $(this)
     if ($self.children().length == 1) {
       $self.addClass('only')
     }

--- a/client/crowi.ts
+++ b/client/crowi.ts
@@ -611,8 +611,8 @@ $(function() {
     }
 
     // Like
-    var $likeButton = $('.like-button')
-    var $likeCount = $('#like-count')
+    const $likeButton = $('.like-button')
+    const $likeCount = $('#like-count')
     $likeButton.click(function() {
       const liked = $likeButton.data('liked')
       const token = window.APP_CONTEXT.csrfToken
@@ -632,7 +632,7 @@ $(function() {
 
       return false
     })
-    var $likerList = $('#liker-list')
+    const $likerList = $('#liker-list')
     const likers = $likerList.data('likers')
     if (likers && likers.length > 0) {
       const users = crowi.findUserByIds(likers.split(','))

--- a/client/crowi.ts
+++ b/client/crowi.ts
@@ -12,22 +12,22 @@ export default class Crowi {
   }
 
   static linkPath = (revisionPath?: string) => {
-    var $revisionPath = revisionPath || '#revision-path'
-    var $title = $($revisionPath)
-    var pathData = $('#content-main').data('path')
+    const $revisionPath = revisionPath || '#revision-path'
+    const $title = $($revisionPath)
+    const pathData = $('#content-main').data('path')
 
     if (!pathData) {
       return
     }
 
-    var realPath = pathData.trim()
+    let realPath = pathData.trim()
     if (realPath.substr(-1, 1) == '/') {
       realPath = realPath.substr(0, realPath.length - 1)
     }
 
-    var path = ''
-    var pathHtml = ''
-    var splittedPath = realPath.split(/\//)
+    let path = ''
+    let pathHtml = ''
+    const splittedPath = realPath.split(/\//)
     splittedPath.shift()
     splittedPath.forEach((sub: string) => {
       path += '/'
@@ -46,10 +46,10 @@ export default class Crowi {
 
   static correctHeaders = (contentId: string) => {
     // h1 ~ h6 の id 名を補正する
-    var $content = $(contentId || '#revision-body-content')
-    var i = 0
+    const $content = $(contentId || '#revision-body-content')
+    let i = 0
     $('h1,h2,h3,h4,h5,h6', $content).each(function() {
-      var id = 'head' + i++
+      const id = 'head' + i++
       $(this).attr('id', id)
       $(this).addClass('revision-head')
       $(this).append(`<span class="revision-head-link"><a href="#${id}">${renderIcon(linkVariant)}</a></span>`)
@@ -57,40 +57,40 @@ export default class Crowi {
   }
 
   static revisionToc = (contentId, tocId) => {
-    var $content = $(contentId || '#revision-body-content')
-    var $tocId = $(tocId || '#revision-toc')
+    const $content = $(contentId || '#revision-body-content')
+    const $tocId = $(tocId || '#revision-toc')
 
-    var $tocContent = $('<div id="revision-toc-content" class="revision-toc-content collapse"></div>')
+    const $tocContent = $('<div id="revision-toc-content" class="revision-toc-content collapse"></div>')
     $tocId.append($tocContent)
 
     $('h1', $content).each(function() {
-      var id = $(this).attr('id')
-      var title = $(this).text()
-      var selector = '#' + id + ' ~ h2:not(#' + id + ' ~ h1 ~ h2)'
+      const id = $(this).attr('id')
+      const title = $(this).text()
+      const selector = '#' + id + ' ~ h2:not(#' + id + ' ~ h1 ~ h2)'
 
-      var $toc = $('<ul></ul>')
-      var $tocLi = $('<li><a href="#' + id + '">' + title + '</a></li>')
+      const $toc = $('<ul></ul>')
+      const $tocLi = $('<li><a href="#' + id + '">' + title + '</a></li>')
 
       $tocContent.append($toc)
       $toc.append($tocLi)
 
       $(selector).each(function() {
-        var id2 = $(this).attr('id')
-        var title2 = $(this).text()
-        var selector2 = '#' + id2 + ' ~ h3:not(#' + id2 + ' ~ h2 ~ h3)'
+        const id2 = $(this).attr('id')
+        const title2 = $(this).text()
+        const selector2 = '#' + id2 + ' ~ h3:not(#' + id2 + ' ~ h2 ~ h3)'
 
-        var $toc2 = $('<ul></ul>')
-        var $tocLi2 = $('<li><a href="#' + id2 + '">' + title2 + '</a></li>')
+        const $toc2 = $('<ul></ul>')
+        const $tocLi2 = $('<li><a href="#' + id2 + '">' + title2 + '</a></li>')
 
         $tocLi.append($toc2)
         $toc2.append($tocLi2)
 
         $(selector2).each(function() {
-          var id3 = $(this).attr('id')
-          var title3 = $(this).text()
+          const id3 = $(this).attr('id')
+          const title3 = $(this).text()
 
-          var $toc3 = $('<ul></ul>')
-          var $tocLi3 = $('<li><a href="#' + id3 + '">' + title3 + '</a></li>')
+          const $toc3 = $('<ul></ul>')
+          const $tocLi3 = $('<li><a href="#' + id3 + '">' + title3 + '</a></li>')
 
           $tocLi2.append($toc3)
           $toc3.append($tocLi3)
@@ -117,31 +117,31 @@ export default class Crowi {
       .replace(/&quot;/g, '"')
 
   static modifyScrollTop = () => {
-    var offset = 10
+    const offset = 10
 
-    var hash = window.location.hash
+    const hash = window.location.hash
     if (hash === '') {
       return
     }
 
-    var pageHeader = document.querySelector('#page-header')
+    const pageHeader = document.querySelector('#page-header')
     if (!pageHeader) {
       return
     }
-    var pageHeaderRect = pageHeader.getBoundingClientRect()
+    const pageHeaderRect = pageHeader.getBoundingClientRect()
 
-    var sectionHeader = document.querySelector(hash)
+    const sectionHeader = document.querySelector(hash)
     if (sectionHeader === null) {
       return
     }
 
-    var timeout = 0
+    let timeout = 0
     if (window.scrollY === 0) {
       timeout = 200
     }
     setTimeout(() => {
       if (!sectionHeader) return
-      var sectionHeaderRect = sectionHeader.getBoundingClientRect()
+      const sectionHeaderRect = sectionHeader.getBoundingClientRect()
       if (sectionHeaderRect.top >= pageHeaderRect.bottom) {
         return
       }
@@ -151,7 +151,7 @@ export default class Crowi {
   }
 
   static findHashFromUrl = url => {
-    var match
+    let match
     if ((match = url.match(/#(.+)$/))) {
       return '#' + match[1]
     }
@@ -180,10 +180,10 @@ $(function() {
   const crowi = window.crowi
   const crowiRenderer = window.crowiRenderer
 
-  var pageId = $('#content-main').data('page-id')
-  var isSeen = $('#content-main').data('page-is-seen')
-  var pagePath = $('#content-main').data('path')
-  var isSharePage = !!$('#content-main').data('is-share-page')
+  const pageId = $('#content-main').data('page-id')
+  const isSeen = $('#content-main').data('page-is-seen')
+  const pagePath = $('#content-main').data('path')
+  const isSharePage = !!$('#content-main').data('is-share-page')
 
   Crowi.linkPath()
 
@@ -192,7 +192,7 @@ $(function() {
   $('[data-tooltip-stay]').tooltip('show')
 
   $('#toggle-sidebar').click(function(e) {
-    var $mainContainer = $('.main-container')
+    const $mainContainer = $('.main-container')
     if ($mainContainer.hasClass('aside-hidden')) {
       $('.main-container').removeClass('aside-hidden')
       $.cookie('aside-hidden', 0, { expires: 30, path: '/' })
@@ -223,7 +223,7 @@ $(function() {
         newPageNameCheck.html(`${renderIcon(alert)} ${res.error}`)
         newPageNameCheck.addClass('alert-danger')
       } else {
-        var page = res.page
+        const page = res.page
 
         newPageNameCheck.removeClass('alert-danger')
         // $('#newPageNameCheck').html('<img src="/images/loading_s.gif"> 移動しました。移動先にジャンプします。');
@@ -256,7 +256,7 @@ $(function() {
         $('#delete-errors').html(`${renderIcon(alert)} ${res.error}`)
         $('#delete-errors').addClass('alert-danger')
       } else {
-        var page = res.page
+        const page = res.page
         top.location.href = page.path
       }
     })
@@ -274,7 +274,7 @@ $(function() {
         $('#delete-errors').html(`${renderIcon(alert)} ${res.error}`)
         $('#delete-errors').addClass('alert-danger')
       } else {
-        var page = res.page
+        const page = res.page
         top.location.href = page.path
       }
     })
@@ -292,7 +292,7 @@ $(function() {
         $('#delete-errors').html(`${renderIcon(alert)} ${res.error}`)
         $('#delete-errors').addClass('alert-danger')
       } else {
-        var page = res.page
+        const page = res.page
         top.location.href = page.path + '?unlinked=true'
       }
     })
@@ -305,9 +305,9 @@ $(function() {
     $('.content-main').addClass('on-edit')
     $('.portal a[data-toggle="tab"][href="#edit-form"]').tab('show')
 
-    var path = $('.content-main').data('path')
+    const path = $('.content-main').data('path')
     if (path != '/' && $('.content-main').data('page-id') == '') {
-      var upperPage = path.substr(0, path.length - 1)
+      const upperPage = path.substr(0, path.length - 1)
       $.get('/_api/pages.get', { path: upperPage }, function(res) {
         if (res.ok && res.page) {
           $('#portal-warning-modal').modal('show')
@@ -336,23 +336,23 @@ $(function() {
 
   // for list page
   $('a[data-toggle="tab"][href="#view-timeline"]').on('show.bs.tab', function() {
-    var isShown = $('#view-timeline').data('shown')
+    const isShown = $('#view-timeline').data('shown')
     if (isShown == 0) {
       $('#view-timeline .timeline-body').each(function() {
-        var id = $(this).attr('id')
-        var contentId = '#' + id + ' > script'
-        var revisionBody = '#' + id + ' .revision-body'
-        var $revisionBody = $(revisionBody)
+        const id = $(this).attr('id')
+        const contentId = '#' + id + ' > script'
+        const revisionBody = '#' + id + ' .revision-body'
+        const $revisionBody = $(revisionBody)
         // var revisionPath = '#' + id + ' .revision-path'
 
-        var markdown = Crowi.unescape($(contentId).html())
-        var parsedHTML = crowiRenderer.render(markdown, $revisionBody.get(0))
+        const markdown = Crowi.unescape($(contentId).html())
+        const parsedHTML = crowiRenderer.render(markdown, $revisionBody.get(0))
         $revisionBody.html(parsedHTML)
 
         $('.template-create-button', $revisionBody).on('click', function() {
-          var path = $(this).data('path')
-          var templateId = $(this).data('template')
-          var template = $('#' + templateId).html()
+          const path = $(this).data('path')
+          const templateId = $(this).data('template')
+          const template = $('#' + templateId).html()
 
           crowi.saveDraft(path, template)
           top.location.href = path
@@ -364,7 +364,7 @@ $(function() {
   })
 
   $('#register-form input[name="registerForm[username]"]').change(function(e) {
-    var username = $(this).val()
+    const username = $(this).val()
     $('#input-group-username').removeClass('has-error')
     $('#help-block-username').html('')
 
@@ -378,7 +378,7 @@ $(function() {
 
   // omg /login/invited
   $('#invited-form input[name="invitedForm[username]"]').change(function(e) {
-    var username = $(this).val()
+    const username = $(this).val()
     $('#input-group-username').removeClass('has-error')
     $('#help-block-username').html('')
 
@@ -534,17 +534,17 @@ $(function() {
 
   if (pageId) {
     // if page exists
-    var $rawTextOriginal = $('#raw-text-original')
+    const $rawTextOriginal = $('#raw-text-original')
     if ($rawTextOriginal.length > 0) {
-      var markdown = Crowi.unescape($('#raw-text-original').html())
-      var revisionBody = $('#revision-body-content')
-      var parsedHTML = crowiRenderer.render(markdown, revisionBody.get(0))
+      const markdown = Crowi.unescape($('#raw-text-original').html())
+      const revisionBody = $('#revision-body-content')
+      const parsedHTML = crowiRenderer.render(markdown, revisionBody.get(0))
       revisionBody.html(parsedHTML)
 
       $('.template-create-button').on('click', function() {
-        var path = $(this).data('path')
-        var templateId = $(this).data('template')
-        var template = $('#' + templateId).html()
+        const path = $(this).data('path')
+        const templateId = $(this).data('template')
+        const template = $('#' + templateId).html()
 
         crowi.saveDraft(path, template)
         top.location.href = path
@@ -585,12 +585,12 @@ $(function() {
     }
 
     const CreateUserLinkWithPicture = function(user) {
-      var $userHtml = $('<a>')
+      const $userHtml = $('<a>')
       $userHtml.data('user-id', user._id)
       $userHtml.attr('href', '/user/' + user.username)
       $userHtml.attr('title', user.name)
 
-      var $userPicture = $('<img class="picture picture-xs picture-rounded">')
+      const $userPicture = $('<img class="picture picture-xs picture-rounded">')
       $userPicture.attr('alt', user.name)
       $userPicture.attr('src', getUserPicture(user))
 
@@ -614,8 +614,8 @@ $(function() {
     var $likeButton = $('.like-button')
     var $likeCount = $('#like-count')
     $likeButton.click(function() {
-      var liked = $likeButton.data('liked')
-      var token = window.APP_CONTEXT.csrfToken
+      const liked = $likeButton.data('liked')
+      const token = window.APP_CONTEXT.csrfToken
       if (!liked) {
         $.post('/_api/likes.add', { _csrf: token, page_id: pageId }, function(res) {
           if (res.ok) {
@@ -633,9 +633,9 @@ $(function() {
       return false
     })
     var $likerList = $('#liker-list')
-    var likers = $likerList.data('likers')
+    const likers = $likerList.data('likers')
     if (likers && likers.length > 0) {
-      var users = crowi.findUserByIds(likers.split(','))
+      const users = crowi.findUserByIds(likers.split(','))
       if (users) {
         AddToLikers(users)
       }
@@ -651,12 +651,12 @@ $(function() {
     }
 
     // presentation
-    var presentaionInitialized = false
-    var $b = $('body')
+    let presentaionInitialized = false
+    const $b = $('body')
 
     $(document)
       .on('click', '.toggle-presentation', function(e) {
-        var $a = $(this)
+        const $a = $(this)
 
         e.preventDefault()
         $b.toggleClass('overlay-on')
@@ -706,10 +706,10 @@ window.addEventListener('load', function(e) {
   }
 
   if ((crowi && crowi.users) || crowi.users.length == 0) {
-    var totalUsers = crowi.users.length
-    var $listLiker = $('.page-list-liker')
+    const totalUsers = crowi.users.length
+    const $listLiker = $('.page-list-liker')
     $listLiker.each(function(i, liker) {
-      var count = $(liker).data('count') || 0
+      const count = $(liker).data('count') || 0
       if (count / totalUsers > 0.05) {
         $(liker).addClass('popular-page-high')
         // 5%
@@ -721,9 +721,9 @@ window.addEventListener('load', function(e) {
         // 0.5%
       }
     })
-    var $listSeer = $('.page-list-seer')
+    const $listSeer = $('.page-list-seer')
     $listSeer.each(function(i, seer) {
-      var count = $(seer).data('count') || 0
+      const count = $(seer).data('count') || 0
       if (count / totalUsers > 0.1) {
         // 10%
         $(seer).addClass('popular-page-high')

--- a/client/utils/CrowiRenderer.ts
+++ b/client/utils/CrowiRenderer.ts
@@ -128,7 +128,7 @@ export default class CrowiRenderer {
       // override
       // @ts-ignore
       marked.Lexer.lex = function(src: string, options: marked.MarkedOptions) {
-        var lexer = new marked.Lexer(options)
+        const lexer = new marked.Lexer(options)
 
         // this is maybe not an official way
         // @ts-ignore: Unofficial hack

--- a/client/utils/PreProcessor/MarkdownFixer.ts
+++ b/client/utils/PreProcessor/MarkdownFixer.ts
@@ -1,6 +1,6 @@
 export default class MarkdownFixer {
   process(markdown: string) {
-    var x = markdown
+    const x = markdown
       .replace(/^(#{1,})((?![\s#]+).+)$/gm, '$1 $2') // spacer for section
       .replace(/>[\s]*\n>[\s]*\n/g, '> <br>\n> \n')
 

--- a/lib/controllers/admin.ts
+++ b/lib/controllers/admin.ts
@@ -186,7 +186,7 @@ export default (crowi: Crowi) => {
   actions.user = {}
   actions.api.user = {}
   actions.api.user.index = function(req: Request, res: Response) {
-    var page = parseInt(req.query.page) || 1
+    const page = parseInt(req.query.page) || 1
 
     // uq means user query
     // q used by search box on header
@@ -248,7 +248,7 @@ export default (crowi: Crowi) => {
   }
 
   actions.api.user.makeAdmin = function(req: Request, res: Response) {
-    var id = req.params.id
+    const id = req.params.id
     User.findById(id, function(err, userData) {
       ;(userData as UserDocument).makeAdmin(function(err, userData) {
         if (err === null) {
@@ -261,7 +261,7 @@ export default (crowi: Crowi) => {
   }
 
   actions.api.user.removeFromAdmin = function(req: Request, res: Response) {
-    var id = req.params.id
+    const id = req.params.id
     User.findById(id, function(err, userData) {
       ;(userData as UserDocument).removeFromAdmin(function(err, userData) {
         if (err === null) {
@@ -274,7 +274,7 @@ export default (crowi: Crowi) => {
   }
 
   actions.api.user.activate = function(req: Request, res: Response) {
-    var id = req.params.id
+    const id = req.params.id
     User.findById(id, function(err, userData) {
       ;(userData as UserDocument).statusActivate(function(err, userData) {
         if (err === null) {
@@ -287,7 +287,7 @@ export default (crowi: Crowi) => {
   }
 
   actions.api.user.suspend = function(req: Request, res: Response) {
-    var id = req.params.id
+    const id = req.params.id
 
     User.findById(id, function(err, userData) {
       ;(userData as UserDocument).statusSuspend(function(err, userData) {
@@ -308,7 +308,7 @@ export default (crowi: Crowi) => {
   // これやったときの relation の挙動未確認
   actions.user.removeCompletely = function(req: Request, res: Response) {
     // ユーザーの物理削除
-    var id = req.params.id
+    const id = req.params.id
 
     User.removeCompletelyById(id, function(err, removed) {
       if (err) {
@@ -394,9 +394,9 @@ export default (crowi: Crowi) => {
 
   actions.api.notificationAdd = function(req: Request, res: Response) {
     const user = req.user as UserDocument
-    var UpdatePost = crowi.model('UpdatePost')
-    var pathPattern = req.body.pathPattern
-    var channel = req.body.channel
+    const UpdatePost = crowi.model('UpdatePost')
+    const pathPattern = req.body.pathPattern
+    const channel = req.body.channel
 
     debug('notification.add', pathPattern, channel)
     UpdatePost.createUpdatePost(pathPattern, channel, user._id)
@@ -472,7 +472,7 @@ export default (crowi: Crowi) => {
       option.secure = true
     }
 
-    var smtpClient = mailer.createSMTPClient(option)
+    const smtpClient = mailer.createSMTPClient(option)
     debug('mailer setup for validate SMTP setting', smtpClient)
 
     smtpClient.sendMail(

--- a/lib/controllers/attachment.ts
+++ b/lib/controllers/attachment.ts
@@ -17,7 +17,7 @@ export default (crowi: Crowi, app: Express) => {
   actions.api = api
 
   api.redirector = function(req: Request, res: Response) {
-    var id = req.params.id
+    const id = req.params.id
 
     Attachment.findById(id)
       .then(function(data) {
@@ -29,7 +29,7 @@ export default (crowi: Crowi, app: Express) => {
           .then(fileName => {
             const encodedFileName = encodeURIComponent(data.originalName)
 
-            var deliveryFile = {
+            const deliveryFile = {
               fileName: fileName,
               options: {
                 headers: {
@@ -65,18 +65,18 @@ export default (crowi: Crowi, app: Express) => {
    * @apiParam {String} page_id
    */
   api.list = function(req: Request, res: Response) {
-    var id = req.query.page_id || null
+    const id = req.query.page_id || null
     if (!id) {
       return res.json(ApiResponse.error('Parameters page_id is required.'))
     }
 
     Attachment.getListByPageId(id).then(function(attachments) {
-      var config = crowi.getConfig()
-      var baseUrl = config.crowi['app:url'] || ''
+      const config = crowi.getConfig()
+      const baseUrl = config.crowi['app:url'] || ''
       return res.json(
         ApiResponse.success({
           attachments: attachments.map(at => {
-            var fileUrl = at.fileUrl
+            const fileUrl = at.fileUrl
             at = at.toObject()
             at.url = baseUrl + fileUrl
             return at

--- a/lib/controllers/backlink.ts
+++ b/lib/controllers/backlink.ts
@@ -24,7 +24,7 @@ export default (crowi: Crowi) => {
 
     Backlink.findByPageId(pageId, limit, offset)
       .then(backlinks => {
-        var result = {
+        const result = {
           data: backlinks,
         }
         return res.json(ApiResponse.success(result))

--- a/lib/controllers/bookmark.ts
+++ b/lib/controllers/bookmark.ts
@@ -21,7 +21,7 @@ export default (crowi: Crowi) => {
    */
   actions.api.get = function(req: Request, res: Response) {
     const user = req.user as UserDocument
-    var pageId = req.query.page_id
+    const pageId = req.query.page_id
 
     Bookmark.findByPageIdAndUserId(pageId, user._id)
       .then(function(bookmark) {
@@ -40,9 +40,9 @@ export default (crowi: Crowi) => {
    */
   actions.api.list = function(req: Request, res: Response) {
     const user = req.user as UserDocument
-    var paginateOptions = ApiPaginate.parseOptions(req.query)
+    const paginateOptions = ApiPaginate.parseOptions(req.query)
 
-    var options = Object.assign(paginateOptions, { populatePage: true })
+    const options = Object.assign(paginateOptions, { populatePage: true })
     Bookmark.findByUserId(user._id, options)
       .then(function(result) {
         return res.json(ApiResponse.success(result))
@@ -60,7 +60,7 @@ export default (crowi: Crowi) => {
    * @apiParam {String} page_id Page Id.
    */
   actions.api.add = async function(req: Request, res: Response) {
-    var pageId = req.body.page_id
+    const pageId = req.body.page_id
 
     try {
       const pageData = await Page.findPageByIdAndGrantedUser(pageId, req.user)
@@ -90,7 +90,7 @@ export default (crowi: Crowi) => {
    * @apiParam {String} page_id Page Id.
    */
   actions.api.remove = function(req: Request, res: Response) {
-    var pageId = req.body.page_id
+    const pageId = req.body.page_id
 
     Bookmark.removeBookmark(pageId, req.user)
       .then(function(data) {

--- a/lib/controllers/comment.ts
+++ b/lib/controllers/comment.ts
@@ -20,8 +20,8 @@ export default (crowi: Crowi) => {
    * @apiParam {String} revision_id Revision Id.
    */
   api.get = function(req: Request, res: Response) {
-    var pageId = req.query.page_id
-    var revisionId = req.query.revision_id
+    const pageId = req.query.page_id
+    const revisionId = req.query.revision_id
 
     if (revisionId) {
       return Comment.getCommentsByRevisionId(revisionId)

--- a/lib/controllers/installer.ts
+++ b/lib/controllers/installer.ts
@@ -12,14 +12,14 @@ export default (crowi: Crowi) => {
   }
 
   actions.createAdmin = function(req: Request, res: Response) {
-    var registerForm = req.body.registerForm || {}
-    var language = req.language || 'en'
+    const registerForm = req.body.registerForm || {}
+    const language = req.language || 'en'
 
     if (req.form.isValid) {
-      var name = registerForm.name
-      var username = registerForm.username
-      var email = registerForm.email
-      var password = registerForm.password
+      const name = registerForm.name
+      const username = registerForm.username
+      const email = registerForm.email
+      const password = registerForm.password
 
       User.createUserByEmailAndPassword(name, username, email, password, language, function(err, userData) {
         if (err) {

--- a/lib/controllers/login.ts
+++ b/lib/controllers/login.ts
@@ -103,8 +103,8 @@ export default (crowi: Crowi, app: Express) => {
   }
 
   actions.error = function(req: Request, res: Response) {
-    var reason = req.params.reason
-    var reasonMessage = ''
+    const reason = req.params.reason
+    let reasonMessage = ''
 
     if (reason === 'suspended') {
       reasonMessage = 'This account is suspended.'
@@ -448,11 +448,11 @@ export default (crowi: Crowi, app: Express) => {
     }
 
     if (req.method == 'POST' && req.form.isValid) {
-      var user = req.user
-      var invitedForm = req.form.invitedForm || {}
-      var username = invitedForm.username
-      var name = invitedForm.name
-      var password = invitedForm.password
+      const user = req.user
+      const invitedForm = req.form.invitedForm || {}
+      const username = invitedForm.username
+      const name = invitedForm.name
+      const password = invitedForm.password
 
       User.isRegisterableUsername(username, function(creatable) {
         if (creatable) {

--- a/lib/controllers/me.ts
+++ b/lib/controllers/me.ts
@@ -18,11 +18,11 @@ export default (crowi: Crowi, app: Express) => {
 
   api.uploadPicture = function(req: Request, res: Response) {
     const user = req.user as UserDocument
-    var fileUploader = FileUploader(crowi)
+    const fileUploader = FileUploader(crowi)
     // var storagePlugin = new pluginService('storage');
     // var storage = require('../service/storage').StorageService(config);
 
-    var tmpFile = req.file || null
+    const tmpFile = req.file || null
     if (!tmpFile) {
       return res.json({
         status: false,
@@ -30,11 +30,11 @@ export default (crowi: Crowi, app: Express) => {
       })
     }
 
-    var tmpPath = tmpFile.path
-    var name = tmpFile.filename + tmpFile.originalname
-    var ext = name.match(/(.*)(?:\.([^.]+$))/)?.[2] || ''
-    var filePath = User.createUserPictureFilePath(user, ext)
-    var acceptableFileType = /image\/.+/
+    const tmpPath = tmpFile.path
+    const name = tmpFile.filename + tmpFile.originalname
+    const ext = name.match(/(.*)(?:\.([^.]+$))/)?.[2] || ''
+    const filePath = User.createUserPictureFilePath(user, ext)
+    const acceptableFileType = /image\/.+/
 
     if (!tmpFile.mimetype.match(acceptableFileType)) {
       return res.json({
@@ -50,7 +50,7 @@ export default (crowi: Crowi, app: Express) => {
     //  'url': imageUrl,
     //  'message': '',
     // });
-    var tmpFileStream = fs.createReadStream(tmpPath, {
+    const tmpFileStream = fs.createReadStream(tmpPath, {
       flags: 'r',
       mode: 666,
       autoClose: true,
@@ -59,7 +59,7 @@ export default (crowi: Crowi, app: Express) => {
     fileUploader
       .uploadFile(filePath, tmpFile.mimetype, tmpFileStream, {})
       .then(function(data) {
-        var imageUrl = fileUploader.generateUrl(filePath)
+        const imageUrl = fileUploader.generateUrl(filePath)
         user.updateImage(imageUrl, function(err, data) {
           fs.unlink(tmpPath, function(err) {
             // エラー自体は無視
@@ -140,9 +140,9 @@ export default (crowi: Crowi, app: Express) => {
     }
 
     if (req.method == 'POST' && req.form.isValid) {
-      var newPassword = passwordForm.newPassword
-      var newPasswordConfirm = passwordForm.newPasswordConfirm
-      var oldPassword = passwordForm.oldPassword
+      const newPassword = passwordForm.newPassword
+      const newPasswordConfirm = passwordForm.newPasswordConfirm
+      const oldPassword = passwordForm.oldPassword
 
       if (user.isPasswordSet() && !user.isPasswordValid(oldPassword)) {
         req.form.errors.push('Wrong current password')
@@ -192,7 +192,7 @@ export default (crowi: Crowi, app: Express) => {
   }
 
   actions.notifications = function(req: Request, res: Response) {
-    var renderVars = {}
+    const renderVars = {}
 
     return res.render('me/notifications.html', renderVars)
   }

--- a/lib/controllers/page.ts
+++ b/lib/controllers/page.ts
@@ -115,9 +115,9 @@ export default (crowi: Crowi) => {
   }
 
   actions.deletedPageListShow = function(req: Request, res: Response) {
-    var path = '/trash' + getPathFromRequest(req)
-    var limit = 50
-    var offset = parseInt(req.query.offset) || 0
+    const path = '/trash' + getPathFromRequest(req)
+    const limit = 50
+    const offset = parseInt(req.query.offset) || 0
 
     // index page
     const pagerOptions: PagerOptions = { offset, limit }
@@ -230,7 +230,7 @@ export default (crowi: Crowi) => {
     const path = getPathFromRequest(req)
 
     // FIXME: せっかく getPathFromRequest になってるのにここが生 params[0] だとダサイ
-    var isMarkdown = req.params[0].match(/.+\.md$/) || false
+    const isMarkdown = req.params[0].match(/.+\.md$/) || false
 
     res.locals.path = path
     try {
@@ -287,21 +287,21 @@ export default (crowi: Crowi) => {
   }
 
   actions.pageEdit = function(req: Request, res: Response) {
-    var pageForm = req.body.pageForm
-    var body = pageForm.body
-    var currentRevision = pageForm.currentRevision
-    var grant = pageForm.grant
-    var path = pageForm.path
+    const pageForm = req.body.pageForm
+    const body = pageForm.body
+    const currentRevision = pageForm.currentRevision
+    const grant = pageForm.grant
+    const path = pageForm.path
 
     // TODO: make it pluggable
-    var notify = pageForm.notify || {}
+    const notify = pageForm.notify || {}
 
     debug('notify: ', notify)
 
-    var redirectPath = encodeURI(path)
-    var pageData: PageDocument | null | {} = {}
-    var updateOrCreate
-    var previousRevision: Types.ObjectId | null | false = false
+    const redirectPath = encodeURI(path)
+    let pageData: PageDocument | null | {} = {}
+    let updateOrCreate
+    let previousRevision: Types.ObjectId | null | false = false
 
     // set to render
     res.locals.pageForm = pageForm
@@ -312,7 +312,7 @@ export default (crowi: Crowi) => {
       return
     }
 
-    var ignoreNotFound = true
+    const ignoreNotFound = true
     Page.findPage(path, req.user, null, ignoreNotFound)
       .then(function(data) {
         pageData = data
@@ -353,7 +353,7 @@ export default (crowi: Crowi) => {
 
             if (crowi.slack) {
               notify.slack.channel.split(',').map(function(chan) {
-                var message = crowi.slack.prepareSlackMessage(pageData, req.user, chan, updateOrCreate, previousRevision)
+                const message = crowi.slack.prepareSlackMessage(pageData, req.user, chan, updateOrCreate, previousRevision)
                 crowi.slack
                   .post(message.channel, message.text, message)
                   .then(function() {})
@@ -377,14 +377,14 @@ export default (crowi: Crowi) => {
 
   // app.get( '/users/:username([^/]+)/bookmarks'      , loginRequired(crowi, app) , page.userBookmarkList);
   actions.userBookmarkList = function(req: Request, res: Response) {
-    var username = req.params.username
-    var limit = 50
-    var offset = parseInt(req.query.offset) || 0
+    const username = req.params.username
+    const limit = 50
+    const offset = parseInt(req.query.offset) || 0
 
-    var renderVars: any = {}
+    const renderVars: any = {}
 
-    var pagerOptions: PagerOptions = { offset, limit }
-    var queryOptions = { offset, limit: limit + 1, populatePage: true, requestUser: req.user }
+    const pagerOptions: PagerOptions = { offset, limit }
+    const queryOptions = { offset, limit: limit + 1, populatePage: true, requestUser: req.user }
 
     User.findUserByUsername(username)
       .then(function(user) {
@@ -414,14 +414,14 @@ export default (crowi: Crowi) => {
 
   // app.get( '/users/:username([^/]+)/recent-create' , loginRequired(crowi, app) , page.userRecentCreatedList);
   actions.userRecentCreatedList = function(req: Request, res: Response) {
-    var username = req.params.username
-    var limit = 50
-    var offset = parseInt(req.query.offset) || 0
+    const username = req.params.username
+    const limit = 50
+    const offset = parseInt(req.query.offset) || 0
 
-    var renderVars: any = {}
+    const renderVars: any = {}
 
-    var pagerOptions: PagerOptions = { offset, limit }
-    var queryOptions = { offset, limit: limit + 1 }
+    const pagerOptions: PagerOptions = { offset, limit }
+    const queryOptions = { offset, limit: limit + 1 }
 
     User.findUserByUsername(username)
       .then(function(user) {
@@ -453,7 +453,7 @@ export default (crowi: Crowi) => {
    * redirector
    */
   api.redirector = function(req: Request, res: Response) {
-    var id = req.params.id
+    const id = req.params.id
 
     Page.findPageById(id)
       .then(function(pageData) {
@@ -486,13 +486,13 @@ export default (crowi: Crowi) => {
    * @apiParam {String} user
    */
   api.list = function(req: Request, res: Response) {
-    var username = req.query.user || null
-    var path = req.query.path || null
-    var limit = 50
-    var offset = parseInt(req.query.offset) || 0
+    const username = req.query.user || null
+    const path = req.query.path || null
+    const limit = 50
+    const offset = parseInt(req.query.offset) || 0
 
-    var pagerOptions: PagerOptions = { offset, limit }
-    var queryOptions = { offset, limit: limit + 1 }
+    const pagerOptions: PagerOptions = { offset, limit }
+    const queryOptions = { offset, limit: limit + 1 }
 
     // Accepts only one of these
     if (username === null && path === null) {
@@ -502,7 +502,7 @@ export default (crowi: Crowi) => {
       return res.json(ApiResponse.error('Parameter user or path is required.'))
     }
 
-    var pageFetcher
+    let pageFetcher
     if (path === null) {
       pageFetcher = User.findUserByUsername(username).then(function(user) {
         if (user === null) {
@@ -539,15 +539,15 @@ export default (crowi: Crowi) => {
    * @apiParam {String} grant
    */
   api.create = function(req: Request, res: Response) {
-    var body = req.body.body || null
-    var pagePath = req.body.path || null
-    var grant = req.body.grant || null
+    const body = req.body.body || null
+    const pagePath = req.body.path || null
+    const grant = req.body.grant || null
 
     if (body === null || pagePath === null) {
       return res.json(ApiResponse.error('Parameters body and path are required.'))
     }
 
-    var ignoreNotFound = true
+    const ignoreNotFound = true
     Page.findPage(pagePath, req.user, null, ignoreNotFound)
       .then(function(data) {
         if (data !== null) {
@@ -560,7 +560,7 @@ export default (crowi: Crowi) => {
         if (!data) {
           throw new Error('Failed to create page.')
         }
-        var result = { page: data.toObject() }
+        const result = { page: data.toObject() }
 
         return res.json(ApiResponse.success(result))
       })
@@ -584,10 +584,10 @@ export default (crowi: Crowi) => {
    * - If revision_id is not specified => force update by the new contents.
    */
   api.update = function(req: Request, res: Response) {
-    var pageBody = req.body.body || null
-    var pageId = req.body.page_id || null
-    var revisionId = req.body.revision_id || null
-    var grant = req.body.grant || null
+    const pageBody = req.body.body || null
+    const pageId = req.body.page_id || null
+    const revisionId = req.body.revision_id || null
+    const grant = req.body.grant || null
 
     if (pageId === null || pageBody === null) {
       return res.json(ApiResponse.error('page_id and body are required.'))
@@ -599,14 +599,14 @@ export default (crowi: Crowi) => {
           throw new Error('Revision error.')
         }
 
-        var grantOption = { grant: pageData.grant }
+        const grantOption = { grant: pageData.grant }
         if (grant !== null) {
           grantOption.grant = grant
         }
         return Page.updatePage(pageData, pageBody, req.user, grantOption)
       })
       .then(function(pageData) {
-        var result = {
+        const result = {
           page: pageData.toObject(),
         }
         return res.json(ApiResponse.success(result))
@@ -662,7 +662,7 @@ export default (crowi: Crowi) => {
    * @apiParam {String} page_id Page Id.
    */
   api.seen = function(req: Request, res: Response) {
-    var pageId = req.body.page_id
+    const pageId = req.body.page_id
     if (!pageId) {
       return res.json(ApiResponse.error('page_id required'))
     }
@@ -690,14 +690,14 @@ export default (crowi: Crowi) => {
    * @apiParam {String} page_id Page Id.
    */
   api.like = function(req: Request, res: Response) {
-    var id = req.body.page_id
+    const id = req.body.page_id
 
     Page.findPageByIdAndGrantedUser(id, req.user)
       .then(function(pageData) {
         return pageData.like(req.user)
       })
       .then(function(data) {
-        var result = { page: data }
+        const result = { page: data }
         return res.json(ApiResponse.success(result))
       })
       .catch(function(err) {
@@ -714,14 +714,14 @@ export default (crowi: Crowi) => {
    * @apiParam {String} page_id Page Id.
    */
   api.unlike = function(req: Request, res: Response) {
-    var id = req.body.page_id
+    const id = req.body.page_id
 
     Page.findPageByIdAndGrantedUser(id, req.user)
       .then(function(pageData) {
         return pageData.unlike(req.user)
       })
       .then(function(data) {
-        var result = { page: data }
+        const result = { page: data }
         return res.json(ApiResponse.success(result))
       })
       .catch(function(err) {
@@ -738,8 +738,8 @@ export default (crowi: Crowi) => {
    * @apiParam {String} path
    */
   api.getUpdatePost = function(req: Request, res: Response) {
-    var path = req.query.path
-    var UpdatePost = crowi.model('UpdatePost')
+    const path = req.query.path
+    const UpdatePost = crowi.model('UpdatePost')
 
     if (!path) {
       return res.json(ApiResponse.error({}))
@@ -751,7 +751,7 @@ export default (crowi: Crowi) => {
           return e.channel
         })
         debug('Found updatePost data', data)
-        var result = { updatePost: data }
+        const result = { updatePost: data }
         return res.json(ApiResponse.success(result))
       })
       .catch(function(err) {
@@ -769,8 +769,8 @@ export default (crowi: Crowi) => {
    * @apiParam {String} revision_id
    */
   api.remove = function(req: Request, res: Response) {
-    var pageId = req.body.page_id
-    var previousRevision = req.body.revision_id || null
+    const pageId = req.body.page_id
+    const previousRevision = req.body.revision_id || null
 
     // get completely flag
     const isCompletely = req.body.completely !== undefined
@@ -810,7 +810,7 @@ export default (crowi: Crowi) => {
    * @apiParam {String} page_id Page Id.
    */
   api.revertRemove = function(req: Request, res: Response) {
-    var pageId = req.body.page_id
+    const pageId = req.body.page_id
 
     Page.findPageByIdAndGrantedUser(pageId, req.user)
       .then(function(pageData) {

--- a/lib/controllers/revision.ts
+++ b/lib/controllers/revision.ts
@@ -18,11 +18,11 @@ export default (crowi: Crowi) => {
    * @apiParam {String} revision_id Revision Id.
    */
   actions.api.get = function(req: Request, res: Response) {
-    var revisionId = req.query.revision_id
+    const revisionId = req.query.revision_id
 
     Revision.findRevision(revisionId)
       .then(function(revisionData) {
-        var result = {
+        const result = {
           revision: revisionData,
         }
         return res.json(ApiResponse.success(result))
@@ -41,7 +41,7 @@ export default (crowi: Crowi) => {
    * @apiParam {String} page_id      Page Id.
    */
   actions.api.ids = function(req: Request, res: Response) {
-    var pageId = req.query.page_id || null
+    const pageId = req.query.page_id || null
 
     if (pageId && crowi.isPageId(pageId)) {
       Page.findPageByIdAndGrantedUser(pageId, req.user)
@@ -69,8 +69,8 @@ export default (crowi: Crowi) => {
    * @apiParam {String} page_id      Page Id.
    */
   actions.api.list = function(req: Request, res: Response) {
-    var revisionIds = (req.query.revision_ids || '').split(',')
-    var pageId = req.query.page_id || null
+    const revisionIds = (req.query.revision_ids || '').split(',')
+    const pageId = req.query.page_id || null
 
     if (pageId) {
       Page.findPageByIdAndGrantedUser(pageId, req.user)

--- a/lib/controllers/search.ts
+++ b/lib/controllers/search.ts
@@ -12,8 +12,8 @@ export default (crowi: Crowi) => {
   const api = (actions.api = {} as any)
 
   actions.searchPage = function(req: Request, res: Response) {
-    var keyword = req.query.q || null
-    var search = crowi.getSearcher()
+    const keyword = req.query.q || null
+    const search = crowi.getSearcher()
     if (!search) {
       return res.json(ApiResponse.error('Configuration of ELASTICSEARCH_URI is required.'))
     }

--- a/lib/controllers/user.ts
+++ b/lib/controllers/user.ts
@@ -12,7 +12,7 @@ export default (crowi: Crowi) => {
   actions.api = api
 
   api.checkUsername = function(req: Request, res: Response) {
-    var username = req.query.username
+    const username = req.query.username
 
     User.findUserByUsername(username)
       .then(function(userData) {
@@ -35,9 +35,9 @@ export default (crowi: Crowi) => {
    * @apiParam {String} user_ids
    */
   api.list = function(req: Request, res: Response) {
-    var userIds = req.query.user_ids || null // TODO: handling
+    const userIds = req.query.user_ids || null // TODO: handling
 
-    var userFetcher
+    let userFetcher
     if (!userIds || userIds.split(',').length <= 0) {
       userFetcher = User.findAllUsers()
     } else {
@@ -46,7 +46,7 @@ export default (crowi: Crowi) => {
 
     userFetcher
       .then(function(userList) {
-        var result = {
+        const result = {
           users: userList,
         }
 

--- a/lib/crowi/index.ts
+++ b/lib/crowi/index.ts
@@ -225,7 +225,7 @@ class Crowi {
     // mongoUri = mongodb://user:password@host/dbname
     mongoose.Promise = global.Promise
 
-    var mongoUri =
+    const mongoUri =
       this.env.MONGOLAB_URI || // for B.C.
       this.env.MONGODB_URI || // MONGOLAB changes their env name
       this.env.MONGOHQ_URL ||

--- a/lib/middlewares/applicationInstalled.ts
+++ b/lib/middlewares/applicationInstalled.ts
@@ -2,7 +2,7 @@ import { Request, Response, NextFunction } from 'express'
 
 export default () => {
   return (req: Request, res: Response, next: NextFunction) => {
-    var config = req.config
+    const config = req.config
 
     if (Object.keys(config.crowi).length === 1) {
       // app:url is set by process

--- a/lib/middlewares/applicationNotInstalled.ts
+++ b/lib/middlewares/applicationNotInstalled.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express'
 
 export default () => {
   return (req: Request, res: Response, next) => {
-    var config = req.config
+    const config = req.config
 
     if (Object.keys(config.crowi).length !== 1) {
       req.flash('errorMessage', 'Application already installed.')

--- a/lib/middlewares/swigFilters.ts
+++ b/lib/middlewares/swigFilters.ts
@@ -12,7 +12,7 @@ export default (crowi: Crowi, app: Express) => {
     })
 
     swig.setFilter('normalizeDateInPath', function(path) {
-      var patterns = [
+      const patterns = [
         [/20(\d{2})(\d{2})(\d{2})(.+)/g, '20$1/$2/$3/$4'],
         [/20(\d{2})(\d{2})(\d{2})/g, '20$1/$2/$3'],
         [/20(\d{2})(\d{2})(.+)/g, '20$1/$2/$3'],
@@ -23,9 +23,9 @@ export default (crowi: Crowi, app: Express) => {
         [/20(\d{2})_(\d{1,2})/g, '20$1/$2'],
       ]
 
-      for (var i = 0; i < patterns.length; i++) {
-        var mat = patterns[i][0]
-        var rep = patterns[i][1]
+      for (let i = 0; i < patterns.length; i++) {
+        const mat = patterns[i][0]
+        const rep = patterns[i][1]
         if (path.match(mat)) {
           return path.replace(mat, rep)
         }

--- a/lib/models/attachment.ts
+++ b/lib/models/attachment.ts
@@ -36,7 +36,7 @@ export default (crowi: Crowi) => {
   const fileUploader = FileUploader(crowi)
 
   function generateFileHash(fileName) {
-    var hasher = crypto.createHash('md5')
+    const hasher = crypto.createHash('md5')
     hasher.update(fileName)
 
     return hasher.digest('hex')

--- a/lib/models/comment.ts
+++ b/lib/models/comment.ts
@@ -61,8 +61,8 @@ export default (crowi: Crowi) => {
    * post save hook
    */
   commentSchema.post('save', function(savedComment: CommentDocument) {
-    var Page = crowi.model('Page')
-    var Activity = crowi.model('Activity')
+    const Page = crowi.model('Page')
+    const Activity = crowi.model('Activity')
 
     Comment.countCommentByPageId(savedComment.page)
       .then(function(count) {

--- a/lib/models/page.test.ts
+++ b/lib/models/page.test.ts
@@ -143,7 +143,7 @@ describe('Page', () => {
 
       let forbidden: string[] = []
       forbidden = ['installer', 'register', 'login', 'logout', 'admin', 'files', 'trash', 'paste', 'comments']
-      for (var i = 0; i < forbidden.length; i++) {
+      for (let i = 0; i < forbidden.length; i++) {
         const pn = forbidden[i]
         expect(Page.isCreatableName('/' + pn + '')).toBe(false)
         expect(Page.isCreatableName('/' + pn + '/')).toBe(false)
@@ -151,7 +151,7 @@ describe('Page', () => {
       }
 
       forbidden = ['bookmarks', 'comments', 'activities', 'pages', 'recent-create', 'recent-edit']
-      for (var i = 0; i < forbidden.length; i++) {
+      for (let i = 0; i < forbidden.length; i++) {
         const pn = forbidden[i]
         expect(Page.isCreatableName('/user/aoi/' + pn)).toBe(false)
         expect(Page.isCreatableName('/user/aoi/x/' + pn)).toBe(true)

--- a/lib/models/page.ts
+++ b/lib/models/page.ts
@@ -244,7 +244,7 @@ export default (crowi: Crowi) => {
   }
 
   pageSchema.methods.isUpdatable = function(previousRevision) {
-    var revision = this.latestRevision || this.revision
+    const revision = this.latestRevision || this.revision
     if (revision != previousRevision) {
       return false
     }
@@ -266,7 +266,7 @@ export default (crowi: Crowi) => {
   }
 
   pageSchema.methods.like = async function(userData) {
-    var Activity = crowi.model('Activity')
+    const Activity = crowi.model('Activity')
 
     const added = ((this.liker as any) as Types.Array<UserDocument>).addToSet(userData._id)
     if (added.length > 0) {
@@ -356,7 +356,7 @@ export default (crowi: Crowi) => {
   }
 
   pageSchema.methods.getSlackChannel = function() {
-    var extended = this.get('extended')
+    const extended = this.get('extended')
     if (!extended) {
       return ''
     }
@@ -365,7 +365,7 @@ export default (crowi: Crowi) => {
   }
 
   pageSchema.methods.updateSlackChannel = function(slackChannel) {
-    var extended = this.extended as any
+    const extended = this.extended as any
     extended.slack = slackChannel
 
     return this.updateExtended(extended)
@@ -450,7 +450,7 @@ export default (crowi: Crowi) => {
   }
 
   pageSchema.statics.getGrantLabels = function() {
-    var grantLabels = {}
+    const grantLabels = {}
     grantLabels[GRANT_PUBLIC] = 'Public' // 公開
     grantLabels[GRANT_RESTRICTED] = 'Anyone with the link' // リンクを知っている人のみ
     // grantLabels[GRANT_SPECIFIED]  = 'Specified users only'; // 特定ユーザーのみ
@@ -485,12 +485,12 @@ export default (crowi: Crowi) => {
   }
 
   pageSchema.statics.isDeletableName = function(path) {
-    var notDeletable = [
+    const notDeletable = [
       /^\/user\/[^/]+$/, // user page
     ]
 
-    for (var i = 0; i < notDeletable.length; i++) {
-      var pattern = notDeletable[i]
+    for (let i = 0; i < notDeletable.length; i++) {
+      const pattern = notDeletable[i]
       if (path.match(pattern)) {
         return false
       }
@@ -500,7 +500,7 @@ export default (crowi: Crowi) => {
   }
 
   pageSchema.statics.isCreatableName = function(name) {
-    var forbiddenPages = [
+    const forbiddenPages = [
       /\^|\$|\*|\+|\?|#/,
       /^\/_.*/, // /_api/* and so on
       /^\/-\/.*/,
@@ -514,9 +514,9 @@ export default (crowi: Crowi) => {
       /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments)(\/.*|$)/,
     ]
 
-    var isCreatable = true
+    let isCreatable = true
     forbiddenPages.forEach(function(page) {
-      var pageNameReg = new RegExp(page)
+      const pageNameReg = new RegExp(page)
       if (name.match(pageNameReg)) {
         isCreatable = false
       }
@@ -665,9 +665,9 @@ export default (crowi: Crowi) => {
   }
 
   pageSchema.statics.findListByCreator = function(user, option, currentUser) {
-    var limit = option.limit || 50
-    var offset = option.offset || 0
-    var conditions: any = {
+    const limit = option.limit || 50
+    const offset = option.offset || 0
+    const conditions: any = {
       creator: user._id,
       redirectTo: null,
       $or: [{ status: null }, { status: STATUS_PUBLISHED }],
@@ -690,8 +690,8 @@ export default (crowi: Crowi) => {
    */
   pageSchema.statics.getStreamOfFindAll = function(options) {
     var options = options || {}
-    var publicOnly = options.publicOnly !== false
-    var criteria: any = { redirectTo: null }
+    const publicOnly = options.publicOnly !== false
+    const criteria: any = { redirectTo: null }
 
     if (publicOnly) {
       criteria.grant = GRANT_PUBLIC
@@ -1031,7 +1031,7 @@ export default (crowi: Crowi) => {
     pageData.path = newPagePath
 
     if (createRedirectPage) {
-      var body = 'redirect ' + newPagePath
+      const body = 'redirect ' + newPagePath
       return Page.createPage(path, body, user, { redirectTo: newPagePath })
     }
     pageEvent.emit('update', pageData, user) // update as renamed page
@@ -1105,8 +1105,8 @@ export default (crowi: Crowi) => {
   }
 
   pageSchema.methods.getNotificationTargetUsers = async function() {
-    var Comment = crowi.model('Comment')
-    var Revision = crowi.model('Revision')
+    const Comment = crowi.model('Comment')
+    const Revision = crowi.model('Revision')
 
     const [commentCreators, revisionAuthors] = await Promise.all([Comment.findCreatorsByPage(this), Revision.findAuthorsByPage(this)])
     debug('commentCreators', commentCreators)
@@ -1115,10 +1115,10 @@ export default (crowi: Crowi) => {
     const targetUsers = [this.creator].concat(commentCreators, revisionAuthors)
     debug('targetUsers', targetUsers)
 
-    var uniqueChecker = {}
-    var uniqueUsers: Types.ObjectId[] = []
+    const uniqueChecker = {}
+    const uniqueUsers: Types.ObjectId[] = []
     targetUsers.forEach(function(user) {
-      var userId = user.toString()
+      const userId = user.toString()
       if (uniqueChecker[userId] !== 1) {
         uniqueUsers.push(user)
         uniqueChecker[userId] = 1
@@ -1130,7 +1130,7 @@ export default (crowi: Crowi) => {
   }
 
   pageSchema.post('save', savedPage => {
-    var Backlink = crowi.model('Backlink')
+    const Backlink = crowi.model('Backlink')
     Backlink.createBySavedPage(savedPage)
       .then(result => {
         debug(result)

--- a/lib/models/page.ts
+++ b/lib/models/page.ts
@@ -100,7 +100,7 @@ export interface PageModel extends Model<PageDocument> {
   findPageByRedirectTo(path): any
   findPagesByIds(ids): any
   findListByCreator(user, option, currentUser): any
-  getStreamOfFindAll(options): any
+  getStreamOfFindAll(options?): any
   findListByStartWith(path, userData, option): Promise<PageDocument[]>
   findChildrenByPath(path, userData, option): any
   findUnfurlablePages(type, array, grants?: number[]): any
@@ -688,8 +688,7 @@ export default (crowi: Crowi) => {
   /**
    * Bulk get (for internal only)
    */
-  pageSchema.statics.getStreamOfFindAll = function(options) {
-    var options = options || {}
+  pageSchema.statics.getStreamOfFindAll = function(options = {}) {
     const publicOnly = options.publicOnly !== false
     const criteria: any = { redirectTo: null }
 

--- a/lib/models/updatePost.ts
+++ b/lib/models/updatePost.ts
@@ -44,14 +44,14 @@ export default (crowi: Crowi) => {
   }
 
   updatePostSchema.statics.createPrefixesByPathPattern = function(pathPattern) {
-    var patternPrefix = ['*', '*']
+    const patternPrefix = ['*', '*']
 
     // not begin with slash
     if (!pathPattern.match(/^\/.+/)) {
       return patternPrefix
     }
 
-    var pattern = pathPattern.split('/')
+    const pattern = pathPattern.split('/')
     pattern.shift()
     if (pattern[0] && pattern[0] != '*') {
       patternPrefix[0] = pattern[0]
@@ -64,7 +64,7 @@ export default (crowi: Crowi) => {
   }
 
   updatePostSchema.statics.getRegExpByPattern = function(pattern) {
-    var reg = pattern
+    let reg = pattern
     if (!reg.match(/^\/.*/)) {
       reg = '/*' + reg + '*'
     }

--- a/lib/models/user.test.ts
+++ b/lib/models/user.test.ts
@@ -46,7 +46,7 @@ describe('User', () => {
     describe('Get username from path', () => {
       test('found', () => {
         return new Promise(resolve => {
-          var username = null
+          let username = null
           username = User.getUsernameByPath('/user/sotarok')
           expect(username).toBe('sotarok')
 
@@ -59,7 +59,7 @@ describe('User', () => {
 
       test('not found', () => {
         return new Promise(resolve => {
-          var username = null
+          let username = null
           username = User.getUsernameByPath('/the/page/is/not/related/to/user/page')
           expect(username).toBeNull()
 

--- a/lib/models/user.ts
+++ b/lib/models/user.ts
@@ -128,8 +128,8 @@ export default (crowi: Crowi) => {
   userEvent.on('activated', userEvent.onActivated)
 
   function decideUserStatusOnRegistration() {
-    var Config = crowi.model('Config')
-    var config = crowi.getConfig()
+    const Config = crowi.model('Config')
+    const config = crowi.getConfig()
 
     if (!config.crowi) {
       return STATUS_ACTIVE // is this ok?
@@ -148,12 +148,12 @@ export default (crowi: Crowi) => {
   }
 
   function generateRandomTempPassword() {
-    var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!=-_'
-    var password = ''
-    var len = 12
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!=-_'
+    let password = ''
+    const len = 12
 
-    for (var i = 0; i < len; i++) {
-      var randomPoz = Math.floor(Math.random() * chars.length)
+    for (let i = 0; i < len; i++) {
+      const randomPoz = Math.floor(Math.random() * chars.length)
       password += chars.substring(randomPoz, randomPoz + 1)
     }
 
@@ -161,14 +161,14 @@ export default (crowi: Crowi) => {
   }
 
   function generatePassword(password) {
-    var hasher = crypto.createHash('sha256')
+    const hasher = crypto.createHash('sha256')
     hasher.update(crowi.env.PASSWORD_SEED + password)
 
     return hasher.digest('hex')
   }
 
   function generateApiToken(user) {
-    var hasher = crypto.createHash('sha256')
+    const hasher = crypto.createHash('sha256')
     hasher.update(new Date().getTime() + user._id)
 
     return hasher.digest('base64')
@@ -347,7 +347,7 @@ export default (crowi: Crowi) => {
 
   userSchema.statics.getLanguageLabels = getLanguageLabels
   userSchema.statics.getUserStatusLabels = function() {
-    var userStatus = {}
+    const userStatus = {}
     userStatus[STATUS_REGISTERED] = '承認待ち'
     userStatus[STATUS_ACTIVE] = 'Active'
     userStatus[STATUS_SUSPENDED] = 'Suspended'
@@ -358,12 +358,12 @@ export default (crowi: Crowi) => {
   }
 
   userSchema.statics.isEmailValid = function(email) {
-    var config = crowi.getConfig()
-    var whitelist = config.crowi['security:registrationWhiteList']
+    const config = crowi.getConfig()
+    const whitelist = config.crowi['security:registrationWhiteList']
 
     if (Array.isArray(whitelist) && whitelist.length > 0) {
       return config.crowi['security:registrationWhiteList'].some(function(allowedEmail) {
-        var re = new RegExp(allowedEmail + '$')
+        const re = new RegExp(allowedEmail + '$')
         return re.test(email)
       })
     }
@@ -372,16 +372,16 @@ export default (crowi: Crowi) => {
   }
 
   userSchema.statics.isGitHubAccountValid = function(organizations) {
-    var config = crowi.getConfig()
-    var org = config.crowi['github:organization']
+    const config = crowi.getConfig()
+    const org = config.crowi['github:organization']
 
-    var orgs = organizations || []
+    const orgs = organizations || []
 
     return !org || orgs.includes(org)
   }
 
   userSchema.statics.findUsers = function(options, callback) {
-    var sort = options.sort || { status: 1, createdAt: 1 }
+    const sort = options.sort || { status: 1, createdAt: 1 }
 
     this.find()
       .sort(sort)
@@ -394,9 +394,9 @@ export default (crowi: Crowi) => {
 
   userSchema.statics.findAllUsers = function(option) {
     var option = option || {}
-    var sort = option.sort || { createdAt: -1 }
-    var status = option.status || [STATUS_ACTIVE, STATUS_SUSPENDED]
-    var fields = option.fields
+    const sort = option.sort || { createdAt: -1 }
+    let status = option.status || [STATUS_ACTIVE, STATUS_SUSPENDED]
+    const fields = option.fields
 
     if (!Array.isArray(status)) {
       status = [status]
@@ -415,9 +415,9 @@ export default (crowi: Crowi) => {
 
   userSchema.statics.findUsersByIds = function(ids, option) {
     var option = option || {}
-    var sort = option.sort || { createdAt: -1 }
-    var status = option.status || STATUS_ACTIVE
-    var fields = option.fields
+    const sort = option.sort || { createdAt: -1 }
+    const status = option.status || STATUS_ACTIVE
+    const fields = option.fields
 
     return User.find({ _id: { $in: ids }, status: status })
       .select(fields)
@@ -433,7 +433,7 @@ export default (crowi: Crowi) => {
   }
 
   userSchema.statics.findUsersWithPagination = function(options, query, callback) {
-    var sort = options.sort || { status: 1, username: 1, createdAt: 1 }
+    const sort = options.sort || { status: 1, username: 1, createdAt: 1 }
 
     this.paginate(
       query,
@@ -498,8 +498,8 @@ export default (crowi: Crowi) => {
   }
 
   userSchema.statics.isRegisterable = async function(email, username, callback) {
-    var emailUsable = true
-    var usernameUsable = true
+    let emailUsable = true
+    let usernameUsable = true
     let userData: UserDocument | null = null
 
     // username check

--- a/lib/models/user.ts
+++ b/lib/models/user.ts
@@ -66,8 +66,8 @@ export interface UserModel extends Model<UserDocument> {
   isEmailValid(email): boolean
   isGitHubAccountValid(organizations): boolean
   findUsers(options, callback: (err: Error, userData: UserDocument[]) => void)
-  findAllUsers(option?): Promise<UserDocument[]>
-  findUsersByIds(ids, option?): Promise<UserDocument[]>
+  findAllUsers(options?): Promise<UserDocument[]>
+  findUsersByIds(ids, options?): Promise<UserDocument[]>
   findAdmins(callback: (err: Error, admins: UserDocument[]) => void): void
   findUsersWithPagination(options, query, callback): any
   findUsersByPartOfEmail(emailPart, options): any
@@ -392,11 +392,10 @@ export default (crowi: Crowi) => {
       })
   }
 
-  userSchema.statics.findAllUsers = function(option) {
-    var option = option || {}
-    const sort = option.sort || { createdAt: -1 }
-    let status = option.status || [STATUS_ACTIVE, STATUS_SUSPENDED]
-    const fields = option.fields
+  userSchema.statics.findAllUsers = function(options = {}) {
+    const sort = options.sort || { createdAt: -1 }
+    let status = options.status || [STATUS_ACTIVE, STATUS_SUSPENDED]
+    const fields = options.fields
 
     if (!Array.isArray(status)) {
       status = [status]
@@ -413,11 +412,10 @@ export default (crowi: Crowi) => {
       .exec()
   }
 
-  userSchema.statics.findUsersByIds = function(ids, option) {
-    var option = option || {}
-    const sort = option.sort || { createdAt: -1 }
-    const status = option.status || STATUS_ACTIVE
-    const fields = option.fields
+  userSchema.statics.findUsersByIds = function(ids, options = {}) {
+    const sort = options.sort || { createdAt: -1 }
+    const status = options.status || STATUS_ACTIVE
+    const fields = options.fields
 
     return User.find({ _id: { $in: ids }, status: status })
       .select(fields)

--- a/lib/utils/fileUploader.ts
+++ b/lib/utils/fileUploader.ts
@@ -4,7 +4,7 @@ export default (crowi: Crowi) => {
   'use strict'
 
   // var debug = Debug('crowi:lib:fileUploader')
-  var method = crowi.env.FILE_UPLOAD || 'aws'
+  const method = crowi.env.FILE_UPLOAD || 'aws'
 
   return require('../../local_modules/crowi-fileupload-' + method + '/index.js')(crowi)
 }

--- a/lib/utils/linkDetector.ts
+++ b/lib/utils/linkDetector.ts
@@ -15,7 +15,7 @@ export default (crowi: Crowi) => {
   linkDetector.getPathRegexps = () => [new RegExp('<(/[^>]+)>', 'g'), /\[(\/[^\]]+)\](?!\()/g]
 
   linkDetector.search = function(text) {
-    var unique = function(array) {
+    const unique = function(array) {
       return array.filter(function(x, i, self) {
         return self.indexOf(x) === i
       })

--- a/lib/utils/mailer.ts
+++ b/lib/utils/mailer.ts
@@ -8,13 +8,13 @@ const debug = Debug('crowi:lib:mailer')
 export default crowi => {
   'use strict'
 
-  var config = crowi.getConfig()
-  var mailConfig: any = {}
-  var mailer: any = {}
-  var MAIL_TEMPLATE_DIR = crowi.mailDir
+  const config = crowi.getConfig()
+  const mailConfig: any = {}
+  let mailer: any = {}
+  const MAIL_TEMPLATE_DIR = crowi.mailDir
 
   function createSMTPClient(option?) {
-    var client
+    let client
 
     debug('createSMTPClient option', option)
     if (!option) {
@@ -42,7 +42,7 @@ export default crowi => {
   }
 
   function createSESClient(option?) {
-    var client
+    let client
 
     if (!option) {
       option = {
@@ -80,8 +80,8 @@ export default crowi => {
   }
 
   function setupMailConfig(overrideConfig) {
-    var c = overrideConfig
-    var mc: any = {}
+    const c = overrideConfig
+    let mc: any = {}
     mc = mailConfig
 
     mc.to = c.to
@@ -94,7 +94,7 @@ export default crowi => {
 
   function send(config, callback) {
     if (mailer) {
-      var templateVars = config.vars || {}
+      const templateVars = config.vars || {}
       return swig.renderFile(MAIL_TEMPLATE_DIR + config.template, templateVars, function(err, output) {
         if (err) {
           throw err

--- a/lib/utils/mailer.ts
+++ b/lib/utils/mailer.ts
@@ -14,8 +14,6 @@ export default crowi => {
   const MAIL_TEMPLATE_DIR = crowi.mailDir
 
   function createSMTPClient(option?) {
-    let client
-
     debug('createSMTPClient option', option)
     if (!option) {
       option = {
@@ -35,15 +33,13 @@ export default crowi => {
     }
     option.tls = { rejectUnauthorized: false }
 
-    client = nodemailer.createTransport(option)
+    const client = nodemailer.createTransport(option)
 
     debug('mailer set up for SMTP', client)
     return client
   }
 
   function createSESClient(option?) {
-    let client
-
     if (!option) {
       option = {
         accessKeyId: config.crowi['mail:aws:accessKeyId'],
@@ -51,7 +47,7 @@ export default crowi => {
       }
     }
 
-    client = nodemailer.createTransport(ses(option))
+    const client = nodemailer.createTransport(ses(option))
 
     debug('mailer set up for SES', client)
     return client

--- a/lib/utils/slack.ts
+++ b/lib/utils/slack.ts
@@ -34,7 +34,7 @@ export default (crowi: Crowi) => {
 
   // this is called to generate redirect_uri
   slack.getSlackAuthCallbackUrl = function() {
-    var config = crowi.getConfig()
+    const config = crowi.getConfig()
     // Web アクセスがきてないと app:url がセットされないので crowi.setupSlack 時にはできない
     // cli, bot 系作るときに問題なりそう
     return (config.crowi['app:url'] || '') + '/admin/notification/slackAuth'
@@ -96,8 +96,8 @@ export default (crowi: Crowi) => {
   }
 
   slack.convertMarkdownToMrkdwn = function(body) {
-    var config = crowi.getConfig()
-    var url = ''
+    const config = crowi.getConfig()
+    let url = ''
     if (config.crowi && config.crowi['app:url']) {
       url = config.crowi['app:url']
     }
@@ -112,7 +112,7 @@ export default (crowi: Crowi) => {
   }
 
   slack.prepareAttachmentTextForCreate = function(page, user) {
-    var body = page.revision.body
+    let body = page.revision.body
     if (body.length > 2000) {
       body = body.substr(0, 2000) + '...'
     }
@@ -121,7 +121,7 @@ export default (crowi: Crowi) => {
   }
 
   slack.prepareAttachmentTextForUpdate = function(page, user, previousRevision) {
-    var diffText = ''
+    let diffText = ''
 
     diff.diffLines(previousRevision.body, page.revision.body).forEach(function(line) {
       debug('diff line', line)
@@ -145,9 +145,9 @@ export default (crowi: Crowi) => {
   }
 
   slack.prepareSlackMessage = function(page, user, channel, updateType, previousRevision) {
-    var config = crowi.getConfig()
-    var url = config.crowi['app:url'] || ''
-    var body = page.revision.body
+    const config = crowi.getConfig()
+    const url = config.crowi['app:url'] || ''
+    let body = page.revision.body
 
     if (updateType == 'create') {
       body = this.prepareAttachmentTextForCreate(page, user)
@@ -155,7 +155,7 @@ export default (crowi: Crowi) => {
       body = this.prepareAttachmentTextForUpdate(page, user, previousRevision)
     }
 
-    var attachment = {
+    const attachment = {
       color: '#263a3c',
       author_name: '@' + user.username,
       author_link: url + '/user/' + user.username,
@@ -169,7 +169,7 @@ export default (crowi: Crowi) => {
       attachment.author_icon = user.image
     }
 
-    var message = {
+    const message = {
       channel: '#' + channel,
       username: 'Crowi',
       text: this.getSlackMessageText(page, user, updateType),

--- a/lib/utils/swigFunctions.ts
+++ b/lib/utils/swigFunctions.ts
@@ -39,7 +39,7 @@ export default (crowi: Crowi, app: Express, req: Request, res: Response) => {
   }
 
   locals.slackConfigured = function() {
-    var config = crowi.getConfig()
+    const config = crowi.getConfig()
     if (Config.hasSlackToken(config)) {
       return true
     }
@@ -47,12 +47,12 @@ export default (crowi: Crowi, app: Express, req: Request, res: Response) => {
   }
 
   locals.isUploadable = function() {
-    var config = crowi.getConfig()
+    const config = crowi.getConfig()
     return Config.isUploadable(config)
   }
 
   locals.isExternalShareEnabled = function() {
-    var config = crowi.getConfig()
+    const config = crowi.getConfig()
     return config.crowi['app:externalShare']
   }
 
@@ -67,8 +67,8 @@ export default (crowi: Crowi, app: Express, req: Request, res: Response) => {
   locals.isTrashPage = () => isTrashPage(req.path || '')
 
   locals.isDeletablePage = function() {
-    var Page = crowi.model('Page')
-    var path = req.path || ''
+    const Page = crowi.model('Page')
+    const path = req.path || ''
 
     return Page.isDeletableName(path)
   }

--- a/local_modules/crowi-fileupload-aws/index.js
+++ b/local_modules/crowi-fileupload-aws/index.js
@@ -3,13 +3,13 @@
 module.exports = function(crowi) {
   'use strict'
 
-  var aws = require('aws-sdk')
-  var fs = require('fs')
-  var path = require('path')
-  var debug = require('debug')('crowi:lib:fileUploaderAws')
-  var lib = {}
-  var getAwsConfig = function() {
-    var config = crowi.getConfig()
+  const aws = require('aws-sdk')
+  const fs = require('fs')
+  const path = require('path')
+  const debug = require('debug')('crowi:lib:fileUploaderAws')
+  const lib = {}
+  const getAwsConfig = function() {
+    const config = crowi.getConfig()
     return {
       accessKeyId: config.crowi['upload:aws:accessKeyId'],
       secretAccessKey: config.crowi['upload:aws:secretAccessKey'],
@@ -84,14 +84,14 @@ module.exports = function(crowi) {
   }
 
   lib.generateUrl = function(filePath) {
-    var awsConfig = getAwsConfig()
-    var url = 'https://' + awsConfig.bucket + '.s3.amazonaws.com/' + filePath
+    const awsConfig = getAwsConfig()
+    const url = 'https://' + awsConfig.bucket + '.s3.amazonaws.com/' + filePath
 
     return url
   }
 
   lib.findDeliveryFile = function(fileId, filePath) {
-    var cacheFile = lib.createCacheFileName(fileId)
+    const cacheFile = lib.createCacheFileName(fileId)
 
     return new Promise((resolve, reject) => {
       debug('find delivery file', cacheFile)
@@ -99,10 +99,10 @@ module.exports = function(crowi) {
         return resolve(cacheFile)
       }
 
-      var loader = require('https')
+      const loader = require('https')
 
-      var fileStream = fs.createWriteStream(cacheFile)
-      var fileUrl = lib.generateUrl(filePath)
+      const fileStream = fs.createWriteStream(cacheFile)
+      const fileUrl = lib.generateUrl(filePath)
       debug('Load attachement file into local cache file', fileUrl, cacheFile)
       loader.get(fileUrl, function(response) {
         response.pipe(fileStream, { end: false })
@@ -144,7 +144,7 @@ module.exports = function(crowi) {
   // private
   lib.shouldUpdateCacheFile = function(filePath) {
     try {
-      var stats = fs.statSync(filePath)
+      const stats = fs.statSync(filePath)
 
       if (!stats.isFile()) {
         debug('Cache file not found or the file is not a regular file.')

--- a/local_modules/crowi-fileupload-local/index.js
+++ b/local_modules/crowi-fileupload-local/index.js
@@ -3,12 +3,12 @@
 module.exports = function(crowi) {
   'use strict'
 
-  var debug = require('debug')('crowi:lib:fileUploaderLocal')
-  var fs = require('fs')
-  var path = require('path')
-  var mkdir = require('mkdirp')
-  var lib = {}
-  var basePath = path.posix.join(crowi.publicDir, 'uploads') // TODO: to configurable
+  const debug = require('debug')('crowi:lib:fileUploaderLocal')
+  const fs = require('fs')
+  const path = require('path')
+  const mkdir = require('mkdirp')
+  const lib = {}
+  const basePath = path.posix.join(crowi.publicDir, 'uploads') // TODO: to configurable
 
   lib.deleteFile = function(fileId, filePath) {
     debug('File deletion: ' + filePath)
@@ -27,15 +27,15 @@ module.exports = function(crowi) {
   lib.uploadFile = function(filePath, contentType, fileStream, options) {
     debug('File uploading: ' + filePath)
     return new Promise(function(resolve, reject) {
-      var localFilePath = path.posix.join(basePath, filePath)
-      var dirpath = path.posix.dirname(localFilePath)
+      const localFilePath = path.posix.join(basePath, filePath)
+      const dirpath = path.posix.dirname(localFilePath)
 
       mkdir(dirpath, function(err) {
         if (err) {
           return reject(err)
         }
 
-        var writer = fs.createWriteStream(localFilePath)
+        const writer = fs.createWriteStream(localFilePath)
 
         writer
           .on('error', function(err) {

--- a/local_modules/crowi-fileupload-none/index.js
+++ b/local_modules/crowi-fileupload-none/index.js
@@ -3,8 +3,8 @@
 module.exports = function(crowi) {
   'use strict'
 
-  var debug = require('debug')('crowi:lib:fileUploaderNone')
-  var lib = {}
+  const debug = require('debug')('crowi:lib:fileUploaderNone')
+  const lib = {}
 
   lib.deleteFile = function(filePath) {
     debug('File deletion: ' + filePath)


### PR DESCRIPTION
This PR depends on #641.

# WHAT

- Enable these rules
  - `no-var`
  - `jest/valid-describe`
  - `no-inner-declarations`
  - `no-redeclare`
  - `react/prefer-stateless-function`
  - `require-jsdoc`
  - `standard/no-callback-literal`
  - `valid-jsdoc`

# WHY

- Some preset we are using already have that some rules turned off
- Improve code consistency and maintainability