### PR TITLE
Add "root" to eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "jsx": true,


### PR DESCRIPTION
## About

- When I used `git worktree`, `npm run lint` was shown "plugins" errors:

```
❯ npm run lint

> crowi@1.8.0-dev lint /Users/suzuki/work/personal/github.com/crowi/crowi
> eslint '**/*.{ts,tsx,js,jsx}'


Oops! Something went wrong! :(

ESLint: 7.3.1

ESLint couldn't determine the plugin "@typescript-eslint" uniquely.

- /Users/suzuki/work/personal/github.com/crowi/crowi/node16/node_modules/@typescript-eslint/eslint-plugin/dist/index.js (loaded in "node16/.eslintrc")
- /Users/suzuki/work/personal/github.com/crowi/crowi/node_modules/@typescript-eslint/eslint-plugin/dist/index.js (loaded in ".eslintrc")

Please remove the "plugins" setting from either config or remove either plugin installation.

If you still can't figure out the problem, please stop by https://eslint.org/chat to chat with the team.
```

- I found the solution to this error
    - https://github.com/eslint/eslint/issues/13385#issuecomment-641252879
> In your case, I guess it's solved if you add root: true into your config file. It stops ESLint loading other config files from ancestor directories than the config file.
- So I want to add this configuration