### PR TITLE
Enable break-all on textarea

### DIFF
--- a/resource/css/_form.scss
+++ b/resource/css/_form.scss
@@ -56,6 +56,7 @@
           border: none;
           box-shadow: none;
           resize: none;
+          word-break: break-all;
 
           &.dragover {
             border: dashed 6px #ccc;


### PR DESCRIPTION
Increase readability on edit page.

Before:
<img width="1211" alt="Screenshot 2020-04-27 17 26 44" src="https://user-images.githubusercontent.com/29064/80350992-8b3cee00-88ac-11ea-82ec-13cb96cd5a96.png">


After:
<img width="1204" alt="Screenshot 2020-04-27 17 26 59" src="https://user-images.githubusercontent.com/29064/80350996-8ed07500-88ac-11ea-9c1b-091fd943488e.png">
