### PR TITLE
Fix tab style on `/me/*`

### DIFF
--- a/lib/pages/Me/Base.tsx
+++ b/lib/pages/Me/Base.tsx
@@ -41,8 +41,8 @@ const Base: FC<Props> = (props) => {
             <ul className="nav nav-tabs">
               {navigationItems.map(({ name, icon, link, text }) =>
                 name !== 'password' || !context.auth.disablePasswordAuth ? (
-                  <li key={name} className={classNames('nav-item', activeItem === name ? 'active' : null)}>
-                    <a className="nav-link" href={link}>
+                  <li key={name} className="nav-item">
+                    <a className={classNames('nav-link', activeItem === name ? 'active' : null)} href={link}>
                       <Icon name={icon} /> {i18n.t(text)}
                     </a>
                   </li>


### PR DESCRIPTION
`active` class has been added to incorrect element.

## wrong

<img width="344" alt="スクリーンショット 2021-05-03 17 58 55" src="https://user-images.githubusercontent.com/12085646/116859500-0ad96780-ac3b-11eb-8acc-6b8bbc7b2bc5.png">

## fixed

<img width="341" alt="スクリーンショット 2021-05-03 17 57 41" src="https://user-images.githubusercontent.com/12085646/116859510-0f9e1b80-ac3b-11eb-9fb9-922f1ae91bd6.png">
