### PR TITLE
delete padding for <code> element

### DIFF
--- a/resource/css/crowi.scss
+++ b/resource/css/crowi.scss
@@ -25,7 +25,6 @@ ul {
 }
 
 code {
-  padding: 2px 4px;
   border-radius: 4px;
   background: lighten($pink, 40);
 }


### PR DESCRIPTION
## Background

I found a small misalignment on first line in code blocks of Crowi.
That comes from additional padding for \<code\> element.

### code block

You can create fenced code blocks by placing triple backticks ``` before and after the code block.

## Expected behavior

expected to be no padding left on first line.
Please see screenshots as following.

## Screenshots

### current

4px padding on left side in first line of code block.

![current](https://user-images.githubusercontent.com/4958270/91517515-e2210580-e928-11ea-9c75-41b156d57d54.png)

### expected

This is what you see if removed the padding on \<code\> element in DevTools.

![expected](https://user-images.githubusercontent.com/4958270/91517527-e64d2300-e928-11ea-8c6f-d2c6dc8924f2.png)
