### PR TITLE
Fix: page `/admin/app` did not work on newly-installed crowi

### DIFF
--- a/client/components/Admin/App/SecuritySettings.tsx
+++ b/client/components/Admin/App/SecuritySettings.tsx
@@ -19,7 +19,7 @@ const SecuritySettings: FC<Props> = ({ registrationMode: registrationModeOptions
   const [basicName, setBasicName] = useState(settingForm['security:basicName'] || '')
   const [basicSecret, setBasicSecret] = useState(settingForm['security:basicSecret'] || '')
   const [registrationMode, setRegistrationMode] = useState(settingForm['security:registrationMode'] || '')
-  const [registrationWhiteList, setRegistrationWhiteList] = useState(settingForm['security:registrationWhiteList'].join(`\n`))
+  const [registrationWhiteList, setRegistrationWhiteList] = useState((settingForm['security:registrationWhiteList'] || []).join(`\n`))
 
   const handleSubmit = (e) => {
     e.preventDefault()


### PR DESCRIPTION
If some settings value is missing, `/admin/page` will be stopped due to errors.

See an image below:

<img width="697" alt="スクリーンショット 2021-05-02 15 13 33" src="https://user-images.githubusercontent.com/12085646/116804346-fa50c080-ab58-11eb-9914-88d3c138d03d.png">

I tested with latest Firefox, but this error should be caused on other browsers.