### PR TITLE
Fix es version to 7.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14150,9 +14150,9 @@
       "dev": true
     },
     "es7": {
-      "version": "npm:@elastic/elasticsearch@7.17.0",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.17.0.tgz",
-      "integrity": "sha512-5QLPCjd0uLmLj1lSuKSThjNpq39f6NmlTy9ROLFwG5gjyTgpwSqufDeYG/Fm43Xs05uF7WcscoO7eguI3HuuYA==",
+      "version": "npm:@elastic/elasticsearch@7.13.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.13.0.tgz",
+      "integrity": "sha512-WgwLWo2p9P2tdqzBGX9fHeG8p5IOTXprXNTECQG2mJ7z9n93N5AFBJpEw4d35tWWeCWi9jI13A2wzQZH7XZ/xw==",
       "requires": {
         "debug": "^4.3.1",
         "hpagent": "^0.1.1",
@@ -14181,9 +14181,9 @@
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "secure-json-parse": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.4.0.tgz",
-          "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg=="
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.5.0.tgz",
+          "integrity": "sha512-ZQruFgZnIWH+WyO9t5rWt4ZEGqCKPwhiw+YbzTwpmT9elgLrLcfuyUiSnwwjUiVy9r4VM3urtbNF1xmEh9IL2w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "emojify.js": "^1.1.0",
     "errorhandler": "^1.5.1",
     "es6": "npm:@elastic/elasticsearch@^6.8.3",
-    "es7": "npm:@elastic/elasticsearch@^7.17.0",
+    "es7": "npm:@elastic/elasticsearch@7.13.0",
     "eventemitter3": "^4.0.0",
     "express": "^4.17.1",
     "express-form": "~0.12.0",


### PR DESCRIPTION
On v1.8, Crowi supports ElasticSearch and its SaaS version (like Bonsai), and Bonsai uses OpenSearch in its backend.
Unfortunately, ElasticSearch and OpenSearch broke its relationship and from ES clietn library v7.14 and above hadn't supported OpenSearch.

We would support both ES itself and OpenSearch in v1.9~.
Currently, support both above with the current code base.