### PR TITLE
Fix 500 error on /me when set the registrationWhiteList

### DIFF
--- a/lib/pages/Me/IndexPage.tsx
+++ b/lib/pages/Me/IndexPage.tsx
@@ -44,7 +44,7 @@ const IndexPage: FC<Props> = (props) => {
                       <ul>
                         {context.security.registrationWhiteList.map((em) => (
                           <li key={em}>
-                            <code>{{ em }}</code>
+                            <code>{em}</code>
                           </li>
                         ))}
                       </ul>


### PR DESCRIPTION
## About

- We cannot open `/me` when set the "Whitelist of email addresses for registration permission"

## Screenshot

- Whitelist settings

<img width="848" alt="スクリーンショット 2020-11-01 9 13 54" src="https://user-images.githubusercontent.com/10488/97792516-963d5600-1c22-11eb-8f38-a63bb45aadfa.png">

### Using `master`

<img width="1797" alt="スクリーンショット 2020-11-01 8 27 39" src="https://user-images.githubusercontent.com/10488/97792506-68f0a800-1c22-11eb-912c-da7f0a733ab9.png">

### Using this branch

<img width="1447" alt="スクリーンショット 2020-11-01 9 18 59" src="https://user-images.githubusercontent.com/10488/97792575-59be2a00-1c23-11eb-89fe-6ad8d1eb407f.png">
