### PR TITLE
Fix: changing passwords fails

### DIFF
--- a/lib/controllers/me.ts
+++ b/lib/controllers/me.ts
@@ -161,6 +161,7 @@ export default (crowi: Crowi, app: Express) => {
         i18n: req.i18n,
         context: getAppContext(crowi, req),
         activeItem: 'password',
+        hasPassword: user.isPasswordSet(),
         messages: { ...options.messages, success: req.flash('successMessage') },
       })
 

--- a/lib/pages/Me/PasswordPage.tsx
+++ b/lib/pages/Me/PasswordPage.tsx
@@ -15,7 +15,7 @@ const PasswordPage: FC<Props> = (props) => {
 
   return (
     <Base title={i18n.t('Password Settings')} {...props}>
-      {hasPassword && <div className="alert alert-danger">{i18n.t('Please set a password')}</div>}
+      {!hasPassword && <div className="alert alert-danger">{i18n.t('Please set a password')}</div>}
 
       {user.email && (
         <p>


### PR DESCRIPTION
- An input element for current password is missing on `/me/password` because `prop:hasPassword` is not passed to a component.
  - Due to this, users cannot change own password.
- A message `Please set a password` is unexpectedly shown for users who already has passwords.