### PR TITLE
Fix bug faced when clicking watch the log

### DIFF
--- a/client/components/ExternalShare/AccessLogModal.tsx
+++ b/client/components/ExternalShare/AccessLogModal.tsx
@@ -102,13 +102,15 @@ class AccessLogModal extends React.Component<Props, State> {
       lastAccessedAt,
     } = accesses
     const index = i + 1
-    const { name: platformName, os } = platform.parse ? platform.parse(userAgent) : { name: '', os: '' }
+    const { name: platformName, os } = platform?.parse(userAgent) || { name: '', os: { family: '', version: '' } }
     const date = formatToLocaleString(lastAccessedAt)
     return (
       <tr key={i}>
         <td>{index}</td>
         <td>{platformName}</td>
-        <td>{os}</td>
+        <td>
+          {os?.family} {os?.version}
+        </td>
         <td>{remoteAddress}</td>
         <td>{date}</td>
       </tr>


### PR DESCRIPTION
## WHAT

- Show OS details in valid format

Result:

<img width="349" alt="Screen Shot 2020-03-17 at 0 18 59" src="https://user-images.githubusercontent.com/38908416/76772885-f5aa3b00-67e4-11ea-818d-079585b274d9.png">


## WHY

When I click 'watch the log' button, an error occurred and cannot be rendered logs.

<img width="692" alt="Screen Shot 2020-03-17 at 0 06 33" src="https://user-images.githubusercontent.com/38908416/76772411-2d64b300-67e4-11ea-9d48-759300b45cb1.png">