### PR TITLE
Add "max-old-space-size" option to GH Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,10 +50,16 @@ jobs:
       run: npm ci
 
     - name: Type check
+      env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
       run: npm run type-check
+
     - name: Run lint
       run: npm run lint
+
     - name: Build package
+      env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
       run: npm run build
 
     # TODO: coverage


### PR DESCRIPTION
## About

- Add `--max-old-space-size=8192` option to some jobs on GitHub Actions