### PR TITLE
Fix potentially vulnerable cloned function

### DIFF
--- a/apps/crowi-api/public/js/reveal/plugin/markdown/markdown.js
+++ b/apps/crowi-api/public/js/reveal/plugin/markdown/markdown.js
@@ -112,7 +112,7 @@
 
 		// prevent script end tags in the content from interfering
 		// with parsing
-		content = content.replace( /<\/script>/g, SCRIPT_END_PLACEHOLDER );
+		content = content.replace( /<\/script>/gi, SCRIPT_END_PLACEHOLDER );
 
 		return '<script type="text/template">' + content + '</script>';
 


### PR DESCRIPTION
Hi again,

Our tool identified a potential vulnerability in a clone function in `apps/crowi-api/public/js/reveal/plugin/markdown/markdown.js` sourced from [hedgedoc/hedgedoc](https://github.com/hedgedoc/hedgedoc). This issue, originally reported in CVE-2021-21259, was resolved in the repository via this commit https://github.com/hedgedoc/hedgedoc/commit/1546786c635f744b8306428bf02e2ec0285fcb51.

This PR suggests applying the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!