### PR TITLE
feat(web): add user page with profile, bookmarks, and recent pages

### DIFF
--- a/apps/crowi-api/package.json
+++ b/apps/crowi-api/package.json
@@ -41,6 +41,7 @@
     "async": "~1.5.0",
     "aws-sdk": "~2.88.0",
     "basic-auth-connect": "~1.0.0",
+    "bcryptjs": "^3.0.3",
     "buffer": "^6.0.3",
     "classnames": "^2.2.6",
     "cli": "~1.0.1",
@@ -89,6 +90,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^3.0.0",
     "@types/classnames": "^2.2.9",
     "@types/connect-flash": "^0.0.40",
     "@types/csrf": "^1.3.2",

--- a/apps/crowi-api/src/models/user.ts
+++ b/apps/crowi-api/src/models/user.ts
@@ -3,6 +3,7 @@ import { Types, Document, Model, Schema, model } from 'mongoose';
 import Debug from 'debug';
 import mongoosePaginate from 'mongoose-paginate';
 import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
 import async from 'async';
 import { googleLoginEnabled, githubLoginEnabled, isDisabledPasswordAuth } from 'src/models/config';
 
@@ -162,11 +163,32 @@ export default (crowi: Crowi) => {
     return password;
   }
 
-  function generatePassword(password) {
+  /**
+   * Generate password hash using SHA-256 (legacy algorithm)
+   * This is kept for backward compatibility with existing passwords
+   */
+  function generatePasswordLegacy(password) {
     const hasher = crypto.createHash('sha256');
     hasher.update(crowi.env.PASSWORD_SEED + password);
 
     return hasher.digest('hex');
+  }
+
+  /**
+   * Generate password hash using bcrypt (recommended)
+   * Bcrypt hashes start with $2a$ or $2b$ prefix
+   */
+  function generatePasswordHash(password) {
+    const saltRounds = 10;
+    return bcrypt.hashSync(password, saltRounds);
+  }
+
+  /**
+   * Check if a hash is a bcrypt hash
+   * Bcrypt hashes start with $2a$ or $2b$ prefix
+   */
+  function isBcryptHash(hash: string) {
+    return hash && (hash.startsWith('$2a$') || hash.startsWith('$2b$'));
   }
 
   function generateApiToken(user) {
@@ -195,15 +217,25 @@ export default (crowi: Crowi) => {
   };
 
   userSchema.methods.isPasswordValid = function (password) {
-    const inputHash = generatePassword(password);
+    debug('Password check - stored hash format:', isBcryptHash(this.password) ? 'bcrypt' : 'legacy SHA-256');
+
+    // Check if stored password is a bcrypt hash
+    if (isBcryptHash(this.password)) {
+      return bcrypt.compareSync(password, this.password);
+    }
+
+    // Fall back to legacy SHA-256 verification for backward compatibility
+    const inputHash = generatePasswordLegacy(password);
     debug('Password check - stored:', this.password);
-    debug('Password check - input hash:', inputHash);
+    debug('Password check - input hash (legacy):', inputHash);
     debug('Password check - PASSWORD_SEED exists:', !!crowi.env.PASSWORD_SEED);
     return this.password == inputHash;
   };
 
   userSchema.methods.setPassword = function (password) {
-    this.password = generatePassword(password);
+    // Always use bcrypt for new passwords
+    this.password = generatePasswordHash(password);
+    debug('Password set using bcrypt');
     return this;
   };
 
@@ -491,9 +523,27 @@ export default (crowi: Crowi) => {
     return User.findOne({ email }).exec();
   };
 
-  userSchema.statics.findUserByEmailAndPassword = function (email, password) {
-    const hashedPassword = generatePassword(password);
-    return User.findOne({ email, password: hashedPassword }).exec();
+  userSchema.statics.findUserByEmailAndPassword = async function (email, password) {
+    // First, try to find user by email and legacy SHA-256 hash (for backward compatibility)
+    const hashedPasswordLegacy = generatePasswordLegacy(password);
+    let user = await User.findOne({ email, password: hashedPasswordLegacy }).select('+password').exec();
+
+    if (user) {
+      debug('User found with legacy SHA-256 password');
+      return user;
+    }
+
+    // If not found, find user by email and verify bcrypt password
+    user = await User.findOne({ email }).select('+password').exec();
+    if (user && user.password && isBcryptHash(user.password)) {
+      const isValid = bcrypt.compareSync(password, user.password);
+      if (isValid) {
+        debug('User found with bcrypt password');
+        return user;
+      }
+    }
+
+    return null;
   };
 
   userSchema.statics.isRegisterableUsername = async function (username, callback) {

--- a/apps/crowi-api/src/routes/ts-rest/index.ts
+++ b/apps/crowi-api/src/routes/ts-rest/index.ts
@@ -5,6 +5,7 @@ import installerRoutes from './installer';
 import tokenAuthRoutes from './tokenAuth';
 import meRoutes from './me';
 import pageRoutes from './page';
+import userRoutes from './user';
 import jwtAuth from '../../middlewares/jwtAuth';
 import jwtAdminRequired from '../../middlewares/jwtAdminRequired';
 import Debug from 'debug';
@@ -39,10 +40,12 @@ export default (crowi: Crowi, app: Express) => {
 
   const meRouter = meRoutes(crowi, app);
   const pageRouter = pageRoutes(crowi, app);
+  const userRouter = userRoutes(crowi, app);
 
   debug('Mounting authenticated routes (JWT required)');
   authenticatedRouter.use(meRouter);
   authenticatedRouter.use(pageRouter);
+  authenticatedRouter.use(userRouter);
 
   // Admin Router - JWT authentication + admin permission required
   const adminRouter = Router();

--- a/apps/crowi-api/src/routes/ts-rest/me.ts
+++ b/apps/crowi-api/src/routes/ts-rest/me.ts
@@ -263,18 +263,6 @@ export default (crowi: Crowi, _app: Express) => {
         };
       }
 
-      // Double-check password confirmation (already validated by Zod, but keeping for safety)
-      if (newPassword !== newPasswordConfirm) {
-        return {
-          status: 400 as const,
-          body: {
-            status: 'error' as const,
-            message: 'Passwords do not match',
-            errors: ['Passwords do not match'],
-          },
-        };
-      }
-
       // Get user with password field populated for validation
       const userWithSecrets = await user.populateSecrets();
       const hasPassword = userWithSecrets.isPasswordSet();

--- a/apps/crowi-api/src/routes/ts-rest/user.ts
+++ b/apps/crowi-api/src/routes/ts-rest/user.ts
@@ -1,13 +1,74 @@
 import { createExpressEndpoints, initServer } from '@ts-rest/express';
-import { apiContract } from '@crowi/api-contract';
+import { apiContract, UserPublic, Page, PageUser, Bookmark, Revision } from '@crowi/api-contract';
 import Crowi from 'src/crowi';
 import { Express, Router } from 'express';
 import { UserDocument } from 'src/models/user';
 import { PageDocument } from 'src/models/page';
 import { BookmarkDocument } from 'src/models/bookmark';
+import { Types } from 'mongoose';
 import Debug from 'debug';
 
 const debug = Debug('crowi:routes:ts-rest:user');
+
+/**
+ * Type for populated user fields in Mongoose documents
+ */
+interface PopulatedUser {
+  _id: Types.ObjectId;
+  username: string;
+  name: string;
+  email: string;
+  image?: string | null;
+  createdAt?: Date;
+}
+
+/**
+ * Type for populated revision in Mongoose documents
+ */
+interface PopulatedRevision {
+  _id: Types.ObjectId;
+  path: string;
+  body: string;
+  format?: string;
+  author?: PopulatedUser | null;
+  createdAt?: Date;
+}
+
+/**
+ * Type for page data that may be a Mongoose document or plain object
+ */
+interface PageLike {
+  _id: Types.ObjectId | string;
+  path: string;
+  revision?: PopulatedRevision | Types.ObjectId | null;
+  redirectTo?: string | null;
+  status?: string | null;
+  grant?: number;
+  grantedUsers?: (Types.ObjectId | string)[];
+  creator?: PopulatedUser | Types.ObjectId | null;
+  lastUpdateUser?: PopulatedUser | Types.ObjectId | null;
+  liker?: (Types.ObjectId | string)[];
+  seenUsers?: (Types.ObjectId | string)[];
+  commentCount?: number;
+  extended?: Record<string, unknown>;
+  createdAt?: Date;
+  updatedAt?: Date;
+  latestRevision?: Types.ObjectId | string;
+  likerCount?: number;
+  seenUsersCount?: number;
+  toObject?: () => PageLike;
+}
+
+/**
+ * Type for bookmark data that may be a Mongoose document or plain object
+ */
+interface BookmarkLike {
+  _id: Types.ObjectId | string;
+  page?: PageLike | null;
+  user: PopulatedUser | Types.ObjectId | string;
+  createdAt?: Date;
+  toObject?: () => BookmarkLike;
+}
 
 /**
  * Helper to safely convert date to ISO string
@@ -18,113 +79,107 @@ const toISOStringOrNull = (date: Date | undefined | null): string | null => {
 };
 
 /**
+ * Helper to convert ObjectId or string to string
+ */
+const toStringId = (id: Types.ObjectId | string): string => {
+  return typeof id === 'string' ? id : id.toString();
+};
+
+/**
+ * Convert user data to PageUser response format
+ */
+const toPageUser = (user: PopulatedUser): PageUser => ({
+  _id: user._id.toString(),
+  id: user._id.toString(),
+  username: user.username,
+  name: user.name,
+  email: user.email,
+  image: user.image || null,
+  createdAt: toISOStringOrNull(user.createdAt) || new Date().toISOString(),
+});
+
+/**
  * Convert UserDocument to serializable object for API response
  */
-const userToResponse = (user: UserDocument) => {
-  return {
-    _id: user._id.toString(),
-    id: user._id.toString(),
-    username: user.username,
-    name: user.name,
-    email: user.email,
-    image: user.image || null,
-    introduction: user.introduction || '',
-    createdAt: toISOStringOrNull(user.createdAt) || new Date().toISOString(),
-    admin: user.admin || false,
-    status: user.status,
-  };
+const userToResponse = (user: UserDocument): UserPublic => ({
+  _id: user._id.toString(),
+  id: user._id.toString(),
+  username: user.username,
+  name: user.name,
+  email: user.email,
+  image: user.image || null,
+  introduction: user.introduction || '',
+  createdAt: toISOStringOrNull(user.createdAt) || new Date().toISOString(),
+  admin: user.admin || false,
+  status: user.status,
+});
+
+/**
+ * Check if a value is a populated user object
+ */
+const isPopulatedUser = (value: unknown): value is PopulatedUser => {
+  return typeof value === 'object' && value !== null && '_id' in value && 'username' in value && 'name' in value;
 };
+
+/**
+ * Check if a value is a populated revision object
+ */
+const isPopulatedRevision = (value: unknown): value is PopulatedRevision => {
+  return typeof value === 'object' && value !== null && '_id' in value && 'path' in value && 'body' in value;
+};
+
+/**
+ * Convert revision data to Revision response format
+ */
+const toRevision = (revision: PopulatedRevision): Revision => ({
+  _id: revision._id.toString(),
+  path: revision.path,
+  body: revision.body,
+  format: revision.format || 'markdown',
+  author: revision.author ? toPageUser(revision.author) : null,
+  createdAt: toISOStringOrNull(revision.createdAt) || new Date().toISOString(),
+});
 
 /**
  * Convert PageDocument to serializable object for API response
  */
-const pageToResponse = (page: PageDocument) => {
-  const pageObj = page.toObject() as any;
+const pageToResponse = (page: PageDocument | PageLike): Page => {
+  // Handle both Mongoose documents and plain objects
+  const pageObj: PageLike = typeof (page as PageDocument).toObject === 'function' ? (page as PageDocument).toObject() : (page as PageLike);
 
-  const result: any = {
-    _id: page._id.toString(),
-    path: page.path,
-    revision: pageObj.revision
-      ? {
-          _id: pageObj.revision._id.toString(),
-          path: pageObj.revision.path,
-          body: pageObj.revision.body,
-          format: pageObj.revision.format || 'markdown',
-          author: pageObj.revision.author
-            ? {
-                _id: pageObj.revision.author._id.toString(),
-                id: pageObj.revision.author._id.toString(),
-                username: pageObj.revision.author.username,
-                name: pageObj.revision.author.name,
-                email: pageObj.revision.author.email,
-                image: pageObj.revision.author.image || null,
-                createdAt: toISOStringOrNull(pageObj.revision.author.createdAt),
-              }
-            : null,
-          createdAt: toISOStringOrNull(pageObj.revision.createdAt),
-        }
-      : undefined,
-    redirectTo: page.redirectTo || null,
-    status: page.status || null,
-    grant: page.grant,
-    grantedUsers: page.grantedUsers?.map((id) => id.toString()) || [],
-    creator: pageObj.creator
-      ? {
-          _id: pageObj.creator._id.toString(),
-          id: pageObj.creator._id.toString(),
-          username: pageObj.creator.username,
-          name: pageObj.creator.name,
-          email: pageObj.creator.email,
-          image: pageObj.creator.image || null,
-          createdAt: toISOStringOrNull(pageObj.creator.createdAt),
-        }
-      : null,
-    lastUpdateUser: pageObj.lastUpdateUser
-      ? {
-          _id: pageObj.lastUpdateUser._id.toString(),
-          id: pageObj.lastUpdateUser._id.toString(),
-          username: pageObj.lastUpdateUser.username,
-          name: pageObj.lastUpdateUser.name,
-          email: pageObj.lastUpdateUser.email,
-          image: pageObj.lastUpdateUser.image || null,
-          createdAt: toISOStringOrNull(pageObj.lastUpdateUser.createdAt),
-        }
-      : null,
-    liker: page.liker?.map((id) => id.toString()) || [],
-    seenUsers: page.seenUsers?.map((id) => id.toString()) || [],
-    commentCount: page.commentCount || 0,
-    extended: page.extended,
-    createdAt: toISOStringOrNull(page.createdAt),
-    updatedAt: toISOStringOrNull(page.updatedAt),
-    latestRevision: pageObj.latestRevision?.toString(),
+  return {
+    _id: toStringId(pageObj._id),
+    path: pageObj.path,
+    revision: pageObj.revision && isPopulatedRevision(pageObj.revision) ? toRevision(pageObj.revision) : undefined,
+    redirectTo: pageObj.redirectTo || null,
+    status: (pageObj.status as 'wip' | 'published' | 'deleted' | 'deprecated') || undefined,
+    grant: pageObj.grant,
+    grantedUsers: pageObj.grantedUsers?.map(toStringId) || [],
+    creator: pageObj.creator && isPopulatedUser(pageObj.creator) ? toPageUser(pageObj.creator) : null,
+    lastUpdateUser: pageObj.lastUpdateUser && isPopulatedUser(pageObj.lastUpdateUser) ? toPageUser(pageObj.lastUpdateUser) : null,
+    liker: pageObj.liker?.map(toStringId) || [],
+    seenUsers: pageObj.seenUsers?.map(toStringId) || [],
+    commentCount: pageObj.commentCount || 0,
+    extended: pageObj.extended,
+    createdAt: toISOStringOrNull(pageObj.createdAt) || new Date().toISOString(),
+    updatedAt: toISOStringOrNull(pageObj.updatedAt) || undefined,
+    latestRevision: pageObj.latestRevision ? toStringId(pageObj.latestRevision) : undefined,
     likerCount: pageObj.likerCount,
     seenUsersCount: pageObj.seenUsersCount,
   };
-
-  return result;
 };
 
 /**
  * Convert BookmarkDocument to serializable object for API response
  */
-const bookmarkToResponse = (bookmark: BookmarkDocument) => {
-  const bookmarkObj = bookmark.toObject ? bookmark.toObject() : (bookmark as any);
+const bookmarkToResponse = (bookmark: BookmarkDocument | BookmarkLike): Bookmark => {
+  const bookmarkObj: BookmarkLike =
+    typeof (bookmark as BookmarkDocument).toObject === 'function' ? (bookmark as BookmarkDocument).toObject() : (bookmark as BookmarkLike);
 
   return {
-    _id: bookmarkObj._id.toString(),
-    page: bookmarkObj.page ? pageToResponse(bookmarkObj.page) : null,
-    user:
-      typeof bookmarkObj.user === 'object'
-        ? {
-            _id: bookmarkObj.user._id.toString(),
-            id: bookmarkObj.user._id.toString(),
-            username: bookmarkObj.user.username,
-            name: bookmarkObj.user.name,
-            email: bookmarkObj.user.email,
-            image: bookmarkObj.user.image || null,
-            createdAt: toISOStringOrNull(bookmarkObj.user.createdAt),
-          }
-        : bookmarkObj.user.toString(),
+    _id: toStringId(bookmarkObj._id),
+    page: bookmarkObj.page ? pageToResponse(bookmarkObj.page) : (null as unknown as Page),
+    user: isPopulatedUser(bookmarkObj.user) ? toPageUser(bookmarkObj.user) : toStringId(bookmarkObj.user as Types.ObjectId | string),
     createdAt: toISOStringOrNull(bookmarkObj.createdAt) || new Date().toISOString(),
   };
 };

--- a/apps/crowi-api/src/routes/ts-rest/user.ts
+++ b/apps/crowi-api/src/routes/ts-rest/user.ts
@@ -1,0 +1,432 @@
+import { createExpressEndpoints, initServer } from '@ts-rest/express';
+import { apiContract } from '@crowi/api-contract';
+import Crowi from 'src/crowi';
+import { Express, Router } from 'express';
+import { UserDocument } from 'src/models/user';
+import { PageDocument } from 'src/models/page';
+import { BookmarkDocument } from 'src/models/bookmark';
+import Debug from 'debug';
+
+const debug = Debug('crowi:routes:ts-rest:user');
+
+/**
+ * Helper to safely convert date to ISO string
+ */
+const toISOStringOrNull = (date: Date | undefined | null): string | null => {
+  if (!date) return null;
+  return date instanceof Date ? date.toISOString() : String(date);
+};
+
+/**
+ * Convert UserDocument to serializable object for API response
+ */
+const userToResponse = (user: UserDocument) => {
+  return {
+    _id: user._id.toString(),
+    id: user._id.toString(),
+    username: user.username,
+    name: user.name,
+    email: user.email,
+    image: user.image || null,
+    introduction: user.introduction || '',
+    createdAt: toISOStringOrNull(user.createdAt) || new Date().toISOString(),
+    admin: user.admin || false,
+    status: user.status,
+  };
+};
+
+/**
+ * Convert PageDocument to serializable object for API response
+ */
+const pageToResponse = (page: PageDocument) => {
+  const pageObj = page.toObject() as any;
+
+  const result: any = {
+    _id: page._id.toString(),
+    path: page.path,
+    revision: pageObj.revision
+      ? {
+          _id: pageObj.revision._id.toString(),
+          path: pageObj.revision.path,
+          body: pageObj.revision.body,
+          format: pageObj.revision.format || 'markdown',
+          author: pageObj.revision.author
+            ? {
+                _id: pageObj.revision.author._id.toString(),
+                id: pageObj.revision.author._id.toString(),
+                username: pageObj.revision.author.username,
+                name: pageObj.revision.author.name,
+                email: pageObj.revision.author.email,
+                image: pageObj.revision.author.image || null,
+                createdAt: toISOStringOrNull(pageObj.revision.author.createdAt),
+              }
+            : null,
+          createdAt: toISOStringOrNull(pageObj.revision.createdAt),
+        }
+      : undefined,
+    redirectTo: page.redirectTo || null,
+    status: page.status || null,
+    grant: page.grant,
+    grantedUsers: page.grantedUsers?.map((id) => id.toString()) || [],
+    creator: pageObj.creator
+      ? {
+          _id: pageObj.creator._id.toString(),
+          id: pageObj.creator._id.toString(),
+          username: pageObj.creator.username,
+          name: pageObj.creator.name,
+          email: pageObj.creator.email,
+          image: pageObj.creator.image || null,
+          createdAt: toISOStringOrNull(pageObj.creator.createdAt),
+        }
+      : null,
+    lastUpdateUser: pageObj.lastUpdateUser
+      ? {
+          _id: pageObj.lastUpdateUser._id.toString(),
+          id: pageObj.lastUpdateUser._id.toString(),
+          username: pageObj.lastUpdateUser.username,
+          name: pageObj.lastUpdateUser.name,
+          email: pageObj.lastUpdateUser.email,
+          image: pageObj.lastUpdateUser.image || null,
+          createdAt: toISOStringOrNull(pageObj.lastUpdateUser.createdAt),
+        }
+      : null,
+    liker: page.liker?.map((id) => id.toString()) || [],
+    seenUsers: page.seenUsers?.map((id) => id.toString()) || [],
+    commentCount: page.commentCount || 0,
+    extended: page.extended,
+    createdAt: toISOStringOrNull(page.createdAt),
+    updatedAt: toISOStringOrNull(page.updatedAt),
+    latestRevision: pageObj.latestRevision?.toString(),
+    likerCount: pageObj.likerCount,
+    seenUsersCount: pageObj.seenUsersCount,
+  };
+
+  return result;
+};
+
+/**
+ * Convert BookmarkDocument to serializable object for API response
+ */
+const bookmarkToResponse = (bookmark: BookmarkDocument) => {
+  const bookmarkObj = bookmark.toObject ? bookmark.toObject() : (bookmark as any);
+
+  return {
+    _id: bookmarkObj._id.toString(),
+    page: bookmarkObj.page ? pageToResponse(bookmarkObj.page) : null,
+    user:
+      typeof bookmarkObj.user === 'object'
+        ? {
+            _id: bookmarkObj.user._id.toString(),
+            id: bookmarkObj.user._id.toString(),
+            username: bookmarkObj.user.username,
+            name: bookmarkObj.user.name,
+            email: bookmarkObj.user.email,
+            image: bookmarkObj.user.image || null,
+            createdAt: toISOStringOrNull(bookmarkObj.user.createdAt),
+          }
+        : bookmarkObj.user.toString(),
+    createdAt: toISOStringOrNull(bookmarkObj.createdAt) || new Date().toISOString(),
+  };
+};
+
+export default (crowi: Crowi, _app: Express) => {
+  const s = initServer();
+  const router = Router();
+  const User = crowi.model('User');
+  const Page = crowi.model('Page');
+  const Bookmark = crowi.model('Bookmark');
+
+  const userRouter = s.router(apiContract.user, {
+    /**
+     * GET /api/v2/user/:username
+     * Get user page information
+     * - Returns user profile with statistics
+     * - Includes recent pages (10) and bookmarks (10) for initial display
+     */
+    getUserPage: async ({ params, req }) => {
+      const currentUser = (req as any).user as UserDocument | null;
+      const { username } = params;
+
+      debug('getUserPage called with:', { username, currentUserId: currentUser?._id });
+
+      try {
+        // Find the target user by username
+        const targetUser = await User.findUserByUsername(username);
+
+        if (!targetUser) {
+          return {
+            status: 404 as const,
+            body: {
+              error: {
+                code: 'USER_NOT_FOUND' as const,
+                message: 'User not found' as const,
+              },
+            },
+          };
+        }
+
+        // Check if user is active
+        if (targetUser.status !== User.STATUS_ACTIVE) {
+          return {
+            status: 404 as const,
+            body: {
+              error: {
+                code: 'USER_NOT_FOUND' as const,
+                message: 'User not found' as const,
+              },
+            },
+          };
+        }
+
+        // Get page count for the user
+        // Use the same conditions as findListByCreator
+        const pageCountConditions: any = {
+          creator: targetUser._id,
+          redirectTo: null,
+          $or: [{ status: null }, { status: 'published' }],
+        };
+        // If not viewing own page and not logged in, only show public pages
+        if (!currentUser || !currentUser._id.equals(targetUser._id)) {
+          pageCountConditions.grant = Page.GRANT_PUBLIC;
+        }
+        const createdPagesCount = await Page.countDocuments(pageCountConditions);
+
+        // Get bookmark count for the user
+        const bookmarksCount = await Bookmark.countDocuments({ user: targetUser._id });
+
+        // Get recent pages (10 items)
+        const recentPagesRaw = await Page.findListByCreator(targetUser, { limit: 10, offset: 0 }, currentUser || targetUser);
+        const recentPages = (await Page.populate(recentPagesRaw, [{ path: 'creator' }, { path: 'lastUpdateUser' }])) as unknown as PageDocument[];
+
+        // Get recent bookmarks (10 items)
+        const bookmarkResult = await Bookmark.findByUserId(targetUser._id, { limit: 10, offset: 0 });
+        const recentBookmarks = bookmarkResult.data as BookmarkDocument[];
+
+        return {
+          status: 200 as const,
+          body: {
+            user: userToResponse(targetUser),
+            createdPagesCount,
+            bookmarksCount,
+            recentPages: recentPages.map((page) => pageToResponse(page)),
+            recentBookmarks: recentBookmarks
+              .filter((bookmark) => bookmark.page) // Filter out bookmarks with null pages
+              .map((bookmark) => bookmarkToResponse(bookmark)),
+          },
+        };
+      } catch (err) {
+        const error = err as Error;
+        debug('Error fetching user page:', error.message);
+
+        return {
+          status: 404 as const,
+          body: {
+            error: {
+              code: 'USER_NOT_FOUND' as const,
+              message: 'User not found' as const,
+            },
+          },
+        };
+      }
+    },
+
+    /**
+     * GET /api/v2/user/:username/bookmarks
+     * Get user bookmarks with pagination
+     * - Returns paginated list of bookmarks for a user
+     * - Only returns bookmarks for pages the current user can access
+     */
+    getUserBookmarks: async ({ params, query, req }) => {
+      const currentUser = (req as any).user as UserDocument | undefined;
+      const { username } = params;
+      const { limit = 50, offset = 0 } = query;
+
+      debug('getUserBookmarks called with:', { username, limit, offset, currentUserId: currentUser?._id });
+
+      // Authentication check - this endpoint requires login
+      if (!currentUser) {
+        return {
+          status: 401 as const,
+          body: {
+            error: {
+              code: 'AUTHENTICATION_REQUIRED' as const,
+              message: 'Authentication is required' as const,
+            },
+          },
+        };
+      }
+
+      try {
+        // Find the target user by username
+        const targetUser = await User.findUserByUsername(username);
+
+        if (!targetUser) {
+          return {
+            status: 404 as const,
+            body: {
+              error: {
+                code: 'USER_NOT_FOUND' as const,
+                message: 'User not found' as const,
+              },
+            },
+          };
+        }
+
+        // Check if user is active
+        if (targetUser.status !== User.STATUS_ACTIVE) {
+          return {
+            status: 404 as const,
+            body: {
+              error: {
+                code: 'USER_NOT_FOUND' as const,
+                message: 'User not found' as const,
+              },
+            },
+          };
+        }
+
+        // Get bookmarks with pagination
+        const bookmarkResult = await Bookmark.findByUserId(targetUser._id, { limit, offset });
+        const bookmarks = bookmarkResult.data as BookmarkDocument[];
+        const total = bookmarkResult.meta.total;
+
+        // Calculate pagination
+        const prev = offset > 0 ? Math.max(0, offset - limit) : null;
+        const next = offset + limit < total ? offset + limit : null;
+
+        return {
+          status: 200 as const,
+          body: {
+            bookmarks: bookmarks.filter((bookmark) => bookmark.page).map((bookmark) => bookmarkToResponse(bookmark)),
+            pager: {
+              prev,
+              next,
+              offset,
+            },
+            total,
+          },
+        };
+      } catch (err) {
+        const error = err as Error;
+        debug('Error fetching user bookmarks:', error.message);
+
+        return {
+          status: 404 as const,
+          body: {
+            error: {
+              code: 'USER_NOT_FOUND' as const,
+              message: 'User not found' as const,
+            },
+          },
+        };
+      }
+    },
+
+    /**
+     * GET /api/v2/user/:username/pages
+     * Get user created pages with pagination
+     * - Returns paginated list of pages created by the user
+     * - Only returns pages the current user can access
+     */
+    getUserPages: async ({ params, query, req }) => {
+      const currentUser = (req as any).user as UserDocument | undefined;
+      const { username } = params;
+      const { limit = 50, offset = 0 } = query;
+
+      debug('getUserPages called with:', { username, limit, offset, currentUserId: currentUser?._id });
+
+      // Authentication check - this endpoint requires login
+      if (!currentUser) {
+        return {
+          status: 401 as const,
+          body: {
+            error: {
+              code: 'AUTHENTICATION_REQUIRED' as const,
+              message: 'Authentication is required' as const,
+            },
+          },
+        };
+      }
+
+      try {
+        // Find the target user by username
+        const targetUser = await User.findUserByUsername(username);
+
+        if (!targetUser) {
+          return {
+            status: 404 as const,
+            body: {
+              error: {
+                code: 'USER_NOT_FOUND' as const,
+                message: 'User not found' as const,
+              },
+            },
+          };
+        }
+
+        // Check if user is active
+        if (targetUser.status !== User.STATUS_ACTIVE) {
+          return {
+            status: 404 as const,
+            body: {
+              error: {
+                code: 'USER_NOT_FOUND' as const,
+                message: 'User not found' as const,
+              },
+            },
+          };
+        }
+
+        // Get pages created by the user with pagination
+        const rawPages = await Page.findListByCreator(targetUser, { limit, offset }, currentUser);
+        const pages = (await Page.populate(rawPages, [{ path: 'creator' }, { path: 'lastUpdateUser' }])) as unknown as PageDocument[];
+
+        // Get total count for pagination
+        const pageCountConditions: any = {
+          creator: targetUser._id,
+          redirectTo: null,
+          $or: [{ status: null }, { status: 'published' }],
+        };
+        // If not viewing own page, only show public pages
+        if (!currentUser._id.equals(targetUser._id)) {
+          pageCountConditions.grant = Page.GRANT_PUBLIC;
+        }
+        const total = await Page.countDocuments(pageCountConditions);
+
+        // Calculate pagination
+        const prev = offset > 0 ? Math.max(0, offset - limit) : null;
+        const next = offset + limit < total ? offset + limit : null;
+
+        return {
+          status: 200 as const,
+          body: {
+            pages: pages.map((page) => pageToResponse(page)),
+            pager: {
+              prev,
+              next,
+              offset,
+            },
+            total,
+          },
+        };
+      } catch (err) {
+        const error = err as Error;
+        debug('Error fetching user pages:', error.message);
+
+        return {
+          status: 404 as const,
+          body: {
+            error: {
+              code: 'USER_NOT_FOUND' as const,
+              message: 'User not found' as const,
+            },
+          },
+        };
+      }
+    },
+  });
+
+  createExpressEndpoints(apiContract.user, userRouter, router);
+
+  return router;
+};

--- a/apps/crowi-api/src/routes/ts-rest/user.ts
+++ b/apps/crowi-api/src/routes/ts-rest/user.ts
@@ -199,10 +199,23 @@ export default (crowi: Crowi, _app: Express) => {
      * - Includes recent pages (10) and bookmarks (10) for initial display
      */
     getUserPage: async ({ params, req }) => {
-      const currentUser = (req as any).user as UserDocument | null;
+      const currentUser = (req as any).user as UserDocument | undefined;
       const { username } = params;
 
       debug('getUserPage called with:', { username, currentUserId: currentUser?._id });
+
+      // Authentication check - this endpoint requires login
+      if (!currentUser) {
+        return {
+          status: 401 as const,
+          body: {
+            error: {
+              code: 'AUTHENTICATION_REQUIRED' as const,
+              message: 'Authentication is required' as const,
+            },
+          },
+        };
+      }
 
       try {
         // Find the target user by username
@@ -240,8 +253,8 @@ export default (crowi: Crowi, _app: Express) => {
           redirectTo: null,
           $or: [{ status: null }, { status: 'published' }],
         };
-        // If not viewing own page and not logged in, only show public pages
-        if (!currentUser || !currentUser._id.equals(targetUser._id)) {
+        // If not viewing own page, only show public pages
+        if (!currentUser._id.equals(targetUser._id)) {
           pageCountConditions.grant = Page.GRANT_PUBLIC;
         }
         const createdPagesCount = await Page.countDocuments(pageCountConditions);
@@ -250,7 +263,7 @@ export default (crowi: Crowi, _app: Express) => {
         const bookmarksCount = await Bookmark.countDocuments({ user: targetUser._id });
 
         // Get recent pages (10 items)
-        const recentPagesRaw = await Page.findListByCreator(targetUser, { limit: 10, offset: 0 }, currentUser || targetUser);
+        const recentPagesRaw = await Page.findListByCreator(targetUser, { limit: 10, offset: 0 }, currentUser);
         const recentPages = (await Page.populate(recentPagesRaw, [{ path: 'creator' }, { path: 'lastUpdateUser' }])) as unknown as PageDocument[];
 
         // Get recent bookmarks (10 items)
@@ -271,14 +284,14 @@ export default (crowi: Crowi, _app: Express) => {
         };
       } catch (err) {
         const error = err as Error;
-        debug('Error fetching user page:', error.message);
+        debug('Error fetching user page:', error.message, error.stack);
 
         return {
-          status: 404 as const,
+          status: 500 as const,
           body: {
             error: {
-              code: 'USER_NOT_FOUND' as const,
-              message: 'User not found' as const,
+              code: 'INTERNAL_ERROR' as const,
+              message: 'Internal server error' as const,
             },
           },
         };
@@ -363,14 +376,14 @@ export default (crowi: Crowi, _app: Express) => {
         };
       } catch (err) {
         const error = err as Error;
-        debug('Error fetching user bookmarks:', error.message);
+        debug('Error fetching user bookmarks:', error.message, error.stack);
 
         return {
-          status: 404 as const,
+          status: 500 as const,
           body: {
             error: {
-              code: 'USER_NOT_FOUND' as const,
-              message: 'User not found' as const,
+              code: 'INTERNAL_ERROR' as const,
+              message: 'Internal server error' as const,
             },
           },
         };
@@ -466,14 +479,14 @@ export default (crowi: Crowi, _app: Express) => {
         };
       } catch (err) {
         const error = err as Error;
-        debug('Error fetching user pages:', error.message);
+        debug('Error fetching user pages:', error.message, error.stack);
 
         return {
-          status: 404 as const,
+          status: 500 as const,
           body: {
             error: {
-              code: 'USER_NOT_FOUND' as const,
-              message: 'User not found' as const,
+              code: 'INTERNAL_ERROR' as const,
+              message: 'Internal server error' as const,
             },
           },
         };

--- a/apps/crowi-web/package.json
+++ b/apps/crowi-web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@crowi/api-contract": "workspace:*",
     "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",

--- a/apps/crowi-web/src/app/(auth)/layout.tsx
+++ b/apps/crowi-web/src/app/(auth)/layout.tsx
@@ -3,8 +3,16 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { LogOut, Settings } from 'lucide-react';
+import { LogOut, Settings, User, Bookmark, FileText, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useAuth } from '@/lib/use-auth';
 
 export default function AuthLayout({
@@ -45,26 +53,68 @@ export default function AuthLayout({
             </Link>
           </div>
           <div className="flex items-center gap-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              asChild
-              className="text-white hover:bg-white/10"
-            >
-              <Link href="/settings">
-                <Settings className="h-4 w-4 mr-2" />
-                Settings
-              </Link>
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={logout}
-              className="text-white hover:bg-white/10"
-            >
-              <LogOut className="h-4 w-4 mr-2" />
-              Logout
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-white hover:bg-white/10 flex items-center gap-2"
+                >
+                  <Avatar className="h-6 w-6">
+                    {user?.image ? (
+                      <AvatarImage src={user.image} alt={user.name || user.username} />
+                    ) : null}
+                    <AvatarFallback className="bg-[var(--crowi-primary)] text-white text-xs">
+                      {(user?.name || user?.username || '?').charAt(0).toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className="hidden sm:inline">{user?.name || user?.username}</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                <div className="px-2 py-1.5 text-sm">
+                  <div className="font-medium">{user?.name}</div>
+                  <div className="text-muted-foreground">@{user?.username}</div>
+                </div>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild>
+                  <Link href={`/user/${user?.username}`}>
+                    <User className="h-4 w-4 mr-2" />
+                    マイページ
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link href={`/user/${user?.username}/bookmarks`}>
+                    <Bookmark className="h-4 w-4 mr-2" />
+                    ブックマーク
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link href={`/user/${user?.username}/recent-create`}>
+                    <FileText className="h-4 w-4 mr-2" />
+                    作成したページ
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild>
+                  <Link href="/trash">
+                    <Trash2 className="h-4 w-4 mr-2" />
+                    ゴミ箱
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild>
+                  <Link href="/settings">
+                    <Settings className="h-4 w-4 mr-2" />
+                    設定
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={logout} className="text-red-600">
+                  <LogOut className="h-4 w-4 mr-2" />
+                  ログアウト
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
       </header>

--- a/apps/crowi-web/src/app/(auth)/layout.tsx
+++ b/apps/crowi-web/src/app/(auth)/layout.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { LogOut, Settings, User, Bookmark, FileText, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import { UserAvatar } from '@/components/user-avatar';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -60,14 +60,7 @@ export default function AuthLayout({
                   size="sm"
                   className="text-white hover:bg-white/10 flex items-center gap-2"
                 >
-                  <Avatar className="h-6 w-6">
-                    {user?.image ? (
-                      <AvatarImage src={user.image} alt={user.name || user.username} />
-                    ) : null}
-                    <AvatarFallback className="!bg-[#43676b] !text-white text-xs font-semibold">
-                      {(user?.name || user?.username || '?').charAt(0).toUpperCase()}
-                    </AvatarFallback>
-                  </Avatar>
+                  {user && <UserAvatar user={user} size="sm" />}
                   <span className="hidden sm:inline !text-white">{user?.name || user?.username}</span>
                 </Button>
               </DropdownMenuTrigger>

--- a/apps/crowi-web/src/app/(auth)/layout.tsx
+++ b/apps/crowi-web/src/app/(auth)/layout.tsx
@@ -64,11 +64,11 @@ export default function AuthLayout({
                     {user?.image ? (
                       <AvatarImage src={user.image} alt={user.name || user.username} />
                     ) : null}
-                    <AvatarFallback className="bg-[var(--crowi-primary)] text-white text-xs">
+                    <AvatarFallback className="!bg-[#43676b] !text-white text-xs font-semibold">
                       {(user?.name || user?.username || '?').charAt(0).toUpperCase()}
                     </AvatarFallback>
                   </Avatar>
-                  <span className="hidden sm:inline">{user?.name || user?.username}</span>
+                  <span className="hidden sm:inline !text-white">{user?.name || user?.username}</span>
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-56">

--- a/apps/crowi-web/src/app/(auth)/settings/password-form.tsx
+++ b/apps/crowi-web/src/app/(auth)/settings/password-form.tsx
@@ -18,29 +18,59 @@ interface PasswordRequirement {
   met: boolean;
 }
 
+// Password requirements configuration
+const PASSWORD_REQUIREMENTS = {
+  minLength: 8,
+  maxLength: 100,
+  letterRegex: /[a-zA-Z]/,
+  digitRegex: /\d/,
+  symbolRegex: /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?`~]/,
+} as const;
+
+// Validate password against all requirements
+const validatePasswordRequirements = (password: string) => {
+  return {
+    hasMinLength: password.length >= PASSWORD_REQUIREMENTS.minLength,
+    hasMaxLength: password.length <= PASSWORD_REQUIREMENTS.maxLength,
+    hasLetter: PASSWORD_REQUIREMENTS.letterRegex.test(password),
+    hasDigit: PASSWORD_REQUIREMENTS.digitRegex.test(password),
+    hasSymbol: PASSWORD_REQUIREMENTS.symbolRegex.test(password),
+  };
+};
+
+// Check if password meets all requirements
+const isPasswordMeetingRequirements = (password: string) => {
+  if (!password) return false;
+  const checks = validatePasswordRequirements(password);
+  return Object.values(checks).every(Boolean);
+};
+
 function PasswordRequirements({ password }: { password: string }) {
-  const requirements: PasswordRequirement[] = useMemo(() => [
-    {
-      label: '8文字以上',
-      met: password.length >= 8,
-    },
-    {
-      label: '100文字以下',
-      met: password.length <= 100,
-    },
-    {
-      label: '英字を含む',
-      met: /[a-zA-Z]/.test(password),
-    },
-    {
-      label: '数字を含む',
-      met: /\d/.test(password),
-    },
-    {
-      label: '記号を含む',
-      met: /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?`~]/.test(password),
-    },
-  ], [password]);
+  const requirements: PasswordRequirement[] = useMemo(() => {
+    const checks = validatePasswordRequirements(password);
+    return [
+      {
+        label: '8文字以上',
+        met: checks.hasMinLength,
+      },
+      {
+        label: '100文字以下',
+        met: checks.hasMaxLength,
+      },
+      {
+        label: '英字を含む',
+        met: checks.hasLetter,
+      },
+      {
+        label: '数字を含む',
+        met: checks.hasDigit,
+      },
+      {
+        label: '記号を含む',
+        met: checks.hasSymbol,
+      },
+    ];
+  }, [password]);
 
   if (!password) {
     return null;
@@ -103,19 +133,20 @@ export function PasswordForm({ profile }: PasswordFormProps) {
     if (!formData.newPassword) {
       validationErrors.push('新しいパスワードを入力してください');
     } else {
-      if (formData.newPassword.length < 8) {
+      const checks = validatePasswordRequirements(formData.newPassword);
+      if (!checks.hasMinLength) {
         validationErrors.push('パスワードは8文字以上にしてください');
       }
-      if (formData.newPassword.length > 100) {
+      if (!checks.hasMaxLength) {
         validationErrors.push('パスワードは100文字以下にしてください');
       }
-      if (!/[a-zA-Z]/.test(formData.newPassword)) {
+      if (!checks.hasLetter) {
         validationErrors.push('パスワードには英字を含めてください');
       }
-      if (!/\d/.test(formData.newPassword)) {
+      if (!checks.hasDigit) {
         validationErrors.push('パスワードには数字を含めてください');
       }
-      if (!/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?`~]/.test(formData.newPassword)) {
+      if (!checks.hasSymbol) {
         validationErrors.push('パスワードには記号を含めてください');
       }
     }
@@ -164,11 +195,7 @@ export function PasswordForm({ profile }: PasswordFormProps) {
     if (profile.hasPassword && !formData.oldPassword) return false;
     if (!formData.newPassword || !formData.newPasswordConfirm) return false;
     if (formData.newPassword !== formData.newPasswordConfirm) return false;
-    if (formData.newPassword.length < 8 || formData.newPassword.length > 100) return false;
-    if (!/[a-zA-Z]/.test(formData.newPassword)) return false;
-    if (!/\d/.test(formData.newPassword)) return false;
-    if (!/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?`~]/.test(formData.newPassword)) return false;
-    return true;
+    return isPasswordMeetingRequirements(formData.newPassword);
   }, [formData, profile.hasPassword]);
 
   return (

--- a/apps/crowi-web/src/app/(auth)/user/[username]/bookmarks/page.tsx
+++ b/apps/crowi-web/src/app/(auth)/user/[username]/bookmarks/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { use } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Bookmark } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { UserBookmarks } from '@/components/user-page';
+
+interface BookmarksPageProps {
+  params: Promise<{
+    username: string;
+  }>;
+}
+
+export default function BookmarksPage({ params }: BookmarksPageProps) {
+  const { username } = use(params);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href={`/user/${username}`}>
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to profile
+          </Link>
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <Bookmark className="h-6 w-6 text-primary" />
+        <h1 className="text-2xl font-bold">
+          Bookmarks by @{username}
+        </h1>
+      </div>
+
+      {/* Bookmarks List (full mode) */}
+      <UserBookmarks username={username} />
+    </div>
+  );
+}

--- a/apps/crowi-web/src/app/(auth)/user/[username]/page.tsx
+++ b/apps/crowi-web/src/app/(auth)/user/[username]/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { use } from 'react';
+import { notFound } from 'next/navigation';
+import { Loader2, AlertCircle } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { UserProfile, UserRecentPages, UserBookmarks } from '@/components/user-page';
+import { useUserPage } from '@/lib/use-user-page';
+
+interface UserPageProps {
+  params: Promise<{
+    username: string;
+  }>;
+}
+
+export default function UserPage({ params }: UserPageProps) {
+  const { username } = use(params);
+  const { data, isLoading, error } = useUserPage(username);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <span className="ml-2 text-muted-foreground">Loading user profile...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    if (error.message === 'User not found') {
+      notFound();
+    }
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription>
+          Failed to load user profile. Please try again later.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Profile Card */}
+      <UserProfile
+        user={data.user}
+        createdPagesCount={data.createdPagesCount}
+        bookmarksCount={data.bookmarksCount}
+      />
+
+      {/* Content Tabs */}
+      <Tabs defaultValue="pages" className="w-full">
+        <TabsList className="w-full justify-start">
+          <TabsTrigger value="pages">Created Pages</TabsTrigger>
+          <TabsTrigger value="bookmarks">Bookmarks</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="pages" className="mt-4">
+          <UserRecentPages username={username} preview previewLimit={10} />
+        </TabsContent>
+
+        <TabsContent value="bookmarks" className="mt-4">
+          <UserBookmarks username={username} preview previewLimit={10} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/crowi-web/src/app/(auth)/user/[username]/recent-create/page.tsx
+++ b/apps/crowi-web/src/app/(auth)/user/[username]/recent-create/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { use } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, FileText } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { UserRecentPages } from '@/components/user-page';
+
+interface RecentCreatePageProps {
+  params: Promise<{
+    username: string;
+  }>;
+}
+
+export default function RecentCreatePage({ params }: RecentCreatePageProps) {
+  const { username } = use(params);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href={`/user/${username}`}>
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to profile
+          </Link>
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <FileText className="h-6 w-6 text-primary" />
+        <h1 className="text-2xl font-bold">
+          Pages by @{username}
+        </h1>
+      </div>
+
+      {/* Pages List (full mode) */}
+      <UserRecentPages username={username} />
+    </div>
+  );
+}

--- a/apps/crowi-web/src/components/ui/dialog.tsx
+++ b/apps/crowi-web/src/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { XIcon } from "lucide-react"
-import { Dialog as DialogPrimitive } from "radix-ui"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"

--- a/apps/crowi-web/src/components/ui/dropdown-menu.tsx
+++ b/apps/crowi-web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/apps/crowi-web/src/components/ui/dropdown-menu.tsx
+++ b/apps/crowi-web/src/components/ui/dropdown-menu.tsx
@@ -74,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/apps/crowi-web/src/components/user-avatar.tsx
+++ b/apps/crowi-web/src/components/user-avatar.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { cn } from '@/lib/utils';
+
+interface UserAvatarProps {
+  user: {
+    name?: string;
+    username: string;
+    image?: string | null;
+  };
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+const sizeClasses = {
+  sm: 'h-6 w-6',
+  md: 'h-8 w-8',
+  lg: 'h-20 w-20',
+} as const;
+
+const textSizeClasses = {
+  sm: 'text-xs',
+  md: 'text-sm',
+  lg: 'text-2xl',
+} as const;
+
+export function UserAvatar({ user, size = 'md', className }: UserAvatarProps) {
+  const displayName = user.name || user.username;
+  const initials = displayName.charAt(0).toUpperCase();
+
+  return (
+    <Avatar className={cn(sizeClasses[size], className)}>
+      {user.image ? <AvatarImage src={user.image} alt={displayName} /> : null}
+      <AvatarFallback className={cn('!bg-[#43676b] !text-white font-semibold', textSizeClasses[size])}>
+        {initials}
+      </AvatarFallback>
+    </Avatar>
+  );
+}

--- a/apps/crowi-web/src/components/user-page/index.ts
+++ b/apps/crowi-web/src/components/user-page/index.ts
@@ -1,0 +1,3 @@
+export { UserProfile } from './user-profile';
+export { UserBookmarks } from './user-bookmarks';
+export { UserRecentPages } from './user-recent-pages';

--- a/apps/crowi-web/src/components/user-page/user-bookmarks.tsx
+++ b/apps/crowi-web/src/components/user-page/user-bookmarks.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import Link from 'next/link';
+import { Loader2, AlertCircle, Bookmark } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { PageListItem } from '@/components/page-list/page-list-item';
+import { useUserBookmarksInfinite } from '@/lib/use-user-page';
+import type { Bookmark as BookmarkType } from '@crowi/api-contract';
+
+interface UserBookmarksProps {
+  username: string;
+  /**
+   * If true, shows only a preview (limited items with "View all" link)
+   */
+  preview?: boolean;
+  /**
+   * Number of items to show in preview mode
+   */
+  previewLimit?: number;
+}
+
+export function UserBookmarks({ username, preview = false, previewLimit = 5 }: UserBookmarksProps) {
+  const {
+    data,
+    isLoading,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useUserBookmarksInfinite(username, preview ? previewLimit : 10);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
+        <span className="ml-2 text-muted-foreground">Loading bookmarks...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription>
+          Failed to load bookmarks. Please try again later.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  // Flatten all pages of bookmarks
+  const allBookmarks: BookmarkType[] = data?.pages.flatMap((page) => page.bookmarks) ?? [];
+  const total = data?.pages[0]?.total ?? 0;
+
+  if (allBookmarks.length === 0) {
+    return (
+      <Card className="p-8 text-center">
+        <Bookmark className="h-12 w-12 mx-auto text-muted-foreground/50 mb-3" />
+        <p className="text-muted-foreground">No bookmarks yet.</p>
+      </Card>
+    );
+  }
+
+  // In preview mode, show limited items
+  const displayBookmarks = preview ? allBookmarks.slice(0, previewLimit) : allBookmarks;
+
+  return (
+    <div className="space-y-4">
+      <Card className="divide-y">
+        {displayBookmarks.map((bookmark) => (
+          <PageListItem key={bookmark._id} page={bookmark.page} />
+        ))}
+      </Card>
+
+      {/* Preview mode: "View all" link */}
+      {preview && total > previewLimit && (
+        <div className="text-center">
+          <Button variant="outline" asChild>
+            <Link href={`/user/${username}/bookmarks`}>
+              View all {total} bookmarks
+            </Link>
+          </Button>
+        </div>
+      )}
+
+      {/* Full mode: "Load more" button */}
+      {!preview && hasNextPage && (
+        <div className="text-center">
+          <Button
+            variant="outline"
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+          >
+            {isFetchingNextPage ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                Loading...
+              </>
+            ) : (
+              'Load more'
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/crowi-web/src/components/user-page/user-profile.tsx
+++ b/apps/crowi-web/src/components/user-page/user-profile.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { FileText, Bookmark } from 'lucide-react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Card, CardContent } from '@/components/ui/card';
+import type { UserPublic } from '@crowi/api-contract';
+
+interface UserProfileProps {
+  user: UserPublic;
+  createdPagesCount: number;
+  bookmarksCount: number;
+}
+
+export function UserProfile({ user, createdPagesCount, bookmarksCount }: UserProfileProps) {
+  const displayName = user.name || user.username;
+  const initials = displayName.charAt(0).toUpperCase();
+
+  return (
+    <Card className="py-4">
+      <CardContent>
+        <div className="flex items-start gap-6">
+          {/* Avatar */}
+          <Avatar className="h-20 w-20 flex-shrink-0">
+            <AvatarImage src={user.image || undefined} alt={displayName} />
+            <AvatarFallback className="bg-[var(--crowi-primary)] text-white text-2xl">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+
+          {/* User Info */}
+          <div className="flex-1 min-w-0">
+            {/* Name and Username */}
+            <h1 className="text-2xl font-bold text-foreground truncate">
+              {displayName}
+            </h1>
+            <p className="text-muted-foreground">
+              @{user.username}
+            </p>
+
+            {/* Introduction */}
+            {user.introduction && (
+              <p className="mt-3 text-foreground whitespace-pre-wrap">
+                {user.introduction}
+              </p>
+            )}
+
+            {/* Statistics */}
+            <div className="flex items-center gap-6 mt-4 text-sm text-muted-foreground">
+              <div className="flex items-center gap-1.5">
+                <FileText className="h-4 w-4" />
+                <span>
+                  <span className="font-semibold text-foreground">{createdPagesCount}</span>
+                  {' pages'}
+                </span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <Bookmark className="h-4 w-4" />
+                <span>
+                  <span className="font-semibold text-foreground">{bookmarksCount}</span>
+                  {' bookmarks'}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/crowi-web/src/components/user-page/user-profile.tsx
+++ b/apps/crowi-web/src/components/user-page/user-profile.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { FileText, Bookmark } from 'lucide-react';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Card, CardContent } from '@/components/ui/card';
+import { UserAvatar } from '@/components/user-avatar';
 import type { UserPublic } from '@crowi/api-contract';
 
 interface UserProfileProps {
@@ -13,19 +13,13 @@ interface UserProfileProps {
 
 export function UserProfile({ user, createdPagesCount, bookmarksCount }: UserProfileProps) {
   const displayName = user.name || user.username;
-  const initials = displayName.charAt(0).toUpperCase();
 
   return (
     <Card className="py-4">
       <CardContent>
         <div className="flex items-start gap-6">
           {/* Avatar */}
-          <Avatar className="h-20 w-20 flex-shrink-0">
-            <AvatarImage src={user.image || undefined} alt={displayName} />
-            <AvatarFallback className="!bg-[#43676b] text-white text-2xl font-semibold">
-              {initials}
-            </AvatarFallback>
-          </Avatar>
+          <UserAvatar user={user} size="lg" className="flex-shrink-0" />
 
           {/* User Info */}
           <div className="flex-1 min-w-0">

--- a/apps/crowi-web/src/components/user-page/user-profile.tsx
+++ b/apps/crowi-web/src/components/user-page/user-profile.tsx
@@ -22,7 +22,7 @@ export function UserProfile({ user, createdPagesCount, bookmarksCount }: UserPro
           {/* Avatar */}
           <Avatar className="h-20 w-20 flex-shrink-0">
             <AvatarImage src={user.image || undefined} alt={displayName} />
-            <AvatarFallback className="bg-[var(--crowi-primary)] text-white text-2xl">
+            <AvatarFallback className="!bg-[#43676b] text-white text-2xl font-semibold">
               {initials}
             </AvatarFallback>
           </Avatar>

--- a/apps/crowi-web/src/components/user-page/user-recent-pages.tsx
+++ b/apps/crowi-web/src/components/user-page/user-recent-pages.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import Link from 'next/link';
+import { Loader2, AlertCircle, FileText } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { PageListItem } from '@/components/page-list/page-list-item';
+import { useUserPagesInfinite } from '@/lib/use-user-page';
+import type { Page } from '@crowi/api-contract';
+
+interface UserRecentPagesProps {
+  username: string;
+  /**
+   * If true, shows only a preview (limited items with "View all" link)
+   */
+  preview?: boolean;
+  /**
+   * Number of items to show in preview mode
+   */
+  previewLimit?: number;
+}
+
+export function UserRecentPages({ username, preview = false, previewLimit = 5 }: UserRecentPagesProps) {
+  const {
+    data,
+    isLoading,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useUserPagesInfinite(username, preview ? previewLimit : 10);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
+        <span className="ml-2 text-muted-foreground">Loading pages...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription>
+          Failed to load pages. Please try again later.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  // Flatten all pages
+  const allPages: Page[] = data?.pages.flatMap((page) => page.pages) ?? [];
+  const total = data?.pages[0]?.total ?? 0;
+
+  if (allPages.length === 0) {
+    return (
+      <Card className="p-8 text-center">
+        <FileText className="h-12 w-12 mx-auto text-muted-foreground/50 mb-3" />
+        <p className="text-muted-foreground">No pages created yet.</p>
+      </Card>
+    );
+  }
+
+  // In preview mode, show limited items
+  const displayPages = preview ? allPages.slice(0, previewLimit) : allPages;
+
+  return (
+    <div className="space-y-4">
+      <Card className="divide-y">
+        {displayPages.map((page) => (
+          <PageListItem key={page._id} page={page} />
+        ))}
+      </Card>
+
+      {/* Preview mode: "View all" link */}
+      {preview && total > previewLimit && (
+        <div className="text-center">
+          <Button variant="outline" asChild>
+            <Link href={`/user/${username}/recent-create`}>
+              View all {total} pages
+            </Link>
+          </Button>
+        </div>
+      )}
+
+      {/* Full mode: "Load more" button */}
+      {!preview && hasNextPage && (
+        <div className="text-center">
+          <Button
+            variant="outline"
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+          >
+            {isFetchingNextPage ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                Loading...
+              </>
+            ) : (
+              'Load more'
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/crowi-web/src/lib/use-user-page.ts
+++ b/apps/crowi-web/src/lib/use-user-page.ts
@@ -15,6 +15,9 @@ export function useUserPage(username: string) {
       if (result.status === 200) {
         return result.body;
       }
+      if (result.status === 401) {
+        throw new Error('Authentication required');
+      }
       if (result.status === 404) {
         throw new Error('User not found');
       }
@@ -37,6 +40,9 @@ export function useUserBookmarks(username: string, params: PaginationRequest = {
       });
       if (result.status === 200) {
         return result.body;
+      }
+      if (result.status === 401) {
+        throw new Error('Authentication required');
       }
       if (result.status === 404) {
         throw new Error('User not found');
@@ -61,6 +67,9 @@ export function useUserPages(username: string, params: PaginationRequest = { lim
       if (result.status === 200) {
         return result.body;
       }
+      if (result.status === 401) {
+        throw new Error('Authentication required');
+      }
       if (result.status === 404) {
         throw new Error('User not found');
       }
@@ -83,6 +92,9 @@ export function useUserBookmarksInfinite(username: string, limit: number = 10) {
       });
       if (result.status === 200) {
         return result.body;
+      }
+      if (result.status === 401) {
+        throw new Error('Authentication required');
       }
       if (result.status === 404) {
         throw new Error('User not found');
@@ -113,6 +125,9 @@ export function useUserPagesInfinite(username: string, limit: number = 10) {
       });
       if (result.status === 200) {
         return result.body;
+      }
+      if (result.status === 401) {
+        throw new Error('Authentication required');
       }
       if (result.status === 404) {
         throw new Error('User not found');

--- a/apps/crowi-web/src/lib/use-user-page.ts
+++ b/apps/crowi-web/src/lib/use-user-page.ts
@@ -1,0 +1,131 @@
+'use client';
+
+import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
+import { apiClient } from './api-client';
+import type { PaginationRequest } from '@crowi/api-contract';
+
+/**
+ * Hook to fetch user page data (profile with statistics)
+ */
+export function useUserPage(username: string) {
+  return useQuery({
+    queryKey: ['user', username],
+    queryFn: async () => {
+      const result = await apiClient.user.getUserPage({ params: { username } });
+      if (result.status === 200) {
+        return result.body;
+      }
+      if (result.status === 404) {
+        throw new Error('User not found');
+      }
+      throw new Error('Failed to fetch user page');
+    },
+    enabled: !!username,
+  });
+}
+
+/**
+ * Hook to fetch user bookmarks with pagination
+ */
+export function useUserBookmarks(username: string, params: PaginationRequest = { limit: 10, offset: 0 }) {
+  return useQuery({
+    queryKey: ['user', username, 'bookmarks', params],
+    queryFn: async () => {
+      const result = await apiClient.user.getUserBookmarks({
+        params: { username },
+        query: params,
+      });
+      if (result.status === 200) {
+        return result.body;
+      }
+      if (result.status === 404) {
+        throw new Error('User not found');
+      }
+      throw new Error('Failed to fetch bookmarks');
+    },
+    enabled: !!username,
+  });
+}
+
+/**
+ * Hook to fetch user created pages with pagination
+ */
+export function useUserPages(username: string, params: PaginationRequest = { limit: 10, offset: 0 }) {
+  return useQuery({
+    queryKey: ['user', username, 'pages', params],
+    queryFn: async () => {
+      const result = await apiClient.user.getUserPages({
+        params: { username },
+        query: params,
+      });
+      if (result.status === 200) {
+        return result.body;
+      }
+      if (result.status === 404) {
+        throw new Error('User not found');
+      }
+      throw new Error('Failed to fetch pages');
+    },
+    enabled: !!username,
+  });
+}
+
+/**
+ * Hook to fetch user bookmarks with infinite scrolling
+ */
+export function useUserBookmarksInfinite(username: string, limit: number = 10) {
+  return useInfiniteQuery({
+    queryKey: ['user', username, 'bookmarks', 'infinite', limit],
+    queryFn: async ({ pageParam = 0 }) => {
+      const result = await apiClient.user.getUserBookmarks({
+        params: { username },
+        query: { limit, offset: pageParam },
+      });
+      if (result.status === 200) {
+        return result.body;
+      }
+      if (result.status === 404) {
+        throw new Error('User not found');
+      }
+      throw new Error('Failed to fetch bookmarks');
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.pager.next !== null) {
+        return lastPage.pager.next;
+      }
+      return undefined;
+    },
+    enabled: !!username,
+  });
+}
+
+/**
+ * Hook to fetch user pages with infinite scrolling
+ */
+export function useUserPagesInfinite(username: string, limit: number = 10) {
+  return useInfiniteQuery({
+    queryKey: ['user', username, 'pages', 'infinite', limit],
+    queryFn: async ({ pageParam = 0 }) => {
+      const result = await apiClient.user.getUserPages({
+        params: { username },
+        query: { limit, offset: pageParam },
+      });
+      if (result.status === 200) {
+        return result.body;
+      }
+      if (result.status === 404) {
+        throw new Error('User not found');
+      }
+      throw new Error('Failed to fetch pages');
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.pager.next !== null) {
+        return lastPage.pager.next;
+      }
+      return undefined;
+    },
+    enabled: !!username,
+  });
+}

--- a/packages/api-contract/src/contracts/index.ts
+++ b/packages/api-contract/src/contracts/index.ts
@@ -4,6 +4,7 @@ import { installerContract } from './installer';
 import { tokenAuthContract } from './tokenAuth';
 import { meContract } from './me';
 import { pageContract } from './page';
+import { userContract } from './user';
 
 const c = initContract();
 
@@ -13,4 +14,5 @@ export const apiContract = c.router({
   tokenAuth: tokenAuthContract,
   me: meContract,
   page: pageContract,
+  user: userContract,
 });

--- a/packages/api-contract/src/contracts/user.ts
+++ b/packages/api-contract/src/contracts/user.ts
@@ -1,0 +1,72 @@
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+import {
+  UserPageResponseSchema,
+  UserBookmarksResponseSchema,
+  UserPagesResponseSchema,
+  UserNotFoundErrorSchema,
+  PaginationRequestSchema,
+} from '../schemas/user';
+import { AuthenticationRequiredErrorSchema } from '../schemas/common';
+
+const c = initContract();
+
+export const userContract = c.router({
+  /**
+   * Get user page information
+   * - Returns user profile with statistics
+   * - Includes recent pages and bookmarks for initial display
+   */
+  getUserPage: {
+    method: 'GET',
+    path: '/user/:username',
+    pathParams: z.object({
+      username: z.string(),
+    }),
+    responses: {
+      200: UserPageResponseSchema,
+      404: UserNotFoundErrorSchema,
+    },
+    summary: 'Get user page information',
+  },
+
+  /**
+   * Get user bookmarks
+   * - Returns paginated list of bookmarks for a user
+   * - Only returns bookmarks for pages the current user can access
+   */
+  getUserBookmarks: {
+    method: 'GET',
+    path: '/user/:username/bookmarks',
+    pathParams: z.object({
+      username: z.string(),
+    }),
+    query: PaginationRequestSchema,
+    responses: {
+      200: UserBookmarksResponseSchema,
+      401: AuthenticationRequiredErrorSchema,
+      404: UserNotFoundErrorSchema,
+    },
+    summary: 'Get user bookmarks',
+  },
+
+  /**
+   * Get user created pages
+   * - Returns paginated list of pages created by the user
+   * - Only returns pages the current user can access
+   */
+  getUserPages: {
+    method: 'GET',
+    path: '/user/:username/pages',
+    pathParams: z.object({
+      username: z.string(),
+    }),
+    query: PaginationRequestSchema,
+    responses: {
+      200: UserPagesResponseSchema,
+      401: AuthenticationRequiredErrorSchema,
+      404: UserNotFoundErrorSchema,
+    },
+    summary: 'Get user created pages',
+  },
+});

--- a/packages/api-contract/src/contracts/user.ts
+++ b/packages/api-contract/src/contracts/user.ts
@@ -7,7 +7,7 @@ import {
   UserNotFoundErrorSchema,
   PaginationRequestSchema,
 } from '../schemas/user';
-import { AuthenticationRequiredErrorSchema } from '../schemas/common';
+import { AuthenticationRequiredErrorSchema, InternalServerErrorSchema } from '../schemas/common';
 
 const c = initContract();
 
@@ -25,7 +25,9 @@ export const userContract = c.router({
     }),
     responses: {
       200: UserPageResponseSchema,
+      401: AuthenticationRequiredErrorSchema,
       404: UserNotFoundErrorSchema,
+      500: InternalServerErrorSchema,
     },
     summary: 'Get user page information',
   },
@@ -46,6 +48,7 @@ export const userContract = c.router({
       200: UserBookmarksResponseSchema,
       401: AuthenticationRequiredErrorSchema,
       404: UserNotFoundErrorSchema,
+      500: InternalServerErrorSchema,
     },
     summary: 'Get user bookmarks',
   },
@@ -66,6 +69,7 @@ export const userContract = c.router({
       200: UserPagesResponseSchema,
       401: AuthenticationRequiredErrorSchema,
       404: UserNotFoundErrorSchema,
+      500: InternalServerErrorSchema,
     },
     summary: 'Get user created pages',
   },

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -4,4 +4,5 @@ export * from './schemas/installer';
 export * from './schemas/common';
 export * from './schemas/me';
 export * from './schemas/page';
+export * from './schemas/user';
 export * from './openapi';

--- a/packages/api-contract/src/schemas/common.ts
+++ b/packages/api-contract/src/schemas/common.ts
@@ -40,8 +40,16 @@ export const ThirdPartyAuthRequiredErrorSchema = ApiErrorSchema.extend({
   }),
 });
 
+export const InternalServerErrorSchema = ApiErrorSchema.extend({
+  error: z.object({
+    code: z.literal('INTERNAL_ERROR'),
+    message: z.literal('Internal server error'),
+  }),
+});
+
 export type ApiError = z.infer<typeof ApiErrorSchema>;
 export type ApplicationNotInstalledError = z.infer<typeof ApplicationNotInstalledErrorSchema>;
 export type AuthenticationRequiredError = z.infer<typeof AuthenticationRequiredErrorSchema>;
 export type UserStatusError = z.infer<typeof UserStatusErrorSchema>;
 export type ThirdPartyAuthRequiredError = z.infer<typeof ThirdPartyAuthRequiredErrorSchema>;
+export type InternalServerError = z.infer<typeof InternalServerErrorSchema>;

--- a/packages/api-contract/src/schemas/me.ts
+++ b/packages/api-contract/src/schemas/me.ts
@@ -55,7 +55,8 @@ export type ProfileErrorResponse = z.infer<typeof ProfileErrorResponseSchema>;
 
 // Password validation regex
 // New password must contain at least one letter, one digit, and one special character
-const PASSWORD_REGEX = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?`~])[\x20-\x7F]+$/;
+// Allowed special characters: !@#$%^&*()_+-=[]{};\:'"|,.<>/?`~
+const PASSWORD_REGEX = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?`~])[a-zA-Z\d!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?`~]+$/;
 
 // Password update request schema
 export const UpdatePasswordRequestSchema = z.object({

--- a/packages/api-contract/src/schemas/user.ts
+++ b/packages/api-contract/src/schemas/user.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+import { PageSchema, PagerSchema } from './page';
+
+// User status enum - matches User model constants
+export const UserStatusSchema = z.enum(['1', '2', '3', '4', '5']).transform((val) => Number(val));
+export const UserStatusEnum = {
+  REGISTERED: 1,
+  ACTIVE: 2,
+  SUSPENDED: 3,
+  DELETED: 4,
+  INVITED: 5,
+} as const;
+
+// Language enum - matches User model
+export const UserLanguageSchema = z.enum(['en', 'en-US', 'en-GB', 'ja']);
+export type UserLanguage = z.infer<typeof UserLanguageSchema>;
+
+// Public user schema - minimal user information for public display
+// Based on UserDocument fields that are safe to expose publicly
+export const UserPublicSchema = z.object({
+  _id: z.string(),
+  id: z.string().optional(), // for compatibility (virtual field)
+  username: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+  image: z.string().nullable().optional(),
+  introduction: z.string().optional(),
+  createdAt: z.string(),
+  admin: z.boolean().optional(),
+  status: z.number().optional(),
+});
+export type UserPublic = z.infer<typeof UserPublicSchema>;
+
+// Bookmark schema with populated page
+export const BookmarkSchema = z.object({
+  _id: z.string(),
+  page: PageSchema,
+  user: z.union([z.string(), UserPublicSchema]),
+  createdAt: z.string(),
+});
+export type Bookmark = z.infer<typeof BookmarkSchema>;
+
+// Pagination request schema
+export const PaginationRequestSchema = z.object({
+  limit: z.coerce.number().optional().default(50),
+  offset: z.coerce.number().optional().default(0),
+});
+export type PaginationRequest = z.infer<typeof PaginationRequestSchema>;
+
+// User page response schema - combines profile, bookmarks, and created pages
+export const UserPageResponseSchema = z.object({
+  user: UserPublicSchema,
+  // Page statistics
+  createdPagesCount: z.number(),
+  bookmarksCount: z.number(),
+  // Optionally include recent items for initial display
+  recentPages: z.array(PageSchema).optional(),
+  recentBookmarks: z.array(BookmarkSchema).optional(),
+});
+export type UserPageResponse = z.infer<typeof UserPageResponseSchema>;
+
+// User bookmarks response schema - paginated bookmarks list
+export const UserBookmarksResponseSchema = z.object({
+  bookmarks: z.array(BookmarkSchema),
+  pager: PagerSchema,
+  total: z.number(),
+});
+export type UserBookmarksResponse = z.infer<typeof UserBookmarksResponseSchema>;
+
+// User pages response schema - paginated pages list
+export const UserPagesResponseSchema = z.object({
+  pages: z.array(PageSchema),
+  pager: PagerSchema,
+  total: z.number(),
+});
+export type UserPagesResponse = z.infer<typeof UserPagesResponseSchema>;
+
+// User not found error schema
+export const UserNotFoundErrorSchema = z.object({
+  error: z.object({
+    code: z.literal('USER_NOT_FOUND'),
+    message: z.literal('User not found'),
+  }),
+});
+export type UserNotFoundError = z.infer<typeof UserNotFoundErrorSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       basic-auth-connect:
         specifier: ~1.0.0
         version: 1.0.0
+      bcryptjs:
+        specifier: ^3.0.3
+        version: 3.0.3
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -177,6 +180,9 @@ importers:
         specifier: ^3.23.8
         version: 3.25.56
     devDependencies:
+      '@types/bcryptjs':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@types/classnames':
         specifier: ^2.2.9
         version: 2.3.4
@@ -297,6 +303,9 @@ importers:
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.8)(react-dom@19.2.3)(react@19.2.3)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.8)(react-dom@19.2.3)(react@19.2.3)
       '@radix-ui/react-label':
         specifier: ^2.1.8
         version: 2.1.8(@types/react-dom@19.2.3)(@types/react@19.2.8)(react-dom@19.2.3)(react@19.2.3)
@@ -4874,6 +4883,13 @@ packages:
       '@babel/types': 7.27.6
     dev: true
 
+  /@types/bcryptjs@3.0.0:
+    resolution: {integrity: sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg==}
+    deprecated: This is a stub types definition. bcryptjs provides its own type definitions, so you do not need this installed.
+    dependencies:
+      bcryptjs: 3.0.3
+    dev: true
+
   /@types/body-parser@1.19.6:
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
     dependencies:
@@ -6162,6 +6178,10 @@ packages:
     dependencies:
       safe-buffer: 5.1.2
     dev: false
+
+  /bcryptjs@3.0.3:
+    resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
+    hasBin: true
 
   /bignumber.js@9.3.0:
     resolution: {integrity: sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==}


### PR DESCRIPTION
## Summary

- Add ts-rest API contracts for user page endpoints
- Implement API routes: GET /user/:username, /bookmarks, /pages
- Create user profile component with avatar and stats
- Add bookmarks and recent pages lists with pagination
- Support both preview mode (10 items) and full list mode

## Changes

### API Contract (packages/api-contract/)
- `src/schemas/user.ts` - Zod schemas for user page responses
- `src/contracts/user.ts` - ts-rest contract definitions

### API Routes (apps/crowi-api/)
- `src/routes/ts-rest/user.ts` - User API route implementations
  - GET /user/:username - Get user profile with stats
  - GET /user/:username/bookmarks - Get user's bookmarked pages
  - GET /user/:username/pages - Get user's recent pages

### Frontend (apps/crowi-web/)
- `src/lib/use-user-page.ts` - React hooks for user page data fetching
- `src/components/user-page/` - User page components
  - `user-profile.tsx` - Profile display with avatar and stats
  - `user-bookmarks.tsx` - Bookmarks list with pagination
  - `user-recent-pages.tsx` - Recent pages list with pagination
- `src/app/(auth)/user/[username]/` - User page routes
  - `page.tsx` - Main user profile page
  - `bookmarks/page.tsx` - Full bookmarks list
  - `recent-create/page.tsx` - Full recent pages list

## Migration Details

| Source (Old) | Target (New) |
|--------------|--------------|
| `lib/routes/user.js` | `apps/crowi-api/src/routes/ts-rest/user.ts` |
| `lib/views/user/*.html` | `apps/crowi-web/src/app/(auth)/user/` |

## Testing

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] Manual testing completed

---

Generated with [Claude Code](https://claude.com/code)