### PR TITLE
I added i18n translation to admin page

### DIFF
--- a/client/components/Admin/App/AWSSettings.tsx
+++ b/client/components/Admin/App/AWSSettings.tsx
@@ -51,12 +51,12 @@ const AWSSettings: FC<Props> = ({ settingForm, update, alert }) => {
 
         <FormRow>
           <Label for="awsRegion">{t('admin.aws.region')}</Label>
-          <Input id="awsRegion" placeholder="例: ap-northeast-1" value={region} onChange={(e) => setRegion(e.target.value)} />
+          <Input id="awsRegion" placeholder={t('admin.aws.region_placeholder')} value={region} onChange={(e) => setRegion(e.target.value)} />
         </FormRow>
 
         <FormRow>
           <Label for="awsBucket">{t('admin.aws.bucket')}</Label>
-          <Input id="awsBucket" placeholder="例: crowi" value={bucket} onChange={(e) => setBucket(e.target.value)} />
+          <Input id="awsBucket" placeholder={t('admin.aws.bucket_placeholder')} value={bucket} onChange={(e) => setBucket(e.target.value)} />
         </FormRow>
 
         <FormRow>

--- a/client/components/Admin/App/SecuritySettings.tsx
+++ b/client/components/Admin/App/SecuritySettings.tsx
@@ -68,7 +68,7 @@ const SecuritySettings: FC<Props> = ({ registrationMode: registrationModeOptions
           <Input type="select" id="securityRegistrationMode" value={registrationMode} onChange={(e) => setRegistrationMode(e.target.value)}>
             {Object.entries(registrationModeOptions).map(([mode, label]) => (
               <option key={mode} value={mode}>
-                {label}
+                {t(`admin.security.registration.mode.label.${label}`)}
               </option>
             ))}
           </Input>

--- a/client/components/Admin/Navigation.tsx
+++ b/client/components/Admin/Navigation.tsx
@@ -1,20 +1,21 @@
 import React, { useContext, useEffect, FC } from 'react'
 import { NavLink } from 'react-router-dom'
-
+import { useTranslation } from 'react-i18next'
 import Icon from 'components/Common/Icon'
 import { AdminContext } from 'components/Admin/AdminPage'
 
 const Navigation: FC<{}> = () => {
+  const [t] = useTranslation()
   const { settingForm, searchConfigured } = useContext(AdminContext)
 
   const items = [
-    { key: 'index', to: '/admin', icon: 'cube', name: 'Wiki 管理トップ', title: 'Wiki管理', exact: true } as const,
-    { key: 'app', to: '/admin/app', icon: 'cogs', name: 'アプリ設定' } as const,
-    { key: 'notification', to: '/admin/notification', icon: 'bell', name: '通知管理' } as const,
-    { key: 'user', to: '/admin/users', icon: 'accountGroup', name: 'ユーザー管理' } as const,
-    { key: 'search', to: '/admin/search', icon: 'magnify', name: '検索管理', show: searchConfigured } as const,
-    { key: 'share', to: '/admin/share', icon: 'openInNew', name: '外部共有設定' } as const,
-    { key: 'backlink', to: '/admin/backlink', icon: 'anchor', name: 'バックリンク管理' } as const,
+    { key: 'index', to: '/admin', icon: 'cube', name: t('admin.navigation.top'), title: t('admin.navigation.title'), exact: true } as const,
+    { key: 'app', to: '/admin/app', icon: 'cogs', name: t('admin.navigation.app') } as const,
+    { key: 'notification', to: '/admin/notification', icon: 'bell', name: t('admin.navigation.notification') } as const,
+    { key: 'user', to: '/admin/users', icon: 'accountGroup', name: t('admin.navigation.users') } as const,
+    { key: 'search', to: '/admin/search', icon: 'magnify', name: t('admin.navigation.search'), show: searchConfigured } as const,
+    { key: 'share', to: '/admin/share', icon: 'openInNew', name: t('admin.navigation.share') } as const,
+    { key: 'backlink', to: '/admin/backlink', icon: 'anchor', name: t('admin.navigation.backlinks') } as const,
   ]
 
   useEffect(() => {

--- a/client/components/Admin/TopPage.tsx
+++ b/client/components/Admin/TopPage.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState, FC } from 'react'
-
+import { useTranslation } from 'react-i18next'
 import { AdminContext } from 'components/Admin/AdminPage'
 
 interface Info {
@@ -23,6 +23,7 @@ function useInfo(crowi) {
 }
 
 const TopPage: FC<{}> = () => {
+  const [t] = useTranslation()
   const { crowi, searchConfigured } = useContext(AdminContext)
   const [{ crowiVersion, searchInfo }, fetchInfo] = useInfo(crowi)
   const { node, indexName, esVersion } = searchInfo
@@ -34,9 +35,9 @@ const TopPage: FC<{}> = () => {
   return (
     <>
       <p>
-        この画面はWiki管理者のみがアクセスできる画面です。
+        {t('admin.top.description')}
         <br />
-        「ユーザー管理」から「管理者にする」ボタンを使ってユーザーをWiki管理者に任命することができます。
+        {t('admin.top.appoint_admin')}
       </p>
       <h2>Information</h2>
       <dl className="row">

--- a/client/components/Admin/User/InviteUserForm.tsx
+++ b/client/components/Admin/User/InviteUserForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState, FC } from 'react'
 import { Collapse, Form, FormGroup, FormText, Label, Input, CustomInput, Button, Row, Col } from 'reactstrap'
+import { useTranslation } from 'react-i18next'
 
 function useForm(invite) {
   const [emails, setEmails] = useState('')
@@ -27,6 +28,7 @@ interface Props {
 }
 
 const InviteUserForm: FC<Props> = ({ invite }) => {
+  const [t] = useTranslation()
   const [collapse, setCollapse] = useState(false)
   const [{ emails, sendEmail }, { setEmails, setSendEmail, onSubmit }] = useForm(invite)
 
@@ -34,7 +36,7 @@ const InviteUserForm: FC<Props> = ({ invite }) => {
     <>
       <p>
         <Button color="secondary" onClick={() => setCollapse(!collapse)}>
-          新規ユーザーの招待
+          {t('admin.user.invite.form.collapse')}
         </Button>
       </p>
       <Form onSubmit={onSubmit}>
@@ -42,11 +44,17 @@ const InviteUserForm: FC<Props> = ({ invite }) => {
           <FormGroup>
             <Row>
               <Col xs={{ size: 2, offset: 1 }}>
-                <Label for="emails">メールアドレス</Label>
+                <Label for="emails">{t('admin.user.invite.form.email')}</Label>
               </Col>
               <Col xs="8">
-                <Input type="textarea" id="emails" placeholder="例: user@crowi.wiki" value={emails} onChange={(e) => setEmails(e.target.value)} />
-                <FormText color="muted">複数行入力で複数人招待可能</FormText>
+                <Input
+                  type="textarea"
+                  id="emails"
+                  placeholder={t('admin.user.invite.form.example')}
+                  value={emails}
+                  onChange={(e) => setEmails(e.target.value)}
+                />
+                <FormText color="muted">{t('admin.user.invite.form.description')}</FormText>
               </Col>
             </Row>
           </FormGroup>
@@ -54,7 +62,14 @@ const InviteUserForm: FC<Props> = ({ invite }) => {
           <FormGroup>
             <Row>
               <Col xs={{ size: 8, offset: 3 }}>
-                <CustomInput id="sendEmail" type="checkbox" label="招待をメールで送信" checked={sendEmail} onChange={() => setSendEmail(!sendEmail)} inline />
+                <CustomInput
+                  id="sendEmail"
+                  type="checkbox"
+                  label={t('admin.user.invite.form.checkbox')}
+                  checked={sendEmail}
+                  onChange={() => setSendEmail(!sendEmail)}
+                  inline
+                />
               </Col>
             </Row>
           </FormGroup>
@@ -62,7 +77,7 @@ const InviteUserForm: FC<Props> = ({ invite }) => {
           <FormGroup>
             <Row>
               <Col xs={{ size: 8, offset: 3 }}>
-                <Button color="primary">招待する</Button>
+                <Button color="primary">{t('admin.user.invite.form.submit')}</Button>
               </Col>
             </Row>
           </FormGroup>

--- a/client/components/Admin/User/InvitedUserModal.tsx
+++ b/client/components/Admin/User/InvitedUserModal.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react'
 import { Modal, ModalHeader, ModalBody, Table } from 'reactstrap'
+import { useTranslation } from 'react-i18next'
 
 interface Props {
   users: any[]
@@ -7,21 +8,23 @@ interface Props {
 }
 
 const InvitedUserModal: FC<Props> = ({ users, clear }) => {
+  const [t] = useTranslation()
   return (
     <Modal isOpen={users.length > 0} toggle={clear}>
-      <ModalHeader toggle={clear}>ユーザーを招待しました</ModalHeader>
+      <ModalHeader toggle={clear}>{t('admin.user.invite.modal.completed_message')}</ModalHeader>
       <ModalBody>
         <p>
-          作成したユーザーは仮パスワードが設定されています。
+          {t('admin.user.invite.modal.temp_password')}
           <br />
-          仮パスワードはこの画面を閉じると二度と表示できませんのでご注意ください。
-          <span className="text-danger">招待メールを送っていない場合、この画面で必ず仮パスワードをコピーし、招待者へ連絡してください。</span>
+          {t('admin.user.invite.modal.caution_password')}
+          <br />
+          <span className="text-danger">{t('admin.user.invite.modal.caution_without_email')}</span>
         </p>
         <Table>
           <thead>
             <tr>
-              <th>メールアドレス</th>
-              <th>パスワード</th>
+              <th>{t('admin.user.invite.modal.email')}</th>
+              <th>{t('admin.user.invite.modal.password')}</th>
             </tr>
           </thead>
           <tbody>
@@ -30,7 +33,7 @@ const InvitedUserModal: FC<Props> = ({ users, clear }) => {
                 <td>
                   <pre>{email}</pre>
                 </td>
-                <td>{user ? <pre>{password}</pre> : <span className="text-danger">作成失敗</span>}</td>
+                <td>{user ? <pre>{password}</pre> : <span className="text-danger">{t('admin.user.invite.modal.failed_message')}</span>}</td>
               </tr>
             ))}
           </tbody>

--- a/client/components/Admin/User/ResetPasswordModal.tsx
+++ b/client/components/Admin/User/ResetPasswordModal.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react'
 import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap'
+import { useTranslation } from 'react-i18next'
 
 interface Props {
   isOpen: boolean
@@ -9,18 +10,19 @@ interface Props {
 }
 
 const ResetPasswordModal: FC<Props> = ({ isOpen, toggle, user = {}, resetPassword }) => {
+  const [t] = useTranslation()
   const handleClick = (e) => {
     e.preventDefault()
     resetPassword(user)
   }
   return (
     <Modal isOpen={isOpen} toggle={toggle}>
-      <ModalHeader toggle={toggle}>パスワードを新規発行しますか?</ModalHeader>
+      <ModalHeader toggle={toggle}>{t('admin.user.reset_password.modal.ask')}</ModalHeader>
       <ModalBody>
         <p>
-          新規発行したパスワードはこの画面を閉じると二度と表示できませんのでご注意ください。
+          {t('admin.user.reset_password.modal.caution')}
           <br />
-          <span className="text-danger">新規発行したパスワードを、対象ユーザーへ連絡してください。</span>
+          <span className="text-danger">{t('admin.user.reset_password.modal.after_reset')}</span>
         </p>
         <p>
           Reset user: <code>{user.email}</code>
@@ -28,7 +30,7 @@ const ResetPasswordModal: FC<Props> = ({ isOpen, toggle, user = {}, resetPasswor
       </ModalBody>
       <ModalFooter>
         <Button type="submit" color="primary" onClick={handleClick}>
-          実行
+          {t('admin.user.reset_password.modal.submit')}
         </Button>
       </ModalFooter>
     </Modal>

--- a/client/components/Admin/User/UserEditDropdown.tsx
+++ b/client/components/Admin/User/UserEditDropdown.tsx
@@ -1,6 +1,7 @@
 import React, { useState, FC } from 'react'
 import { Button, Alert, Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap'
 import { STATUS } from './UserTable'
+import { useTranslation } from 'react-i18next'
 
 function OnlyStatusFactory(user) {
   return ({ status, children }) => user.status === status && children
@@ -21,6 +22,7 @@ interface Props {
 }
 
 const UserEditDropdown: FC<Props> = ({ me, user, ...props }) => {
+  const [t] = useTranslation()
   const { admin, username } = user
   const [open, setOpen] = useState(false)
   const {
@@ -39,60 +41,60 @@ const UserEditDropdown: FC<Props> = ({ me, user, ...props }) => {
   return (
     <Dropdown isOpen={open} toggle={() => setOpen(!open)}>
       <DropdownToggle color="light" caret>
-        編集
+        {t('admin.user.edit.dropdown.edit')}
       </DropdownToggle>
       <DropdownMenu right>
         <div className="dropdown-menu-buttons">
-          <DropdownItem header>編集メニュー</DropdownItem>
+          <DropdownItem header>{t('admin.user.edit.dropdown.edit_menu')}</DropdownItem>
           <Button color="light" onClick={() => handleClickEdit(user)}>
-            編集
+            {t('admin.user.edit.dropdown.edit')}
           </Button>
           <Button color="light" onClick={() => handleClickResetPassword(user)}>
-            パスワードの再発行
+            {t('admin.user.edit.dropdown.reset_password')}
           </Button>
-          <DropdownItem header>ステータス</DropdownItem>
+          <DropdownItem header>{t('admin.user.edit.dropdown.status')}</DropdownItem>
           <OnlyStatus status={STATUS.REGISTERED}>
             <Button color="info" onClick={() => handleClickApprove(user)}>
-              承認する
+              {t('admin.user.edit.dropdown.approve')}
             </Button>
           </OnlyStatus>
           <OnlyStatus status={STATUS.ACTIVE}>
             <Button color="warning" onClick={() => handleClickSuspend(user)}>
-              アカウント停止
+              {t('admin.user.edit.dropdown.suspend')}
             </Button>
           </OnlyStatus>
           <OnlyStatus status={STATUS.SUSPENDED}>
             <Button color="light" onClick={() => handleClickRestore(user)}>
-              元に戻す
+              {t('admin.user.edit.dropdown.restore')}
             </Button>
           </OnlyStatus>
           {/* label は同じだけど、こっちは論理削除 */}
           <Button color="danger" onClick={() => handleClickRemove(user)}>
-            削除する
+            {t('admin.user.edit.dropdown.delete')}
           </Button>
           {/* label は同じだけど、こっちは物理削除 */}
           <OnlyStatus status={STATUS.INVITED}>
             <Button color="danger" onClick={() => handleClickRemoveCompletely(user)}>
-              削除する
+              {t('admin.user.edit.dropdown.delete_completely')}
             </Button>
           </OnlyStatus>
           <OnlyStatus status={STATUS.ACTIVE}>
             {/* activated な人だけこのメニューを表示 */}
-            <DropdownItem header>管理者メニュー</DropdownItem>
+            <DropdownItem header>{t('admin.user.edit.dropdown.admin_menu')}</DropdownItem>
 
             {admin ? (
               username !== me.username ? (
                 <Button color="danger" onClick={() => handleClickRevokeAdmin(user)}>
-                  管理者からはずす
+                  {t('admin.user.edit.dropdown.remove_admin')}
                 </Button>
               ) : (
                 <DropdownItem>
-                  <Alert color="danger">自分自身を管理者から外すことはできません</Alert>
+                  <Alert color="danger">{t('admin.user.edit.dropdown.remove_caution')}</Alert>
                 </DropdownItem>
               )
             ) : (
               <Button color="primary" onClick={() => handleClickGrantAdmin(user)}>
-                管理者にする
+                {t('admin.user.edit.dropdown.make_admin')}
               </Button>
             )}
           </OnlyStatus>

--- a/client/components/Admin/User/UserEditModal.tsx
+++ b/client/components/Admin/User/UserEditModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, FC } from 'react'
 import { Form, FormGroup, Input, Label, Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap'
+import { useTranslation } from 'react-i18next'
 
 interface Props {
   isOpen: boolean
@@ -14,6 +15,7 @@ interface Props {
 }
 
 const UserEditModal: FC<Props> = ({ isOpen, toggle, editUserNameAndEmail, clearForm, name, emailToBeChanged, setName, setEmailToBeChanged, user = {} }) => {
+  const [t] = useTranslation()
   const handleUserNameChange = (e) => {
     setName(e.target.value)
   }
@@ -27,26 +29,26 @@ const UserEditModal: FC<Props> = ({ isOpen, toggle, editUserNameAndEmail, clearF
   }
   return (
     <Modal isOpen={isOpen} toggle={toggle}>
-      <ModalHeader toggle={toggle}>ユーザー情報を編集しますか?</ModalHeader>
+      <ModalHeader toggle={toggle}>{t('admin.user.edit.modal.ask')}</ModalHeader>
       <ModalBody>
         <Form>
           <FormGroup>
             <Label>
-              現在の名前: <code>{user.name}</code>
+              {t('admin.user.edit.modal.current_name')}: <code>{user.name}</code>
             </Label>
-            <Input type="text" name="name" placeholder="新しい名前を入力してください" defaultValue={user.name} onChange={handleUserNameChange} />
+            <Input type="text" name="name" placeholder={t('admin.user.edit.modal.new_name')} defaultValue={user.name} onChange={handleUserNameChange} />
           </FormGroup>
           <FormGroup>
             <Label>
-              現在のメールアドレス: <code>{user.email}</code>
+              {t('admin.user.edit.modal.current_email')}: <code>{user.email}</code>
             </Label>
-            <Input type="email" name="email" placeholder="新しいメールアドレスを入力してください" defaultValue={user.email} onChange={handleEmailChange} />
+            <Input type="email" name="email" placeholder={t('admin.user.edit.modal.new_email')} defaultValue={user.email} onChange={handleEmailChange} />
           </FormGroup>
         </Form>
       </ModalBody>
       <ModalFooter>
         <Button type="submit" color="primary" onClick={handleSubmit}>
-          実行
+          {t('admin.user.edit.modal.submit')}
         </Button>
       </ModalFooter>
     </Modal>

--- a/lib/models/config.ts
+++ b/lib/models/config.ts
@@ -19,9 +19,9 @@ export interface ConfigDocument extends Document {
 }
 
 export const registrationMode: Record<string, any> = {
-  [SECURITY_REGISTRATION_MODE_OPEN]: '公開 (だれでも登録可能)',
-  [SECURITY_REGISTRATION_MODE_RESTRICTED]: '制限 (登録完了には管理者の承認が必要)',
-  [SECURITY_REGISTRATION_MODE_CLOSED]: '非公開 (登録には管理者による招待が必要)',
+  [SECURITY_REGISTRATION_MODE_OPEN]: 'open',
+  [SECURITY_REGISTRATION_MODE_RESTRICTED]: 'restricted',
+  [SECURITY_REGISTRATION_MODE_CLOSED]: 'closed',
 }
 
 export function isRequiredThirdPartyAuth(config: Config): boolean {

--- a/lib/pages/AdminPage.tsx
+++ b/lib/pages/AdminPage.tsx
@@ -13,7 +13,7 @@ const AdminPage: FC<PageProps> = (props) => {
         <Single>
           <div className="header-wrap">
             <header id="page-header">
-              <h1 className="title">Wiki管理</h1>
+              <h1 className="title">{i18n.t('admin.top.title')}</h1>
             </header>
           </div>
           <div id="admin-page" className="content-main content-form"></div>

--- a/locales/en-US/translation.yml
+++ b/locales/en-US/translation.yml
@@ -366,7 +366,7 @@ admin:
     invite:
       form:
         collapse: Invite new users
-        email: email
+        email: Email
         example: 'ex. user@crowi.wiki'
         description: You can invite more than one person at once with multi-line email addresses.
         checkbox: Send invitation by email
@@ -376,8 +376,8 @@ admin:
         temp_password: The new users have temporary passwords.
         caution_password: Please note that you can never find temporary passwords after you close this message.
         caution_without_email: You need to tell directly the invited users temporary passwords if you have not sent email via invitation.
-        email: email
-        password: password
+        email: Email
+        password: Password
         failed_message: Invitation Failed
     reset_password:
       modal:
@@ -385,6 +385,28 @@ admin:
         caution: Please note that you can never find the new password after you close this message.
         after_reset: Please tell the user the new password.
         submit: Submit
+    edit:
+      modal:
+        ask: Do you edit user information?
+        current_name: Current name
+        current_email: Current email
+        new_name: Please enter your new name.
+        new_email: Please enter your new email address.
+        submit: Submit
+      dropdown:
+        edit: Edit
+        edit_menu: Edit menu
+        reset_password: Reset password
+        status: Status
+        approve: Approve
+        suspend: Suspend
+        restore: Restore
+        delete: Delete
+        delete_completely: Delete Completely
+        admin_menu: Admin menu
+        remove_admin: Remove admin
+        remove_caution: You can not remove yourself from admin.
+        make_admin: Make admin
 
 Portalize: Portalize
 portalize:

--- a/locales/en-US/translation.yml
+++ b/locales/en-US/translation.yml
@@ -379,6 +379,12 @@ admin:
         email: email
         password: password
         failed_message: Invitation Failed
+    reset_password:
+      modal:
+        ask: Do you reset the user's password?
+        caution: Please note that you can never find the new password after you close this message.
+        after_reset: Please tell the user the new password.
+        submit: Submit
 
 Portalize: Portalize
 portalize:

--- a/locales/en-US/translation.yml
+++ b/locales/en-US/translation.yml
@@ -363,6 +363,14 @@ admin:
     status: Status
     operation: Operation
     not_found: User Not Found
+    invite:
+      form:
+        collapse: Invite new users
+        email: email
+        example: 'ex. user@crowi.wiki'
+        description: You can invite more than one person at once with multi-line email addresses.
+        checkbox: Send invitation by email
+        submit: Submit
 
 Portalize: Portalize
 portalize:

--- a/locales/en-US/translation.yml
+++ b/locales/en-US/translation.yml
@@ -245,41 +245,41 @@ admin:
   app:
     legend: App Settings
     title: Name for this Wiki
-    title_description: You can rename this Wiki. The name will be displayed for headers and HTML title tag.
+    title_description: You can rename this Wiki - the name will be displayed in headers and HTML title tags.
     confidential: Confidential
-    confidential_placeholder: 'ex. Confidential'
-    confidential_description: You can customize confidential notification on headers.
-    allow_upload_file: Allow users upload files other than image
-    allow_upload_file_description1: You can apply this option only if you applied option which allow users upload files.
+    confidential_placeholder: 'Ex. "Confidential"'
+    confidential_description: You can customize confidential notifications in headers.
+    allow_upload_file: Allow users to upload files other than images.
+    allow_upload_file_description1: This option can only be applied if you allow users to upload files.
     allow_upload_file_description2: Users can attach files other than images if you apply this option.
   aws:
     legend: AWS Settings
-    tips1: You can configure your settings to access AWS. Once you complete this config, which enable file upload and profile picture feature.
-    notice: CAUTION. PLEASE NOTE THAT YOU MAY NOT ACCESS THE FILES YOU UPLOADED IF YOU CHANGE THIS SETTINGS.
+    tips1: You can configure your settings to access AWS. Once completed, file upload and profile picture features are enabled.
+    notice: CAUTION. PLEASE NOTE THAT YOU WILL BE UNABLE TO ACCESS THE FILES YOU UPLOADED IF YOU CHANGE THIS SETTING.
     region: Region
-    region_placeholder: 'ex. ap-northeast-1'
+    region_placeholder: 'Ex. "ap-northeast-1"'
     bucket: Bucket Name
-    bucket_placeholder: 'ex. crowi'
+    bucket_placeholder: 'Ex. "crowi"'
     access_key_id: Access Key ID
     secret_access_key: Secret Access Key
   github:
     legend: GitHub Settings
-    tips1: You will be able to login or sign up with GitHub account if you set GitHub information.
-    tips2: You can restrict login with GitHub account only for the members of organization if you input the organization name in this section.
+    tips1: Once you set up this project, You will be able to login or sign up with your GitHub account.
+    tips2: You can restrict login with GitHub accounts to only members of the organization if you input the organization name in this section.
     client_id: Client ID
     client_secret: Client Secret
     organization: Organization
   google:
     legend: Google Settings
-    tips: You will be able to login or sign up with Google account if you set Google information.
+    tips: Once you set up your project, You will be able to login or sign up with your Google account.
     client_id: Client ID
     client_secret: Client Secret
   mail:
     legend: Mail Settings
-    tips1: If you have SMTP settings in place, it will be used. If you don't have SMTP settings but you have AWS settings, it will try to send via SES. You need to verify FROM email address and enable production access.
-    tips2: Emails are not sent without either configs
-    from: From address
-    from_placeholder: 'ex. mail@crowi.wiki'
+    tips1: If you have SMTP settings in place, it will be used. If you don't have SMTP settings but you have AWS settings, it will try to send via SES. You need to verify the "FROM email address" and enable production access.
+    tips2: Emails can not be sent without either configuration set up.
+    from: FROM address
+    from_placeholder: 'Ex. mail@crowi.wiki'
     smtp:
       legend: SMTP Settings
       smtp: SMTP Settings
@@ -306,9 +306,9 @@ admin:
           open: 'Public - Anyone can register.'
           restricted: 'Restricted - Approval by Admin is required at registration.'
           closed: 'Closed - Invitation by Admin is required at registration.'
-    restriction_description: The information you input here will be displayed in the header
+    restriction_description: The information you input here will be displayed in the header.
     whitelist: Whitelist of email addresses for registration permission
-    whitelist_placeholder: 'ex. mail@crowi.wiki'
+    whitelist_placeholder: 'Ex. mail@crowi.wiki'
     whitelist_description1: You can limit the domain of email addresses that can be registered. For example, if you use crowi.wiki domain in your company, you can write <1>@crowi.wiki</1>, which means that only people with that company's email address can register.
     whitelist_description2: Please input one email address per line.
   backlink:
@@ -352,7 +352,7 @@ admin:
     build_description2: Click "Build Now" to delete all backlinks and create backlinks by all pages.
     build_description3: This may take a while.
   share:
-    legend: External Share Settings
+    legend: External Sharing Settings
     enable_external_share: Enable sharing Wiki pages to external users.
   user:
     legend: User List
@@ -367,27 +367,27 @@ admin:
       form:
         collapse: Invite new users
         email: Email
-        example: 'ex. user@crowi.wiki'
-        description: You can invite more than one person at once with multi-line email addresses.
+        example: 'Ex. user@crowi.wiki'
+        description: You can invite more than one person at a time with multi-line email addresses.
         checkbox: Send invitation by email
         submit: Submit
       modal:
-        completed_message: Success for inviting new users
+        completed_message: Successfully invited new users! 
         temp_password: The new users have temporary passwords.
-        caution_password: Please note that you can never find temporary passwords after you close this message.
-        caution_without_email: You need to tell directly the invited users temporary passwords if you have not sent email via invitation.
+        caution_password: Please note you will not be able to recover the temporary passwords once you close this message.
+        caution_without_email: You need to share the temporary passwords with invited users if you have not sent invitations via email.
         email: Email
         password: Password
         failed_message: Invitation Failed
     reset_password:
       modal:
-        ask: Do you reset the user's password?
-        caution: Please note that you can never find the new password after you close this message.
-        after_reset: Please tell the user the new password.
+        ask: Do you want to reset the user's password?
+        caution: Please note you will not be able to recover the new password once you close this message.
+        after_reset: Please share the new password with the user.
         submit: Submit
     edit:
       modal:
-        ask: Do you edit user information?
+        ask: Do you want to edit user information?
         current_name: Current name
         current_email: Current email
         new_name: Please enter your new name.
@@ -405,7 +405,7 @@ admin:
         delete_completely: Delete Completely
         admin_menu: Admin menu
         remove_admin: Remove admin
-        remove_caution: You can not remove yourself from admin.
+        remove_caution: You can not remove yourself as admin.
         make_admin: Make admin
 
 Portalize: Portalize

--- a/locales/en-US/translation.yml
+++ b/locales/en-US/translation.yml
@@ -300,6 +300,12 @@ admin:
     tips1: The basic authentication is applied to the entire page when you set up this section.
     tips2: Please note that your ID and password will be sent unencrypted.
     restriction: Registration restriction
+    registration:
+      mode:
+        label:
+          open: 'Public - Anyone can register.'
+          restricted: 'Restricted - Approval by Admin is required at registration.'
+          closed: 'Closed - Invitation by Admin is required at registration.'
     restriction_description: The information you input here will be displayed in the header
     whitelist: Whitelist of email addresses for registration permission
     whitelist_placeholder: 'ex. mail@crowi.wiki'

--- a/locales/en-US/translation.yml
+++ b/locales/en-US/translation.yml
@@ -244,7 +244,9 @@ admin:
     tips1: You can configure your settings to access AWS. Once you complete this config, which enable file upload and profile picture feature.
     notice: CAUTION. PLEASE NOTE THAT YOU MAY NOT ACCESS THE FILES YOU UPLOADED IF YOU CHANGE THIS SETTINGS.
     region: Region
+    region_placeholder: 'ex. ap-northeast-1'
     bucket: Bucket Name
+    bucket_placeholder: 'ex. crowi'
     access_key_id: Access Key ID
     secret_access_key: Secret Access Key
   github:

--- a/locales/en-US/translation.yml
+++ b/locales/en-US/translation.yml
@@ -230,10 +230,11 @@ search:
 
 admin:
   top:
+    title: Wiki Admin
     description: This page can only be accessed by the Wiki administrators.
     appoint_admin: You can appoint a user as a Wiki administrator using the Make Admin button in Manage User page.
   navigation:
-    top: Admin Page
+    top: Admin Info
     title: Admin Page
     app: App Settings
     notification: Notification

--- a/locales/en-US/translation.yml
+++ b/locales/en-US/translation.yml
@@ -371,6 +371,14 @@ admin:
         description: You can invite more than one person at once with multi-line email addresses.
         checkbox: Send invitation by email
         submit: Submit
+      modal:
+        completed_message: Success for inviting new users
+        temp_password: The new users have temporary passwords.
+        caution_password: Please note that you can never find temporary passwords after you close this message.
+        caution_without_email: You need to tell directly the invited users temporary passwords if you have not sent email via invitation.
+        email: email
+        password: password
+        failed_message: Invitation Failed
 
 Portalize: Portalize
 portalize:

--- a/locales/en-US/translation.yml
+++ b/locales/en-US/translation.yml
@@ -229,6 +229,9 @@ search:
     results: '{{value}} results'
 
 admin:
+  top:
+    description: This page can only be accessed by the Wiki administrators.
+    appoint_admin: You can appoint a user as a Wiki administrator using the Make Admin button in Manage User page.
   app:
     legend: App Settings
     title: Name for this Wiki

--- a/locales/en-US/translation.yml
+++ b/locales/en-US/translation.yml
@@ -231,65 +231,65 @@ search:
 admin:
   app:
     legend: App Settings
-    title: Wikiの名前
-    title_description: ヘッダーやHTMLタイトルに使用されるWikiの名前を変更できます。
-    confidential: コンフィデンシャル表示
-    confidential_placeholder: '例: 社外秘'
-    confidential_description: ここに入力した内容は、ヘッダー等に表示されます。
-    allow_upload_file: 画像以外のファイルアップロードを許可
-    allow_upload_file_description1: ファイルアップロードの設定を有効にしている場合にのみ、選択可能です。
-    allow_upload_file_description2: 許可をしている場合、画像以外のファイルをページに添付可能になります。
+    title: Name for this Wiki
+    title_description: You can rename this Wiki. The name will be displayed for headers and HTML title tag.
+    confidential: Confidential
+    confidential_placeholder: 'ex. Confidential'
+    confidential_description: You can customize confidential notification on headers.
+    allow_upload_file: Allow users upload files other than image
+    allow_upload_file_description1: You can apply this option only if you applied option which allow users upload files.
+    allow_upload_file_description2: Users can attach files other than images if you apply this option.
   aws:
     legend: AWS Settings
-    tips1: AWS にアクセスするための設定を行います。AWS の設定を完了させると、ファイルアップロード機能、プロフィール写真機能などが有効になります。
-    notice: この設定を途中で変更すると、これまでにアップロードしたファイル等へのアクセスができなくなりますのでご注意下さい。
-    region: リージョン
-    bucket: バケット名
+    tips1: You can configure your settings to access AWS. Once you complete this config, which enable file upload and profile picture feature.
+    notice: CAUTION. PLEASE NOTE THAT YOU MAY NOT ACCESS THE FILES YOU UPLOADED IF YOU CHANGE THIS SETTINGS.
+    region: Region
+    bucket: Bucket Name
     access_key_id: Access Key ID
     secret_access_key: Secret Access Key
   github:
     legend: GitHub Settings
-    tips1: GitHub プロジェクトの設定をすると、GitHub アカウントにコネクトして登録やログインが可能になります。
-    tips2: また、Organizationを指定した場合は、その組織に所属するアカウントのみがコネクトできるようになります。
+    tips1: You will be able to login or sign up with GitHub account if you set GitHub information.
+    tips2: You can restrict login with GitHub account only for the members of organization if you input the organization name in this section.
     client_id: Client ID
     client_secret: Client Secret
     organization: Organization
   google:
     legend: Google Settings
-    tips: Google プロジェクトの設定をすると、Google アカウントにコネクトして登録やログインが可能になります。
+    tips: You will be able to login or sign up with Google account if you set Google information.
     client_id: Client ID
     client_secret: Client Secret
   mail:
     legend: Mail Settings
-    tips1: SMTPの設定がされている場合、それが利用されます。SMTP設定がなく、AWSの設定がある場合、SESでの送信を試みます。SESを利用するためにはFromメールアドレスのVerify、プロダクション利用設定をする必要があります。
-    tips2: どちらの設定もない場合、メールは送信されません。
-    from: Fromアドレス
-    from_placeholder: '例: mail@crowi.wiki'
+    tips1: If you have SMTP settings in place, it will be used. If you don't have SMTP settings but you have AWS settings, it will try to send via SES. You need to verify FROM email address and enable production access.
+    tips2: Emails are not sent without either configs
+    from: From address
+    from_placeholder: 'ex. mail@crowi.wiki'
     smtp:
-      legend: SMTP設定
-      smtp: SMTP設定
-      host: ホスト
-      port: ポート
-      user: ユーザー
-      password: パスワード
+      legend: SMTP Settings
+      smtp: SMTP Settings
+      host: Host
+      port: Port
+      user: User
+      password: Password
     aws:
-      legend: AWS設定
-      region: リージョン
+      legend: AWS Settings
+      region: Region
       access_key_id: Access Key ID
       secret_access_key: Secret Access Key
   security:
     legend: Security Settings
-    basic_auth: Basic認証
+    basic_auth: Basic Authentication
     id: ID
-    password: パスワード
-    tips1: Basic認証を設定すると、ページ全体に共通の認証がかかります。
-    tips2: IDとパスワードは暗号化されずに送信されるのでご注意下さい。
-    restriction: 登録の制限
-    restriction_description: ここに入力した内容は、ヘッダー等に表示されます。
-    whitelist: 登録許可メールアドレスのホワイトリスト
-    whitelist_placeholder: '例: mail@crowi.wiki'
-    whitelist_description1: 登録可能なメールアドレスを制限することができます。例えば、会社で使う場合、<1>@crowi.wiki</1>などと記載すると、その会社のメールアドレスを持っている人のみ登録可能になります。
-    whitelist_description2: 1行に1メールアドレス入力してください。
+    password: Password
+    tips1: The basic authentication is applied to the entire page when you set up this section.
+    tips2: Please note that your ID and password will be sent unencrypted.
+    restriction: Registration restriction
+    restriction_description: The information you input here will be displayed in the header
+    whitelist: Whitelist of email addresses for registration permission
+    whitelist_placeholder: 'ex. mail@crowi.wiki'
+    whitelist_description1: You can limit the domain of email addresses that can be registered. For example, if you use crowi.wiki domain in your company, you can write <1>@crowi.wiki</1>, which means that only people with that company's email address can register.
+    whitelist_description2: Please input one email address per line.
   backlink:
     legend: Backlinks Build
     build: Build Now
@@ -332,16 +332,16 @@ admin:
     build_description3: This may take a while.
   share:
     legend: External Share Settings
-    enable_external_share: Wikiページの外部ユーザーへの共有を有効にする。
+    enable_external_share: Enable sharing Wiki pages to external users.
   user:
     legend: User List
-    user_id: ユーザーID
-    name: 名前
-    email: メールアドレス
-    created_at: 作成日
-    status: ステータス
-    operation: 操作
-    not_found: ユーザーが見つかりませんでした
+    user_id: User ID
+    name: Name
+    email: Email
+    created_at: Created
+    status: Status
+    operation: Operation
+    not_found: User Not Found
 
 Portalize: Portalize
 portalize:

--- a/locales/en-US/translation.yml
+++ b/locales/en-US/translation.yml
@@ -232,15 +232,15 @@ admin:
   top:
     title: Wiki Admin
     description: This page can only be accessed by the Wiki administrators.
-    appoint_admin: You can appoint a user as a Wiki administrator using the Make Admin button in Manage User page.
+    appoint_admin: You can appoint any user as a Wiki administrator using the Make Admin button in the Manage User page.
   navigation:
     top: Admin Info
     title: Admin Page
     app: App Settings
-    notification: Notification
+    notification: Notifications
     users: Users
     search: Search Index
-    share: External Share Settings
+    share: External Sharing Settings
     backlinks: Backlinks
   app:
     legend: App Settings

--- a/locales/en-US/translation.yml
+++ b/locales/en-US/translation.yml
@@ -232,6 +232,15 @@ admin:
   top:
     description: This page can only be accessed by the Wiki administrators.
     appoint_admin: You can appoint a user as a Wiki administrator using the Make Admin button in Manage User page.
+  navigation:
+    top: Admin Page
+    title: Admin Page
+    app: App Settings
+    notification: Notification
+    users: Users
+    search: Search Index
+    share: External Share Settings
+    backlinks: Backlinks
   app:
     legend: App Settings
     title: Name for this Wiki

--- a/locales/ja/translation.yml
+++ b/locales/ja/translation.yml
@@ -245,7 +245,9 @@ admin:
     tips2: また、SMTP の設定が無い場合、SES を利用したメール送信が行われます。FromメールアドレスのVerify、プロダクション利用設定をする必要があります。
     notice: この設定を途中で変更すると、これまでにアップロードしたファイル等へのアクセスができなくなりますのでご注意下さい。
     region: リージョン
+    region_placeholder: '例: ap-northeast-1'
     bucket: バケット名
+    bucket_placeholder: '例: crowi'
     access_key_id: Access Key ID
     secret_access_key: Secret Access Key
   github:

--- a/locales/ja/translation.yml
+++ b/locales/ja/translation.yml
@@ -379,6 +379,12 @@ admin:
         email: メールアドレス
         password: パスワード
         failed_message: 作成失敗
+    reset_password:
+      modal:
+        ask: パスワードを新規発行しますか?
+        caution: 新規発行したパスワードはこの画面を閉じると二度と表示できませんのでご注意ください。
+        after_reset: 新規発行したパスワードを、対象ユーザーへ連絡してください。
+        submit: 実行
 
 Portalize: ポータル化
 portalize:

--- a/locales/ja/translation.yml
+++ b/locales/ja/translation.yml
@@ -371,6 +371,14 @@ admin:
         description: 複数行入力で複数人を招待可能
         checkbox: 招待をメールで送信
         submit: 招待する
+      modal:
+        completed_message: ユーザーを招待しました
+        temp_password: 作成したユーザーは仮パスワードが設定されています。
+        caution_password: 仮パスワードはこの画面を閉じると二度と表示できませんのでご注意ください。
+        caution_without_email: 招待メールを送っていない場合、この画面で必ず仮パスワードをコピーし、招待者へ連絡してください。
+        email: メールアドレス
+        password: パスワード
+        failed_message: 作成失敗
 
 Portalize: ポータル化
 portalize:

--- a/locales/ja/translation.yml
+++ b/locales/ja/translation.yml
@@ -300,6 +300,12 @@ admin:
     tips1: Basic認証を設定すると、ページ全体に共通の認証がかかります。
     tips2: IDとパスワードは暗号化されずに送信されるのでご注意下さい。
     restriction: 登録の制限
+    registration:
+      mode:
+        label:
+          open: '公開（誰でも登録可能）'
+          restricted: '制限（登録完了には管理者の承認が必要）'
+          closed: '非公開（登録には管理者による招待が必要）'
     restriction_description: ここに入力した内容は、ヘッダー等に表示されます。
     whitelist: 登録許可メールアドレスのホワイトリスト
     whitelist_placeholder: '例: mail@crowi.wiki'

--- a/locales/ja/translation.yml
+++ b/locales/ja/translation.yml
@@ -385,6 +385,28 @@ admin:
         caution: 新規発行したパスワードはこの画面を閉じると二度と表示できませんのでご注意ください。
         after_reset: 新規発行したパスワードを、対象ユーザーへ連絡してください。
         submit: 実行
+    edit:
+      modal:
+        ask: ユーザー情報を編集しますか？
+        current_name: 現在の名前
+        current_email: 現在のメールアドレス
+        new_name: 新しい名前を入力してください
+        new_email: 新しいメールアドレスを入力してください
+        submit: 実行 
+      dropdown:
+        edit: 編集
+        edit_menu: 編集メニュー
+        reset_password: パスワードの再発行
+        status: ステータス
+        approve: 承認する
+        suspend: アカウント停止
+        restore: 元に戻す
+        delete: 削除する
+        delete_completely: 完全に削除する
+        admin_menu: 管理者メニュー
+        remove_admin: 管理者から外す 
+        remove_caution: 自分自身を管理者から外すことはできません。
+        make_admin: 管理者にする
 
 Portalize: ポータル化
 portalize:

--- a/locales/ja/translation.yml
+++ b/locales/ja/translation.yml
@@ -363,6 +363,14 @@ admin:
     status: ステータス
     operation: 操作
     not_found: ユーザーが見つかりませんでした
+    invite:
+      form:
+        collapse: 新規ユーザーの招待
+        email: メールアドレス
+        example: '例: user@crowi.wiki'
+        description: 複数行入力で複数人を招待可能
+        checkbox: 招待をメールで送信
+        submit: 招待する
 
 Portalize: ポータル化
 portalize:

--- a/locales/ja/translation.yml
+++ b/locales/ja/translation.yml
@@ -229,6 +229,9 @@ search:
     results: '{{value}} 件'
 
 admin:
+  top:
+    description: この画面はWiki管理者のみがアクセスできる画面です。
+    appoint_admin: 「ユーザー管理」から「管理者にする」ボタンを使ってユーザーをWiki管理者に任命することができます。
   app:
     legend: アプリ設定
     title: Wikiの名前

--- a/locales/ja/translation.yml
+++ b/locales/ja/translation.yml
@@ -232,6 +232,15 @@ admin:
   top:
     description: この画面はWiki管理者のみがアクセスできる画面です。
     appoint_admin: 「ユーザー管理」から「管理者にする」ボタンを使ってユーザーをWiki管理者に任命することができます。
+  navigation:
+    top: Wiki 管理トップ
+    title: Wiki 管理
+    app: アプリ設定
+    notification: 通知設定
+    users: ユーザー管理
+    search: 検索管理
+    share: 外部共有設定  
+    backlinks: バックリンク管理
   app:
     legend: アプリ設定
     title: Wikiの名前

--- a/locales/ja/translation.yml
+++ b/locales/ja/translation.yml
@@ -230,6 +230,7 @@ search:
 
 admin:
   top:
+    title: Wiki管理
     description: この画面はWiki管理者のみがアクセスできる画面です。
     appoint_admin: 「ユーザー管理」から「管理者にする」ボタンを使ってユーザーをWiki管理者に任命することができます。
   navigation:


### PR DESCRIPTION
## Overview

I added i18n translation definition to the resource YAML, and React hooks to some components that need to be translated when users set their language into English.

## Background

There are some Japanese text in Crowi admin page even when users set their language in English. Please see screenshots.

This cause from two reasons bellow.

1. Crowi has some Japanese words in the resource which i18next use for English translation
2. No React hooks for translation in some components (Crowi uses i18next for providing translation to components, so we need to add them and call t function for translation)

These are what I try to fix them in this pull request.

## Screenshots

### current

![before](https://user-images.githubusercontent.com/4958270/93007904-3d016080-f5a9-11ea-9af6-b7c39ea9db74.png)

### after

If this PR is merged

![after](https://user-images.githubusercontent.com/4958270/93007905-42f74180-f5a9-11ea-93e2-64e1e9291580.png)
