### PR TITLE
Fix unexpected domain deletion in the whitelist settings

### DIFF
--- a/client/components/Admin/App/SecuritySettings.tsx
+++ b/client/components/Admin/App/SecuritySettings.tsx
@@ -19,7 +19,7 @@ const SecuritySettings: FC<Props> = ({ registrationMode: registrationModeOptions
   const [basicName, setBasicName] = useState(settingForm['security:basicName'] || '')
   const [basicSecret, setBasicSecret] = useState(settingForm['security:basicSecret'] || '')
   const [registrationMode, setRegistrationMode] = useState(settingForm['security:registrationMode'] || '')
-  const [registrationWhiteList, setRegistrationWhiteList] = useState(settingForm['security:registrationWhiteList'].join("\n"))
+  const [registrationWhiteList, setRegistrationWhiteList] = useState(settingForm['security:registrationWhiteList'].join(`\n`))
 
   const handleSubmit = (e) => {
     e.preventDefault()

--- a/client/components/Admin/App/SecuritySettings.tsx
+++ b/client/components/Admin/App/SecuritySettings.tsx
@@ -19,7 +19,7 @@ const SecuritySettings: FC<Props> = ({ registrationMode: registrationModeOptions
   const [basicName, setBasicName] = useState(settingForm['security:basicName'] || '')
   const [basicSecret, setBasicSecret] = useState(settingForm['security:basicSecret'] || '')
   const [registrationMode, setRegistrationMode] = useState(settingForm['security:registrationMode'] || '')
-  const [registrationWhiteList, setRegistrationWhiteList] = useState(settingForm['security:registrationWhiteList'])
+  const [registrationWhiteList, setRegistrationWhiteList] = useState(settingForm['security:registrationWhiteList'].join("\n"))
 
   const handleSubmit = (e) => {
     e.preventDefault()


### PR DESCRIPTION
## About

- Fix unexpected domain deletion in the whitelist

## Reproduction

### 1. Save multiple domains 

- Save `@gmail.com` and `@crowi.wiki` domains

<img width="1315" alt="スクリーンショット 2020-11-01 11 59 31" src="https://user-images.githubusercontent.com/10488/97794170-c7755080-1c39-11eb-96c6-54d2ab63186c.png">

- `configs` in the DB also has both domains

```
> db.configs.find({key: "security:registrationWhiteList"}).pretty();
{
	"_id" : ObjectId("5f90ba3a5957db40c9fe42aa"),
	"key" : "security:registrationWhiteList",
	"ns" : "crowi",
	"__v" : 0,
	"value" : "[\"@gmail.com\",\"@crowi.wiki\"]"
}
```

### 2. Reload setting screen

- Both domains are shown, but it's comma-separated values

<img width="1315" alt="スクリーンショット 2020-11-01 11 59 45" src="https://user-images.githubusercontent.com/10488/97794172-d22fe580-1c39-11eb-93a0-debaa6127bab.png">


### 3. Save again

- Save

<img width="1315" alt="スクリーンショット 2020-11-01 11 59 49" src="https://user-images.githubusercontent.com/10488/97794174-da882080-1c39-11eb-8a48-a5ee6181f2dc.png">


### 4. Reload again, 2nd domain was gone

- `@crowi.wiki` was gone away

<img width="1315" alt="スクリーンショット 2020-11-01 11 59 53" src="https://user-images.githubusercontent.com/10488/97794179-e70c7900-1c39-11eb-8912-85ea5d9461a8.png">

- Also, in the DB, `@crowi.wiki` was gone away. Only `@gmail.com` is available.

```
> db.configs.find({key: "security:registrationWhiteList"}).pretty();
{
	"_id" : ObjectId("5f90ba3a5957db40c9fe42aa"),
	"key" : "security:registrationWhiteList",
	"ns" : "crowi",
	"__v" : 0,
	"value" : "[\"@gmail.com\"]"
}
```

## Fixed behavior using this branch

### 1. Save

<img width="1315" alt="スクリーンショット 2020-11-01 12 11 15" src="https://user-images.githubusercontent.com/10488/97794303-60f13200-1c3b-11eb-9738-bc32ced6e7a4.png">

### 2. Reload

<img width="1315" alt="スクリーンショット 2020-11-01 12 11 19" src="https://user-images.githubusercontent.com/10488/97794307-6e0e2100-1c3b-11eb-86b8-7ae39d370517.png">

```
> db.configs.find({key: "security:registrationWhiteList"}).pretty();
{
	"_id" : ObjectId("5f90ba3a5957db40c9fe42aa"),
	"key" : "security:registrationWhiteList",
	"ns" : "crowi",
	"__v" : 0,
	"value" : "[\"@gmail.com\",\"@crowi.wiki\"]"
}
```