### PR TITLE
Fix: search type 'public' searcheas incorrect filters

### DIFF
--- a/lib/util/elasticsearch/query.test.ts
+++ b/lib/util/elasticsearch/query.test.ts
@@ -174,8 +174,7 @@ describe('filterPortalPages', () => {
 
 describe('filterPublicPages', () => {
   it('should filter public pages', () => {
-    expect(filterPublicPages(baseQuery).body.query.bool.filter).toEqual([queries.user])
-    expect(filterPublicPages(baseQuery).body.query.bool.must_not).toEqual([queries.portal])
+    expect(filterPublicPages(baseQuery).body.query.bool.must_not).toEqual([queries.user, queries.portal])
   })
 })
 

--- a/lib/util/elasticsearch/query.ts
+++ b/lib/util/elasticsearch/query.ts
@@ -182,7 +182,7 @@ export const filterPortalPages = <T extends Search>(query: T) => {
 export const filterPublicPages = <T extends Search>(query: T) => {
   return pipe(
     query,
-    query => appendBoolFilterQuery(query, queries.user),
+    query => appendBoolMustNotQuery(query, queries.user),
     query => appendBoolMustNotQuery(query, queries.portal),
   )
 }


### PR DESCRIPTION
## What

- Search query of `type=public` is incorrect (caused by refactoring).


## Before

<img width="435" alt="スクリーンショット 2020-06-24 20 47 18" src="https://user-images.githubusercontent.com/29064/85550556-0d068900-b65c-11ea-82dc-d33da5131f94.png">

## After

<img width="529" alt="スクリーンショット 2020-06-24 20 46 36" src="https://user-images.githubusercontent.com/29064/85550568-0ed04c80-b65c-11ea-9c80-ec01da71d783.png">
