### PR TITLE
Fix/admin user list pager

### DIFF
--- a/client/components/Admin/User/UserPage.tsx
+++ b/client/components/Admin/User/UserPage.tsx
@@ -70,9 +70,8 @@ function useQuery(crowi) {
 function useFetchUsers(crowi, setFailure, clearStatus) {
   const [users, setUsers] = useState([])
   const [{ page, query }, { setPage, setQuery }] = useQuery(crowi)
-  const [count, setCount] = useState(0)
   const [search, setSearch] = useState('')
-  const pagination = { current: page, count }
+  const [pager, setPager] = useState()
   const fetchUsers = async (options = {}) => {
     clearStatus(null)
 
@@ -80,7 +79,7 @@ function useFetchUsers(crowi, setFailure, clearStatus) {
       const { users, pager } = await crowi.apiGet('/admin/users', { uq: search, page, ...options })
       setUsers(users)
       setPage(pager.page)
-      setCount(pager.pagesCount)
+      setPager(pager)
     } catch ({ message }) {
       setFailure(message)
     }
@@ -97,7 +96,7 @@ function useFetchUsers(crowi, setFailure, clearStatus) {
   }, [search])
 
   return [
-    { users, pagination, query },
+    { users, pager, query },
     { setQuery, setSearch, fetchUsers, move },
   ] as const
 }
@@ -153,7 +152,7 @@ const UserPage: FC<{}> = () => {
   const { crowi } = useContext(AdminContext)
   const me = crowi.getUser()
   const [{ success, failure }, { setSuccess, setFailure, clearStatus }] = useAlerts()
-  const [{ users, pagination, query }, { setQuery, setSearch, fetchUsers, move }] = useFetchUsers(crowi, setFailure, clearStatus)
+  const [{ users, pager, query }, { setQuery, setSearch, fetchUsers, move }] = useFetchUsers(crowi, setFailure, clearStatus)
   const [{ invitedUsers }, { invite, clear }] = useInviteUsers(crowi, fetchUsers, setFailure, clearStatus)
 
   const [{ isOpen: isOpenResetModal, modalState: resetModalState }, { toggle: toggleResetModal, open: openResetModal, close: closeResetModal }] = useModal()
@@ -175,7 +174,7 @@ const UserPage: FC<{}> = () => {
       <UserTable
         me={me}
         users={users}
-        pagination={pagination}
+        pager={pager}
         query={query}
         setQuery={setQuery}
         search={setSearch}

--- a/client/components/Admin/User/UserTable.tsx
+++ b/client/components/Admin/User/UserTable.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import Pagination, { Pager } from 'components/Common/Pagination'
+import Pagination from 'components/Common/Pagination'
 import UserSearchForm from './UserSearchForm'
 import UserTableRow from './UserTableRow'
 import { Me } from 'client/utils/Crowi'
@@ -56,7 +56,10 @@ function getHanlders(openResetModal, changeStatus) {
 interface Props {
   me: Me
   users: any[]
-  pager?: Pager
+  pagination: {
+    currentPage: number
+    totalPages: number
+  }
   query: string
   setQuery: (query: string) => void
   search: (query: string) => void
@@ -65,8 +68,9 @@ interface Props {
   changeStatus: (user: any, string: string) => void
 }
 
-const UserTable: FC<Props> = ({ me, users, pager, query, setQuery, search, move, openResetModal, changeStatus }) => {
+const UserTable: FC<Props> = ({ me, users, pagination, query, setQuery, search, move, openResetModal, changeStatus }) => {
   const [t] = useTranslation()
+  const { currentPage, totalPages } = pagination
   const handlers = getHanlders(openResetModal, changeStatus)
   return (
     <>
@@ -92,7 +96,7 @@ const UserTable: FC<Props> = ({ me, users, pager, query, setQuery, search, move,
                 ))}
               </tbody>
             </table>
-            <Pagination pager={pager} onClick={move} />
+            <Pagination current={currentPage} count={totalPages} onClick={move} />
           </>
         ) : (
           <p>{t('admin.user.not_found')}</p>

--- a/client/components/Admin/User/UserTable.tsx
+++ b/client/components/Admin/User/UserTable.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import Pagination from 'components/Common/Pagination'
+import Pagination, { Pager } from 'components/Common/Pagination'
 import UserSearchForm from './UserSearchForm'
 import UserTableRow from './UserTableRow'
 import { Me } from 'client/utils/Crowi'
@@ -56,10 +56,7 @@ function getHanlders(openResetModal, changeStatus) {
 interface Props {
   me: Me
   users: any[]
-  pagination: {
-    current: number
-    count: number
-  }
+  pager?: Pager
   query: string
   setQuery: (query: string) => void
   search: (query: string) => void
@@ -68,9 +65,8 @@ interface Props {
   changeStatus: (user: any, string: string) => void
 }
 
-const UserTable: FC<Props> = ({ me, users, pagination, query, setQuery, search, move, openResetModal, changeStatus }) => {
+const UserTable: FC<Props> = ({ me, users, pager, query, setQuery, search, move, openResetModal, changeStatus }) => {
   const [t] = useTranslation()
-  const { current, count } = pagination
   const handlers = getHanlders(openResetModal, changeStatus)
   return (
     <>
@@ -96,7 +92,7 @@ const UserTable: FC<Props> = ({ me, users, pagination, query, setQuery, search, 
                 ))}
               </tbody>
             </table>
-            <Pagination current={current} count={count} onClick={move} />
+            <Pagination pager={pager} onClick={move} />
           </>
         ) : (
           <p>{t('admin.user.not_found')}</p>

--- a/client/components/Common/Pagination.stories.tsx
+++ b/client/components/Common/Pagination.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import Pagination from './Pagination'
+
+export default { title: 'Common/Pagination' }
+
+export const Default = () => <Pagination current={5} count={10} onClick={() => {}} />
+
+export const StartPage = () => <Pagination current={1} count={3} onClick={() => {}} />
+
+export const SmallTotalSize = () => <Pagination current={2} count={3} onClick={() => {}} />
+
+export const SmallTotalSizeLastPage = () => <Pagination current={3} count={3} onClick={() => {}} />
+
+export const AlmostLastPage = () => <Pagination current={9} count={10} onClick={() => {}} />
+
+export const LastPage = () => <Pagination current={10} count={10} onClick={() => {}} />

--- a/client/components/Common/Pagination.tsx
+++ b/client/components/Common/Pagination.tsx
@@ -1,27 +1,37 @@
 import React from 'react'
 import { Pagination, PaginationItem, PaginationLink } from 'reactstrap'
 
-// it is the same as server's definition
-export interface Pager {
-  page: any
-  pagesCount: number
-  pages: number[]
-  total: number
-  previous: number | null
-  previousDots: boolean
-  next: number | null
-  nextDots: boolean
-}
+const PAGER_VIEW_COUNT = 5
 
 interface Props {
   onClick: Function
-  current?: number
-  count?: number
-  pager?: Pager
+  current: number
+  count: number
+}
+
+const createPages = function(current: number, count: number) {
+  let pageSize = PAGER_VIEW_COUNT
+  let start = current - Math.floor(PAGER_VIEW_COUNT / 2)
+
+  if (count <= PAGER_VIEW_COUNT) {
+    pageSize = count
+    start = 1
+  } else if (start <= 1) {
+    start = 1
+    if (count < PAGER_VIEW_COUNT) {
+      pageSize = count
+    }
+  } else if (start > 1) {
+    if (start > count - PAGER_VIEW_COUNT) {
+      start = count - PAGER_VIEW_COUNT + 1
+    }
+  }
+
+  return [...Array(pageSize)].map((_, i) => i + start)
 }
 
 const PaginationWrapper: React.FC<Props> = props => {
-  const { current, count, pager } = props
+  const { current, count } = props
 
   const onClick = (i?: number | null) => {
     const { onClick } = props
@@ -31,69 +41,49 @@ const PaginationWrapper: React.FC<Props> = props => {
     }
   }
 
-  // LegacyPagination
-  if (!pager) {
-    if (current && count && (current < 1 || count < 1)) {
-      return null
-    }
-
-    return (
-      <Pagination>
-        <PaginationItem disabled={current === 1}>
-          <PaginationLink previous onClick={onClick(1)} />
-        </PaginationItem>
-        {[...Array(count).keys()].map((v, k) => {
-          const page = k + 1
-          return (
-            <PaginationItem key={page} active={page === current}>
-              <PaginationLink onClick={onClick(page)}>{page}</PaginationLink>
-            </PaginationItem>
-          )
-        })}
-        <PaginationItem disabled={current === count}>
-          <PaginationLink next onClick={onClick(count)} />
-        </PaginationItem>
-      </Pagination>
-    )
+  if (current < 1 || count < 1) {
+    return null
   }
+
+  const pages: number[] = createPages(current, count)
 
   return (
     <Pagination>
-      {pager.page !== 1 && (
+      {current !== 1 && (
         <PaginationItem>
           <PaginationLink first onClick={onClick(1)} />
         </PaginationItem>
       )}
-      {pager.previous && (
+      {current !== 1 && (
         <PaginationItem>
-          <PaginationLink previous onClick={onClick(pager.previous)} />
+          <PaginationLink previous onClick={onClick(current - 1)} />
         </PaginationItem>
       )}
-      {pager.previousDots && (
+      {count > PAGER_VIEW_COUNT && current - Math.floor(PAGER_VIEW_COUNT / 2) > 1 && (
         <PaginationItem>
           <PaginationLink href="#">...</PaginationLink>
         </PaginationItem>
       )}
-      {pager.pages.map(p => {
+      {pages.map(p => {
         return (
-          <PaginationItem key={p} active={p === pager.page}>
+          <PaginationItem key={p} active={p === current}>
             <PaginationLink onClick={onClick(p)}>{p}</PaginationLink>
           </PaginationItem>
         )
       })}
-      {pager.nextDots && (
+      {count > PAGER_VIEW_COUNT && current + Math.floor(PAGER_VIEW_COUNT / 2) < count && (
         <PaginationItem>
           <PaginationLink href="#">...</PaginationLink>
         </PaginationItem>
       )}
-      {pager.next && (
+      {current !== count && (
         <PaginationItem>
-          <PaginationLink next onClick={onClick(pager.next)} />
+          <PaginationLink next onClick={onClick(current + 1)} />
         </PaginationItem>
       )}
-      {pager.page !== pager.pagesCount && (
+      {current !== count && (
         <PaginationItem>
-          <PaginationLink last onClick={onClick(pager.pagesCount)} />
+          <PaginationLink last onClick={onClick(count)} />
         </PaginationItem>
       )}
     </Pagination>

--- a/client/components/Common/Pagination.tsx
+++ b/client/components/Common/Pagination.tsx
@@ -1,47 +1,103 @@
 import React from 'react'
 import { Pagination, PaginationItem, PaginationLink } from 'reactstrap'
 
-interface Props {
-  current: number
-  count: number
-  onClick: Function
+// it is the same as server's definition
+export interface Pager {
+  page: any
+  pagesCount: number
+  pages: number[]
+  total: number
+  previous: number | null
+  previousDots: boolean
+  next: number | null
+  nextDots: boolean
 }
 
-export default class PaginationWrapper extends React.Component<Props> {
-  onClick(i: number) {
-    const { onClick } = this.props
+interface Props {
+  onClick: Function
+  current?: number
+  count?: number
+  pager?: Pager
+}
+
+const PaginationWrapper: React.FC<Props> = props => {
+  const { current, count, pager } = props
+
+  const onClick = (i?: number | null) => {
+    const { onClick } = props
     return (e: React.MouseEvent<HTMLElement>) => {
       e.preventDefault()
-      if (onClick) {
-        onClick(i)
-      }
+      onClick(i)
     }
   }
 
-  render() {
-    const { current, count } = this.props
-    if (current < 1 || count < 1) {
+  // LegacyPagination
+  if (!pager) {
+    if (current && count && (current < 1 || count < 1)) {
       return null
     }
-    const range = [...Array(count).keys()]
-    const items = range.map((v, k) => {
-      const page = k + 1
-      return (
-        <PaginationItem key={page} active={page === current}>
-          <PaginationLink onClick={this.onClick(page)}>{page}</PaginationLink>
-        </PaginationItem>
-      )
-    })
+
     return (
       <Pagination>
         <PaginationItem disabled={current === 1}>
-          <PaginationLink previous onClick={this.onClick(1)} />
+          <PaginationLink previous onClick={onClick(1)} />
         </PaginationItem>
-        {items}
+        {[...Array(count).keys()].map((v, k) => {
+          const page = k + 1
+          return (
+            <PaginationItem key={page} active={page === current}>
+              <PaginationLink onClick={onClick(page)}>{page}</PaginationLink>
+            </PaginationItem>
+          )
+        })}
         <PaginationItem disabled={current === count}>
-          <PaginationLink next onClick={this.onClick(count)} />
+          <PaginationLink next onClick={onClick(count)} />
         </PaginationItem>
       </Pagination>
     )
   }
+
+  return (
+    <Pagination>
+      {pager.page !== 1 && (
+        <PaginationItem>
+          <PaginationLink first onClick={onClick(1)} />
+        </PaginationItem>
+      )}
+      {pager.previous && (
+        <PaginationItem>
+          <PaginationLink previous onClick={onClick(pager.previous)} />
+        </PaginationItem>
+      )}
+      {pager.previousDots && (
+        <PaginationItem>
+          <PaginationLink href="#">...</PaginationLink>
+        </PaginationItem>
+      )}
+      {pager.pages.map(p => {
+        return (
+          <PaginationItem key={p} active={p === pager.page}>
+            <PaginationLink onClick={onClick(p)}>{p}</PaginationLink>
+          </PaginationItem>
+        )
+      })}
+      {pager.nextDots && (
+        <PaginationItem>
+          <PaginationLink href="#">...</PaginationLink>
+        </PaginationItem>
+      )}
+      {pager.next && (
+        <PaginationItem>
+          <PaginationLink next onClick={onClick(pager.next)} />
+        </PaginationItem>
+      )}
+      {pager.page !== pager.pagesCount && (
+        <PaginationItem>
+          <PaginationLink last onClick={onClick(pager.pagesCount)} />
+        </PaginationItem>
+      )}
+    </Pagination>
+  )
 }
+
+export default PaginationWrapper

--- a/lib/controllers/admin.ts
+++ b/lib/controllers/admin.ts
@@ -24,9 +24,9 @@ export default (crowi: Crowi) => {
       pages: number[]
       total: number
       previous: number | null
-      previousDots: boolean | null
+      previousDots: boolean
       next: number | null
-      nextDots: boolean | null
+      nextDots: boolean
     } = {
       page,
       pagesCount,
@@ -63,12 +63,10 @@ export default (crowi: Crowi) => {
       }
     }
 
-    pager.previousDots = null
     if (pagerMin > 1) {
       pager.previousDots = true
     }
 
-    pager.nextDots = null
     if (pagerMax < pagesCount) {
       pager.nextDots = true
     }

--- a/resource/css/_theme.scss
+++ b/resource/css/_theme.scss
@@ -13,3 +13,4 @@ $crowiAsideBackground: rgb(248, 249, 250);
 $font-size-base: 0.9rem !default; // Assumes the browser default, typically `16px`
 $font-family-base: 'Open Sans', 'Helvetica Neue', 'Hiragino Kaku Gothic Pro', 'Meiryo', sans-serif;
 
+$pagination-line-height: 1.45;


### PR DESCRIPTION
## What

- Currently, all page list appears on pagination.
  - So if the number of user is quite large, the pages link overflowed outside of the screen like:
    - 
![image](https://user-images.githubusercontent.com/29064/82136127-41a94880-9845-11ea-8495-5b55b237823b.png)
- Adjust to the original spec that assumed previous/next 2 pages appear around current page and show first/past link.
- To keep compatibility (for another pages using `Common/Pagination` component, it still works both with `pager` param and with `count` and `current` params.

##  Before

<img width="424" alt="Screenshot 2020-05-17 11 55 19" src="https://user-images.githubusercontent.com/29064/82136073-c5af0080-9844-11ea-8fbb-697bf1f0aaaf.png">

## After

![2020-05-17 13 43 46](https://user-images.githubusercontent.com/29064/82136100-f000be00-9844-11ea-8bd6-8227b92c166e.gif)
