### PR TITLE
Focus input in page create modal automatically

### DIFF
--- a/client/components/Modal/PageCreateModal.tsx
+++ b/client/components/Modal/PageCreateModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, FC } from 'react'
+import React, { useCallback, useRef, useState, FC } from 'react'
 import { useTranslation, Trans } from 'react-i18next'
 import { Button, Form, Input, Label, Modal, ModalBody, ModalHeader, ModalProps } from 'reactstrap'
 import format from 'client/utils/formatDate'
@@ -88,18 +88,14 @@ const PageCreateModal: FC<Props> = ({ crowi, fade = false, toggle, ...modalProps
   const [portalName, setPotalName] = useState<string>(t('Memo'))
   const [pageName, setPageName] = useState('')
   const [underTreePath, setUnderTreePath] = useState(decodeURI(parentPath(currentPath)))
-  const inputRef = useRef<HTMLInputElement>(null)
+  const wrapperRef = useRef<HTMLElement>(null)
 
-  useEffect(() => {
-    if (!modalProps.isOpen) return
-
-    // Input is not mounted immediately after isOpen changed true
-    setTimeout(() => {
-      if (inputRef.current) {
-        inputRef.current.focus()
-      }
-    }, 100)
-  }, [modalProps.isOpen])
+  const onOpened = useCallback(() => {
+    const inputList = wrapperRef.current?.querySelectorAll('input')
+    if (inputList) {
+      inputList[1].focus()
+    }
+  }, [])
 
   const createTodayPage = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -113,7 +109,7 @@ const PageCreateModal: FC<Props> = ({ crowi, fade = false, toggle, ...modalProps
   }
 
   return (
-    <Modal fade={fade} toggle={toggle} {...modalProps}>
+    <Modal innerRef={wrapperRef} fade={fade} toggle={toggle} onOpened={onOpened} {...modalProps}>
       <ModalHeader toggle={toggle}>{t('New Page')}</ModalHeader>
       <ModalBody>
         <FormLabel>{t("Create today's")}</FormLabel>
@@ -123,7 +119,6 @@ const PageCreateModal: FC<Props> = ({ crowi, fade = false, toggle, ...modalProps
             <PortalNameInput type="text" value={portalName} onChange={(event: React.ChangeEvent<HTMLInputElement>) => setPotalName(event.target.value)} />
             <Path>{datePath}</Path>
             <PageNameInput
-              innerRef={inputRef}
               type="text"
               value={pageName}
               onChange={(event: React.ChangeEvent<HTMLInputElement>) => setPageName(event.target.value)}

--- a/client/components/Modal/PageCreateModal.tsx
+++ b/client/components/Modal/PageCreateModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FC } from 'react'
+import React, { useEffect, useRef, useState, FC } from 'react'
 import { useTranslation, Trans } from 'react-i18next'
 import { Button, Form, Input, Label, Modal, ModalBody, ModalHeader, ModalProps } from 'reactstrap'
 import format from 'client/utils/formatDate'
@@ -88,6 +88,18 @@ const PageCreateModal: FC<Props> = ({ crowi, fade = false, toggle, ...modalProps
   const [portalName, setPotalName] = useState<string>(t('Memo'))
   const [pageName, setPageName] = useState('')
   const [underTreePath, setUnderTreePath] = useState(decodeURI(parentPath(currentPath)))
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (!modalProps.isOpen) return
+
+    // Input is not mounted immediately after isOpen changed true
+    setTimeout(() => {
+      if (inputRef.current) {
+        inputRef.current.focus()
+      }
+    }, 100)
+  }, [modalProps.isOpen])
 
   const createTodayPage = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -111,6 +123,7 @@ const PageCreateModal: FC<Props> = ({ crowi, fade = false, toggle, ...modalProps
             <PortalNameInput type="text" value={portalName} onChange={(event: React.ChangeEvent<HTMLInputElement>) => setPotalName(event.target.value)} />
             <Path>{datePath}</Path>
             <PageNameInput
+              innerRef={inputRef}
               type="text"
               value={pageName}
               onChange={(event: React.ChangeEvent<HTMLInputElement>) => setPageName(event.target.value)}


### PR DESCRIPTION
bug fix

Wait for the `Input` in `Modal` to be mounted using `setTimeout`.
This problem caused by reactstrap.