### PR TITLE
Update Ubuntu from 18.04 to 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   run-tests:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
 
     strategy:


### PR DESCRIPTION
## About

- Upgrade the Ubuntu version of GH Actions runner from 18.04 to 20.04
    - https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/