### PR TITLE
Fix: search result page broken in some case

### DIFF
--- a/resource/css/_wiki.scss
+++ b/resource/css/_wiki.scss
@@ -136,6 +136,7 @@ div.body {
 
     code {
       background: transparent;
+      word-break: break-all;
     }
   }
 


### PR DESCRIPTION
Search result page broken if page includes very long string in search results.

## Before

![Screenshot 2020-06-22 23 31 28](https://user-images.githubusercontent.com/29064/85299847-c50f2700-b4e0-11ea-9f26-fec2c18ac065.png)
![Screenshot 2020-06-22 23 31 34](https://user-images.githubusercontent.com/29064/85299854-c8a2ae00-b4e0-11ea-88ff-93588fb9128c.png)


## After

![Screenshot 2020-06-22 23 31 44](https://user-images.githubusercontent.com/29064/85299868-cdfff880-b4e0-11ea-9181-959c5381db76.png)

