### PR TITLE
Upgrade Heroku stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "stack": "heroku-18",
+  "stack": "heroku-22",
   "name": "Crowi",
   "description": "The simple & powerful Wiki",
   "keywords": [


### PR DESCRIPTION
## About

- Heroku Stack 18 was deprecated
    - https://help.heroku.com/X5OE6BCA/heroku-18-end-of-life-faq
- So upgrade to the latest Heroku 22

